### PR TITLE
fix: inject tool reprimand into next MCP tool result for immediate feedback

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/acp/client/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/acp/client/CopilotClient.java
@@ -514,12 +514,13 @@ public final class CopilotClient extends AcpClient {
             // feedback — the agent corrects behaviour within the same turn instead of
             // waiting until the user sends another prompt.
             String notice = buildSingleToolReprimand(toolId);
-            PsiBridgeService psi =
-                PsiBridgeService.getInstance(project);
+            PsiBridgeService psi = PsiBridgeService.getInstance(project);
             psi.setPendingNudge(notice);
             // Once the nudge is consumed (agent saw it), clear the tracking set so
             // beforeSendPrompt() doesn't repeat the same reprimand on the next prompt.
-            psi.setOnNudgeConsumed(misusedBuiltInTools::clear);
+            // Use addOnNudgeConsumed (not set) to chain with any existing callback,
+            // e.g. the UI callback from onNudgeClicked that clears pendingNudgeId.
+            psi.addOnNudgeConsumed(misusedBuiltInTools::clear);
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/psi/PsiBridgeService.java
@@ -156,6 +156,14 @@ public final class PsiBridgeService implements Disposable {
         onNudgeConsumed = callback;
     }
 
+    public void addOnNudgeConsumed(@NotNull Runnable callback) {
+        Runnable current = onNudgeConsumed;
+        onNudgeConsumed = current == null ? callback : () -> {
+            current.run();
+            callback.run();
+        };
+    }
+
     public void enqueueMessage(@NotNull String message) {
         if (!message.trim().isEmpty()) {
             messageQueue.offer(message.trim());


### PR DESCRIPTION
## Root Cause

When the agent misuses a built-in tool (e.g. `bash`, `edit`, `grep`), the corrective reprimand was only prepended to the **next user prompt** via `beforeSendPrompt()`. This meant the agent wouldn't see the correction until the user sent another message — allowing it to continue misusing tools for the rest of the current turn.

## Fix

`onBuiltInToolApproved()` now also injects the reprimand as a **pending nudge** via `PsiBridgeService.setPendingNudge()`. The nudge is consumed on the very next MCP tool call (`callTool()` → `consumePendingNudge()`), giving the agent immediate mid-turn feedback.

Once the nudge is consumed, `misusedBuiltInTools` is cleared via `setOnNudgeConsumed()` so `beforeSendPrompt()` doesn't double-report the same tools on the next prompt.

The prompt-prepend logic remains as a fallback for the rare case where no MCP tool call follows the misuse within the same turn.

### Flow (after fix)

1. Agent calls built-in tool → `onBuiltInToolApproved()` fires
2. Reprimand injected as pending nudge + tool ID added to `misusedBuiltInTools`
3. Agent calls next MCP tool → nudge consumed → reprimand in tool result (**immediate**)
4. `onNudgeConsumed` callback clears `misusedBuiltInTools`
5. Next prompt → `beforeSendPrompt()` sees empty set → no double-report

Closes #44

---
*⚠️ This message was generated automatically by an AI language model (LLM) via the [IDE Agent for Copilot plugin](https://github.com/catatafishen/agentbridge). It may contain errors. Please review carefully before acting on it.*