### PR TITLE
refactor: migrate custom banners to JetBrains InlineBanner

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/AgenticCopilotToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/AgenticCopilotToolWindowContent.kt
@@ -237,30 +237,21 @@ class AgenticCopilotToolWindowContent(private val project: Project) {
                 isCLINotFound -> {
                     val cmd = if (System.getProperty("os.name").lowercase().contains("win"))
                         "winget install GitHub.Copilot" else "npm install -g @github/copilot-cli"
-                    textLabel.text = "<html><b>Copilot CLI is not installed</b> — install with: <tt>$cmd</tt></html>"
-                    installButton.isVisible = true
-                    actionButton.isVisible = false
+                    updateState("Copilot CLI is not installed \u2014 install with: $cmd", showInstall = true)
                 }
 
-                authService.isAuthenticationError(diag) -> {
-                    textLabel.text = "<html><b>Not signed in to Copilot</b> — click Sign In, then click Retry.</html>"
-                    installButton.isVisible = false
-                    actionButton.isVisible = true
-                }
+                authService.isAuthenticationError(diag) ->
+                    updateState("Not signed in to Copilot \u2014 click Sign In, then click Retry.", showSignIn = true)
 
-                else -> {
-                    textLabel.text = "<html><b>Copilot CLI unavailable</b></html>"
-                    installButton.isVisible = false
-                    actionButton.isVisible = false
-                }
+                else -> updateState("Copilot CLI unavailable")
             }
         }
-        banner.installButton.addActionListener {
+        banner.installHandler = {
             com.intellij.ide.BrowserUtil.browse("https://github.com/github/copilot-cli#installation")
         }
         // Clear pending auth error on Retry so diagnostics re-verifies from scratch
-        banner.retryButton.addActionListener { authService.clearPendingAuthError() }
-        banner.actionButton.addActionListener {
+        banner.retryHandler = { authService.clearPendingAuthError() }
+        banner.signInHandler = {
             banner.showSignInPending()
             // Try inline auth first (captures device code from CLI stdout)
             inlineAuthProcess?.destroy()
@@ -295,25 +286,23 @@ class AgenticCopilotToolWindowContent(private val project: Project) {
             onFixed = onFixed,
         ) { diag ->
             when {
-                "not installed" in diag.lowercase() -> {
-                    textLabel.text =
-                        "<html><b>GitHub CLI (gh) is not installed</b> — needed for billing info. Install from <tt>cli.github.com</tt>.</html>"
-                    installButton.isVisible = true
-                    actionButton.isVisible = false
-                }
+                "not installed" in diag.lowercase() ->
+                    updateState(
+                        "GitHub CLI (gh) is not installed \u2014 needed for billing info. Install from cli.github.com.",
+                        showInstall = true
+                    )
 
-                else -> {
-                    textLabel.text =
-                        "<html><b>Not signed in to GitHub CLI (gh)</b> — needed for billing info. Click Sign In.</html>"
-                    installButton.isVisible = false
-                    actionButton.isVisible = true
-                }
+                else ->
+                    updateState(
+                        "Not signed in to GitHub CLI (gh) \u2014 needed for billing info. Click Sign In.",
+                        showSignIn = true
+                    )
             }
         }
-        banner.installButton.addActionListener {
+        banner.installHandler = {
             com.intellij.ide.BrowserUtil.browse("https://cli.github.com")
         }
-        banner.actionButton.addActionListener {
+        banner.signInHandler = {
             banner.showSignInPending()
             authService.startGhLogin()
         }
@@ -321,58 +310,16 @@ class AgenticCopilotToolWindowContent(private val project: Project) {
     }
 
     /** Creates a warning banner shown when the PSI bridge HTTP server is not reachable. Hidden by default. */
-    private fun createPsiBridgeBanner(): JBPanel<JBPanel<*>> {
-        val banner = JBPanel<JBPanel<*>>(BorderLayout())
+    private fun createPsiBridgeBanner(): com.intellij.ui.InlineBanner {
+        val banner = com.intellij.ui.InlineBanner(
+            "IntelliJ code tools unavailable \u2014 PSI bridge is not running. " +
+                "Make sure a project is open and the IDE Agent for Copilot plugin is active, then restart IntelliJ.",
+            com.intellij.ui.EditorNotificationPanel.Status.Warning
+        )
         banner.isVisible = false
-        banner.border = JBUI.Borders.compound(
-            com.intellij.ui.SideBorder(
-                JBColor(Color(0xE5, 0xA0, 0x00), Color(0x99, 0x75, 0x00)),
-                com.intellij.ui.SideBorder.BOTTOM
-            ),
-            JBUI.Borders.empty(4, 8)
-        )
-        banner.background = JBColor(Color(0xFF, 0xF3, 0xCD), Color(0x3D, 0x36, 0x20))
-        banner.isOpaque = true
-
-        val icon = JBLabel(com.intellij.icons.AllIcons.General.Warning)
-        icon.border = JBUI.Borders.emptyRight(6)
-
-        val text = JBLabel(
-            "<html><b>IntelliJ code tools unavailable</b> — PSI bridge is not running. " +
-                "Make sure a project is open and the IDE Agent for Copilot plugin is active, then restart IntelliJ.</html>"
-        )
-        text.foreground = JBColor(Color(0x5C, 0x45, 0x00), Color(0xE0, 0xC0, 0x60))
-
-        val detailsButton = JButton("Details…")
-        detailsButton.border = JBUI.Borders.emptyLeft(8)
-        detailsButton.isOpaque = false
-        detailsButton.isBorderPainted = false
-        detailsButton.foreground = JBColor(Color(0x5C, 0x45, 0x00), Color(0xE0, 0xC0, 0x60))
-        detailsButton.cursor = java.awt.Cursor.getPredefinedCursor(java.awt.Cursor.HAND_CURSOR)
-        detailsButton.toolTipText = "Show diagnostic information"
-
-        val recheckButton = JButton("Recheck")
-        recheckButton.border = JBUI.Borders.emptyLeft(4)
-        recheckButton.isOpaque = false
-        recheckButton.isBorderPainted = false
-        recheckButton.foreground = JBColor(Color(0x5C, 0x45, 0x00), Color(0xE0, 0xC0, 0x60))
-        recheckButton.cursor = java.awt.Cursor.getPredefinedCursor(java.awt.Cursor.HAND_CURSOR)
-        recheckButton.toolTipText = "Re-run the PSI bridge check"
-
-        val buttons = JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.LEFT, 0, 0))
-        buttons.isOpaque = false
-        buttons.add(detailsButton)
-        buttons.add(recheckButton)
-
-        val content = JBPanel<JBPanel<*>>(BorderLayout())
-        content.isOpaque = false
-        content.add(icon, BorderLayout.WEST)
-        content.add(text, BorderLayout.CENTER)
-        content.add(buttons, BorderLayout.EAST)
-        banner.add(content, BorderLayout.CENTER)
 
         // Runs check on a pooled thread, then updates the banner on the EDT.
-        // lastDiag is stored so Details… always shows the freshest result.
+        // lastDiag is stored so Details\u2026 always shows the freshest result.
         var lastDiag: String? = null
 
         // Scheduler used for adaptive polling: 5 s while bridge is down, 30 s while healthy.
@@ -390,7 +337,6 @@ class AgenticCopilotToolWindowContent(private val project: Project) {
                     SwingUtilities.invokeLater {
                         lastDiag = diag
                         banner.isVisible = diag != null
-                        recheckButton.isEnabled = true
                     }
                     scheduleNext(diag != null)
                 },
@@ -399,27 +345,21 @@ class AgenticCopilotToolWindowContent(private val project: Project) {
         }
 
         fun runCheck() {
-            // Cancel any pending poll so we don't end up with two parallel chains.
             scheduledFuture?.cancel(false)
-            recheckButton.isEnabled = false
             ApplicationManager.getApplication().executeOnPooledThread {
                 val diag = psiBridgeDiagnostics()
                 SwingUtilities.invokeLater {
                     lastDiag = diag
                     banner.isVisible = diag != null
-                    recheckButton.isEnabled = true
                 }
                 scheduleNext(diag != null)
             }
         }
 
-        detailsButton.addActionListener {
-            // Always run a fresh check so the dialog never shows stale data.
-            detailsButton.isEnabled = false
+        banner.addAction("Details\u2026") {
             ApplicationManager.getApplication().executeOnPooledThread {
                 val diag = psiBridgeDiagnostics()
                 SwingUtilities.invokeLater {
-                    detailsButton.isEnabled = true
                     lastDiag = diag
                     banner.isVisible = diag != null
                     com.intellij.openapi.ui.Messages.showMessageDialog(
@@ -432,7 +372,7 @@ class AgenticCopilotToolWindowContent(private val project: Project) {
                 }
             }
         }
-        recheckButton.addActionListener { runCheck() }
+        banner.addAction("Recheck") { runCheck() }
 
         // First check after 5 s so the bridge has time to start.
         scheduledFuture = scheduler.schedule(

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/AuthSetupBanner.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/AuthSetupBanner.kt
@@ -1,13 +1,13 @@
 package com.github.catatafishen.ideagentforcopilot.ui
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.ui.JBColor
+import com.intellij.ui.EditorNotificationPanel
+import com.intellij.ui.InlineBanner
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPanel
 import com.intellij.util.concurrency.AppExecutorUtil
 import com.intellij.util.ui.JBUI
 import java.awt.BorderLayout
-import java.awt.Color
 import java.awt.FlowLayout
 import java.awt.Font
 import java.awt.datatransfer.StringSelection
@@ -20,17 +20,18 @@ import javax.swing.SwingUtilities
 /**
  * Reusable warning banner for auth / setup prerequisite checks.
  *
- * Shows a yellow warning strip: [⚠ icon] [text label] [install button] [action button] [retry button]
+ * Uses [InlineBanner] for native JetBrains look and feel, with an optional device-code row
+ * shown during inline auth flows.
  *
  * The banner self-shows/hides by polling [diagnosticsFn].  When the diagnostic clears, [onFixed]
  * is called and the banner hides.  Polling uses [AppExecutorUtil] so no raw executor threads are
  * ever leaked.
  *
- * Callers configure text and button visibility in [onDiagUpdate], which fires on the EDT whenever
- * a new (non-null) diagnostic value arrives.
+ * Callers configure the display state in [onDiagUpdate] via [updateState], which fires on the EDT
+ * whenever a new (non-null) diagnostic value arrives.
  */
 class AuthSetupBanner(
-    retryTooltip: String,
+    @Suppress("UNUSED_PARAMETER") retryTooltip: String,
     private val pollIntervalDown: Long = 30,
     private val pollIntervalUp: Long = 60,
     private val diagnosticsFn: () -> String?,
@@ -39,31 +40,36 @@ class AuthSetupBanner(
     private val onDiagUpdate: AuthSetupBanner.(diag: String) -> Unit,
 ) : JBPanel<JBPanel<*>>(BorderLayout()) {
 
-    // ── Palette — single source of truth for all three colour roles ──────────
-    private companion object {
-        val bannerBorder = JBColor(Color(0xE5, 0xA0, 0x00), Color(0x99, 0x75, 0x00))
-        val bannerBg = JBColor(Color(0xFF, 0xF3, 0xCD), Color(0x3D, 0x36, 0x20))
-        val bannerFg = JBColor(Color(0x5C, 0x45, 0x00), Color(0xE0, 0xC0, 0x60))
-    }
+    private val banner = InlineBanner("", EditorNotificationPanel.Status.Warning)
 
-    // ── Public widgets callers may configure ─────────────────────────────────
-    val textLabel = JBLabel().apply { foreground = bannerFg }
-    val installButton = bannerButton("Install…")
-    val actionButton = bannerButton("Sign In")
-    val retryButton = bannerButton("Retry").apply { toolTipText = retryTooltip }
+    /** Set by callers to handle the "Install…" action click. */
+    var installHandler: (() -> Unit)? = null
+
+    /** Set by callers to handle the "Sign In" action click. */
+    var signInHandler: (() -> Unit)? = null
+
+    /** Set by callers for extra cleanup on retry (runs before [triggerCheck]). */
+    var retryHandler: (() -> Unit)? = null
 
     // ── Device code row (shown when inline auth parses a code + URL) ─────────
     private val deviceCodeRow = JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.LEFT, 6, 0)).apply {
         isOpaque = false
         isVisible = false
-        border = JBUI.Borders.emptyLeft(22) // indent to align with text (past icon)
+        border = JBUI.Borders.emptyLeft(22)
     }
     private val codeLabel = JBLabel().apply {
-        foreground = bannerFg
         font = font.deriveFont(Font.BOLD)
     }
-    private val copyButton = bannerButton("\uD83D\uDCCB Copy Code")
-    private val openBrowserButton = bannerButton("\uD83D\uDD17 Open GitHub")
+    private val copyButton = JButton("\uD83D\uDCCB Copy Code").apply {
+        isOpaque = false
+        isBorderPainted = false
+        cursor = java.awt.Cursor.getPredefinedCursor(java.awt.Cursor.HAND_CURSOR)
+    }
+    private val openBrowserButton = JButton("\uD83D\uDD17 Open GitHub").apply {
+        isOpaque = false
+        isBorderPainted = false
+        cursor = java.awt.Cursor.getPredefinedCursor(java.awt.Cursor.HAND_CURSOR)
+    }
     private var deviceUrl: String? = null
 
     private var scheduledFuture: ScheduledFuture<*>? = null
@@ -71,50 +77,21 @@ class AuthSetupBanner(
 
     init {
         isVisible = false
-        isOpaque = true
-        background = bannerBg
-        border = JBUI.Borders.compound(
-            com.intellij.ui.SideBorder(bannerBorder, com.intellij.ui.SideBorder.BOTTOM),
-            JBUI.Borders.empty(4, 8),
-        )
+        isOpaque = false
 
-        installButton.isVisible = false
-        actionButton.isVisible = false
-
-        val icon = JBLabel(com.intellij.icons.AllIcons.General.Warning).apply {
-            border = JBUI.Borders.emptyRight(6)
-            accessibleContext.accessibleName = "Warning"
-        }
-
-        val buttons = JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.LEFT, 6, 0)).apply {
-            isOpaque = false
-            add(installButton)
-            add(actionButton)
-            add(retryButton)
-        }
-
-        val topRow = JBPanel<JBPanel<*>>(BorderLayout()).apply {
-            isOpaque = false
-            add(icon, BorderLayout.WEST)
-            add(textLabel, BorderLayout.CENTER)
-            add(buttons, BorderLayout.EAST)
-        }
-
-        // Device code row: [Your code:] [CODE] [Copy] [Open Browser]
-        deviceCodeRow.add(JBLabel("Your code:").apply { foreground = bannerFg })
+        deviceCodeRow.add(JBLabel("Your code:"))
         deviceCodeRow.add(codeLabel)
         deviceCodeRow.add(copyButton)
         deviceCodeRow.add(openBrowserButton)
 
-        val rows = JBPanel<JBPanel<*>>().apply {
+        val stack = JBPanel<JBPanel<*>>().apply {
             layout = BoxLayout(this, BoxLayout.Y_AXIS)
             isOpaque = false
-            add(topRow)
+            add(banner)
             add(deviceCodeRow)
         }
-        add(rows, BorderLayout.CENTER)
+        add(stack, BorderLayout.CENTER)
 
-        retryButton.addActionListener { triggerCheck() }
         copyButton.addActionListener {
             val code = codeLabel.text.trim()
             if (code.isNotEmpty()) {
@@ -140,11 +117,24 @@ class AuthSetupBanner(
                 cancelPoll()
             }
 
-            override fun ancestorMoved(e: javax.swing.event.AncestorEvent) {}
+            override fun ancestorMoved(e: javax.swing.event.AncestorEvent) { /* no-op */
+            }
         })
     }
 
     // ── Public API ─────────────────────────────────────────────────────────────
+
+    /**
+     * Update the banner display state. Called from [onDiagUpdate] callback.
+     *
+     * @param message     Plain-text message to display.
+     * @param showInstall Whether to show the "Install…" action (triggers [installHandler]).
+     * @param showSignIn  Whether to show the "Sign In" action (triggers [signInHandler]).
+     */
+    fun updateState(message: String, showInstall: Boolean = false, showSignIn: Boolean = false) {
+        banner.setMessage(message)
+        rebuildActions(showInstall, showSignIn)
+    }
 
     /** Force an immediate re-check (e.g. after an auth error in a request). */
     fun triggerCheck() = runCheck()
@@ -156,8 +146,8 @@ class AuthSetupBanner(
     fun showDeviceCode(code: String, url: String) {
         codeLabel.text = " $code "
         deviceUrl = url
-        textLabel.text = "<html><b>Sign in to Copilot</b> \u2014 copy your code, then open GitHub to enter it.</html>"
-        actionButton.isVisible = false
+        banner.setMessage("Sign in to Copilot \u2014 copy your code, then open GitHub to enter it.")
+        rebuildActions(showInstall = false, showSignIn = false)
         deviceCodeRow.isVisible = true
         revalidate()
         repaint()
@@ -167,6 +157,33 @@ class AuthSetupBanner(
     fun hideDeviceCode() {
         deviceCodeRow.isVisible = false
         deviceUrl = null
+    }
+
+    /** Give immediate "signing in" feedback. */
+    fun showSignInPending() {
+        banner.setMessage("Signing in\u2026 waiting for device code from CLI.")
+        rebuildActions(showInstall = false, showSignIn = false)
+        // Re-enable Sign In after a few seconds so the user can retry if nothing happened
+        AppExecutorUtil.getAppScheduledExecutorService().schedule(
+            { SwingUtilities.invokeLater { rebuildActions(showInstall = false, showSignIn = true) } },
+            8L, TimeUnit.SECONDS,
+        )
+    }
+
+    // ── Action management ─────────────────────────────────────────────────────
+
+    private fun rebuildActions(showInstall: Boolean, showSignIn: Boolean) {
+        banner.removeAllActions()
+        if (showInstall) {
+            banner.addAction("Install\u2026") { installHandler?.invoke() }
+        }
+        if (showSignIn) {
+            banner.addAction("Sign In") { signInHandler?.invoke() }
+        }
+        banner.addAction("Retry") {
+            retryHandler?.invoke()
+            triggerCheck()
+        }
     }
 
     // ── Polling ───────────────────────────────────────────────────────────────
@@ -192,13 +209,11 @@ class AuthSetupBanner(
 
     private fun runCheck() {
         cancelPoll()
-        retryButton.isEnabled = false
-        retryButton.text = "Checking\u2026"
+        banner.setMessage("Checking\u2026")
+        rebuildActions(showInstall = false, showSignIn = false)
         ApplicationManager.getApplication().executeOnPooledThread {
             val diag = diagnosticsFn()
             SwingUtilities.invokeLater {
-                retryButton.text = "Retry"
-                retryButton.isEnabled = true
                 applyDiag(diag)
                 scheduleNext(diag != null)
             }
@@ -215,27 +230,5 @@ class AuthSetupBanner(
         isVisible = nowDown
         if (wasDown && !nowDown) onFixed()
         wasDown = nowDown
-    }
-
-    // ── Sign In feedback helpers ──────────────────────────────────────────────
-
-    /** Call inside an [actionButton] ActionListener to give immediate "signing in" feedback. */
-    fun showSignInPending() {
-        actionButton.isEnabled = false
-        textLabel.text = "<html><b>Signing in\u2026</b> waiting for device code from CLI.</html>"
-        // Re-enable after a few seconds so the user can retry if nothing happened
-        AppExecutorUtil.getAppScheduledExecutorService().schedule(
-            { SwingUtilities.invokeLater { actionButton.isEnabled = true } },
-            8L, TimeUnit.SECONDS,
-        )
-    }
-
-    // ── Layout helper ─────────────────────────────────────────────────────────
-
-    private fun bannerButton(label: String) = JButton(label).apply {
-        foreground = bannerFg
-        isOpaque = false
-        isBorderPainted = false
-        cursor = java.awt.Cursor.getPredefinedCursor(java.awt.Cursor.HAND_CURSOR)
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/GitWarningBanner.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/GitWarningBanner.kt
@@ -1,111 +1,45 @@
 package com.github.catatafishen.ideagentforcopilot.ui
 
-import com.intellij.icons.AllIcons
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
-import com.intellij.ui.JBColor
-import com.intellij.ui.SideBorder
-import com.intellij.ui.components.JBCheckBox
-import com.intellij.ui.components.JBLabel
-import com.intellij.ui.components.JBPanel
-import com.intellij.util.ui.JBUI
-import java.awt.BorderLayout
-import java.awt.Color
-import java.awt.Cursor
-import java.awt.FlowLayout
+import com.intellij.ui.EditorNotificationPanel
+import com.intellij.ui.InlineBanner
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
-import javax.swing.BoxLayout
-import javax.swing.JButton
 
 /**
  * Warning banner shown when the project has no git repository or no git remote configured.
  * Warns users that the agent can make destructive edits and version control is important
- * for safe rollbacks. Dismissible per-project via a "don't remind me" checkbox.
+ * for safe rollbacks. Dismissible per-project via "Don't show again" action.
  */
-class GitWarningBanner(private val project: Project) : JBPanel<JBPanel<*>>(BorderLayout()) {
+class GitWarningBanner(private val project: Project) : InlineBanner("", EditorNotificationPanel.Status.Error) {
 
     private companion object {
         const val KEY_DISMISSED = "copilot.gitWarningDismissed"
-        val bannerBorder = JBColor(Color(0xC7, 0x22, 0x22), Color(0x99, 0x33, 0x33))
-        val bannerBg = JBColor(Color(0xFD, 0xE8, 0xE8), Color(0x3D, 0x20, 0x20))
-        val bannerFg = JBColor(Color(0x7A, 0x1B, 0x1B), Color(0xE0, 0x80, 0x80))
     }
 
     init {
         isVisible = false
-        isOpaque = true
-        background = bannerBg
-        border = JBUI.Borders.compound(
-            SideBorder(bannerBorder, SideBorder.BOTTOM),
-            JBUI.Borders.empty(6, 8),
-        )
-
-        val icon = JBLabel(AllIcons.General.Warning).apply {
-            border = JBUI.Borders.emptyRight(6)
-        }
-
-        val textLabel = JBLabel().apply {
-            foreground = bannerFg
-        }
-
-        val dontRemindCheckbox = JBCheckBox("Don't remind me again for this project").apply {
-            foreground = bannerFg
-            isOpaque = false
-            border = JBUI.Borders.emptyLeft(4)
-        }
-
-        val closeButton = JButton("✕").apply {
-            foreground = bannerFg
-            isOpaque = false
-            isBorderPainted = false
-            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-            toolTipText = "Dismiss"
-            border = JBUI.Borders.empty(0, 8)
-        }
-
-        closeButton.addActionListener {
-            if (dontRemindCheckbox.isSelected) {
-                PropertiesComponent.getInstance(project).setValue(KEY_DISMISSED, true)
-            }
+        showCloseButton(true)
+        setCloseAction {
             isVisible = false
-            revalidate()
-            repaint()
+        }
+        addAction("Don't show again") {
+            PropertiesComponent.getInstance(project).setValue(KEY_DISMISSED, true)
+            close()
         }
 
-        val topRow = JBPanel<JBPanel<*>>(BorderLayout()).apply {
-            isOpaque = false
-            add(icon, BorderLayout.WEST)
-            add(textLabel, BorderLayout.CENTER)
-            add(closeButton, BorderLayout.EAST)
-        }
-
-        val bottomRow = JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.LEFT, 0, 0)).apply {
-            isOpaque = false
-            border = JBUI.Borders.emptyLeft(22) // align with text past icon
-            add(dontRemindCheckbox)
-        }
-
-        val rows = JBPanel<JBPanel<*>>().apply {
-            layout = BoxLayout(this, BoxLayout.Y_AXIS)
-            isOpaque = false
-            add(topRow)
-            add(bottomRow)
-        }
-        add(rows, BorderLayout.CENTER)
-
-        // Check git status on a background thread
         ApplicationManager.getApplication().executeOnPooledThread {
             val warning = checkGitStatus()
             if (warning != null) {
                 javax.swing.SwingUtilities.invokeLater {
-                    textLabel.text = "<html><b>⚠ No version control detected.</b> $warning " +
-                        "The agent can make destructive edits — having git with a remote " +
-                        "is important for safe rollbacks.</html>"
+                    setMessage(
+                        "No version control detected. $warning " +
+                            "The agent can make destructive edits \u2014 having git with a remote " +
+                            "is important for safe rollbacks."
+                    )
                     isVisible = true
-                    revalidate()
-                    repaint()
                 }
             }
         }
@@ -118,21 +52,15 @@ class GitWarningBanner(private val project: Project) : JBPanel<JBPanel<*>>(Borde
         val basePath = project.basePath ?: return "No project directory found."
         val dir = java.io.File(basePath)
 
-        // Check if git is available
         if (!isGitInstalled(dir)) {
             return "Git is not installed or not found in PATH."
         }
-
-        // Check if this is a git repository
         if (!isGitRepo(dir)) {
             return "This project is not a git repository."
         }
-
-        // Check if any remote is configured
         if (!hasGitRemote(dir)) {
-            return "No git remote is configured — local commits alone may not be enough for recovery."
+            return "No git remote is configured \u2014 local commits alone may not be enough for recovery."
         }
-
         return null
     }
 


### PR DESCRIPTION
Replace hand-rolled JBPanel banners with the platform's InlineBanner component for native look & feel and proper theme support:

- GitWarningBanner: InlineBanner(Status.Error) with close + "Don't show again"
- PsiBridgeBanner: InlineBanner(Status.Warning) with Details/Recheck actions
- AuthSetupBanner: InlineBanner wrapper with dynamic actions + device code row

Removes ~140 lines of custom color, border, and layout code.