### PR TITLE
fix: wrap tools/list response in JSON-RPC 2.0 envelope

### DIFF
--- a/standalone-mcp/src/main/java/com/github/catatafishen/idemcpserver/McpProtocolHandler.java
+++ b/standalone-mcp/src/main/java/com/github/catatafishen/idemcpserver/McpProtocolHandler.java
@@ -46,7 +46,7 @@ public final class McpProtocolHandler {
 
             JsonObject result = switch (method) {
                 case "initialize" -> handleInitialize(msg);
-                case "tools/list" -> handleToolsList();
+                case "tools/list" -> handleToolsList(msg);
                 case "tools/call" -> handleToolsCall(msg);
                 case "ping" -> respondResult(msg, new JsonObject());
                 default -> respondError(msg, -32601, "Method not found: " + method);
@@ -79,7 +79,7 @@ public final class McpProtocolHandler {
         return respondResult(msg, result);
     }
 
-    private JsonObject handleToolsList() {
+    private JsonObject handleToolsList(JsonObject msg) {
         McpServerSettings settings = McpServerSettings.getInstance(project);
         List<ToolRegistry.ToolEntry> enabledTools = McpToolFilter.getEnabledTools(settings, project);
 
@@ -99,7 +99,7 @@ public final class McpProtocolHandler {
 
         JsonObject result = new JsonObject();
         result.add("tools", tools);
-        return result;
+        return respondResult(msg, result);
     }
 
     private JsonObject handleToolsCall(JsonObject msg) {


### PR DESCRIPTION
handleToolsList() was returning `{"tools": [...]}` directly instead of wrapping it with respondResult() like all other handlers. The Copilot CLI expects proper JSON-RPC 2.0 responses: `{"jsonrpc": "2.0", "id": ..., "result": {"tools": [...]}}`.