### PR TITLE
fix: remove failed prompt by ID and restore text to input box (closes #45)

### DIFF
--- a/plugin-core/chat-ui/src/ChatController.ts
+++ b/plugin-core/chat-ui/src/ChatController.ts
@@ -134,9 +134,10 @@ const ChatController = {
 
     // ── Public API ─────────────────────────────────────────────
 
-    addUserMessage(text: string, timestamp: string, encodedBubbleHtml?: string): void {
+    addUserMessage(text: string, timestamp: string, encodedBubbleHtml?: string, entryId?: string): void {
         const msg = document.createElement('chat-message');
         msg.setAttribute('type', 'user');
+        if (entryId) msg.id = entryId;
         const meta = document.createElement('message-meta');
         meta.innerHTML = '<span class="ts">' + timestamp + '</span>';
         msg.appendChild(meta);
@@ -150,6 +151,10 @@ const ChatController = {
         msg.appendChild(bubble);
         this._insertMsg(msg);
         this._container()?.forceScroll();
+    },
+
+    removeUserMessage(entryId: string): void {
+        document.getElementById(entryId)?.remove();
     },
 
     appendAgentText(turnId: string, agentId: string, text: string, timestamp?: string): void {

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/v2/EntryDataConverter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/v2/EntryDataConverter.java
@@ -216,7 +216,7 @@ public final class EntryDataConverter {
                     case "text" -> {
                         String text = part.has("text") ? part.get("text").getAsString() : "";
                         if ("user".equals(msg.role)) {
-                            result.add(new EntryData.Prompt(text, ts, null));
+                            result.add(new EntryData.Prompt(text, ts, null, ""));
                         } else {
                             result.add(new EntryData.Text(
                                 new StringBuilder(text),

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatConsolePanel.kt
@@ -269,15 +269,22 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
         executeJs("document.querySelector('chat-container').style.scrollBehavior = '${if (enabled) "smooth" else "auto"}'")
     }
 
-    override fun addPromptEntry(text: String, contextFiles: List<Triple<String, String, Int>>?, bubbleHtml: String?) {
+    override fun addPromptEntry(text: String, contextFiles: List<Triple<String, String, Int>>?, bubbleHtml: String?): String {
         toolJustCompleted = false
         finalizeCurrentText()
         collapseThinking()
         currentTurnId = "t${turnCounter++}"
         val ts = timestamp()
-        entries.add(EntryData.Prompt(text, ts, contextFiles))
+        entries.add(EntryData.Prompt(text, ts, contextFiles, id = currentTurnId))
         val encodedBubble = if (bubbleHtml != null) b64(bubbleHtml) else ""
-        executeJs("ChatController.addUserMessage('${escJs(text)}','${displayTs(ts)}','$encodedBubble');ChatController.showWorkingIndicator()")
+        executeJs("ChatController.addUserMessage('${escJs(text)}','${displayTs(ts)}','$encodedBubble','$currentTurnId');ChatController.showWorkingIndicator()")
+        return currentTurnId
+    }
+
+    override fun removePromptEntry(entryId: String) {
+        val idx = entries.indexOfLast { it is EntryData.Prompt && it.id == entryId }
+        if (idx >= 0) entries.removeAt(idx)
+        executeJs("ChatController.removeUserMessage('$entryId')")
     }
 
     override fun startStreaming() {

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatDataModel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatDataModel.kt
@@ -37,7 +37,8 @@ sealed class EntryData {
     class Prompt(
         val text: String,
         val timestamp: String = "",
-        val contextFiles: List<Triple<String, String, Int>>? = null
+        val contextFiles: List<Triple<String, String, Int>>? = null,
+        val id: String = "",
     ) : EntryData()
 
     class Text(

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatPanelApi.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatPanelApi.kt
@@ -21,7 +21,9 @@ interface ChatPanelApi : Disposable {
         text: String,
         contextFiles: List<Triple<String, String, Int>>? = null,
         bubbleHtml: String? = null
-    )
+    ): String
+
+    fun removePromptEntry(entryId: String)
 
     fun setPromptStats(modelId: String, multiplier: String)
     fun setCodeChangeStats(linesAdded: Int, linesRemoved: Int)

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatToolWindowContent.kt
@@ -65,10 +65,6 @@ class ChatToolWindowContent(
     private var restartSessionGroup: RestartSessionGroup? = null
     private lateinit var promptTextArea: EditorTextField
     private var isSending = false
-
-    // @Volatile: written by the onNudgeConsumed callback on the HTTP handler thread,
-    // read by setSendingState(false) which may arrive on the orchestrator thread before the
-    // EDT has a chance to flush — @Volatile ensures cross-thread visibility.
     @Volatile
     private var pendingNudgeId: String? = null
     @Volatile
@@ -681,6 +677,7 @@ class ChatToolWindowContent(
                 },
                 onClientUpdate = ::handleClientUpdate,
                 sendPromptDirectly = ::sendPromptDirectly,
+                restorePromptText = ::restorePromptText,
             )
         )
 
@@ -760,12 +757,18 @@ class ChatToolWindowContent(
             }
         } else null
         val bubbleHtml = buildBubbleHtml(rawText, contextItems)
-        consolePanel.addPromptEntry(prompt, ctxFiles, bubbleHtml)
+        val entryId = consolePanel.addPromptEntry(prompt, ctxFiles, bubbleHtml)
         promptTextArea.text = ""
 
         val selectedModelId = resolveSelectedModelId()
         ApplicationManager.getApplication().executeOnPooledThread {
-            promptOrchestrator.execute(prompt, contextItems, selectedModelId)
+            promptOrchestrator.execute(prompt, contextItems, selectedModelId, rawText, entryId)
+        }
+    }
+
+    private fun restorePromptText(rawText: String) {
+        ApplicationManager.getApplication().invokeLater {
+            promptTextArea.text = rawText
         }
     }
 
@@ -1862,10 +1865,10 @@ class ChatToolWindowContent(
 
         statusBanner?.dismissCurrent()
         setSendingState(true)
-        consolePanel.addPromptEntry(trimmed, null)
+        val entryId = consolePanel.addPromptEntry(trimmed, null)
         val selectedModelId = resolveSelectedModelId()
         ApplicationManager.getApplication().executeOnPooledThread {
-            promptOrchestrator.execute(trimmed, emptyList(), selectedModelId)
+            promptOrchestrator.execute(trimmed, emptyList(), selectedModelId, trimmed, entryId)
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/PromptOrchestrator.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/PromptOrchestrator.kt
@@ -33,6 +33,8 @@ data class PromptOrchestratorCallbacks(
     val onClientUpdate: (SessionUpdate) -> Unit,
     /** Trigger a new prompt execution (used for queued messages). */
     val sendPromptDirectly: (String) -> Unit,
+    /** Restore the user's prompt text to the input box on send failure. */
+    val restorePromptText: (rawText: String) -> Unit,
 )
 
 /** Stored banner message to re-display at the start of the next prompt turn. */
@@ -79,8 +81,14 @@ class PromptOrchestrator(
     private var turnHadContent = false
     private var codeChangeListener: Runnable? = null
 
+    private var pendingRawText = ""
+    private var pendingPromptEntryId = ""
+
     /** Executes a prompt on the calling thread (must be called from a background thread). */
-    fun execute(prompt: String, contextItems: List<ContextItemData>, selectedModelId: String) {
+    fun execute(prompt: String, contextItems: List<ContextItemData>, selectedModelId: String,
+                rawText: String, promptEntryId: String) {
+        pendingRawText = rawText
+        pendingPromptEntryId = promptEntryId
         stopped = false
         // Clear any stale interrupt flag left by a previous stop() call so it doesn't fire
         // immediately on the first blocking operation in the new turn.
@@ -677,9 +685,20 @@ class PromptOrchestrator(
             msg = "ACP error: $msg"
         }
 
+        // If the prompt was never delivered (no content streamed) and the user didn't
+        // cancel, remove the failed prompt bubble and restore the text to the input box.
+        val shouldRestore = !turnHadContent && !isCancelled
+        if (shouldRestore) {
+            consolePanel().removePromptEntry(pendingPromptEntryId)
+        }
+
         consolePanel().cancelAllRunning()
         consolePanel().finishResponse(turnToolCallCount, turnModelId, "")
         callbacks.saveConversation()
+
+        if (shouldRestore) {
+            callbacks.restorePromptText(pendingRawText)
+        }
 
         if (authService.isAuthenticationError(msg)) {
             log.info("Authentication error detected: $msg")
@@ -703,7 +722,9 @@ class PromptOrchestrator(
             consolePanel().addErrorEntry("Error: $msg")
         }
         if (!isCancelled) {
-            statusBanner()?.showError(msg, "Reconnect") { reconnectAfterError() }
+            val bannerMsg = if (shouldRestore) "$msg — your message has been restored to the input box"
+            else msg
+            statusBanner()?.showError(bannerMsg, "Reconnect") { reconnectAfterError() }
         }
 
         e.printStackTrace()


### PR DESCRIPTION
## Summary

When a prompt fails before any streaming content is received (connection error, auth failure, session creation failure), the user's message bubble is removed from the chat and the original text is restored to the input box so they can retry without retyping.

## Design

The removal is **ID-based**: `addPromptEntry()` now returns the entry ID (the turn ID, e.g. `t3`), which is set as the DOM element's `id` attribute. On failure, `removePromptEntry(entryId)` targets exactly that element using `document.getElementById` — not a generic "remove last message" query.

This is safe in any race or edge case: only the specific bubble that was added for the failed turn is removed.

## Changes

- **`ChatDataModel.kt`**: add `id: String` field to `EntryData.Prompt`
- **`ChatController.ts`**: `addUserMessage()` accepts optional `entryId` and sets it as the DOM element's `id`; new `removeUserMessage(entryId)` replaces `removeLastUserMessage()`
- **`ChatPanelApi.kt`**: `addPromptEntry()` returns `String` (entry ID); `removeLastPromptEntry()` → `removePromptEntry(entryId: String)`
- **`ChatConsolePanel.kt`**: `addPromptEntry()` passes the turn ID to JS, stores it in `EntryData.Prompt`, returns the turn ID to the caller
- **`PromptOrchestrator.kt`**: `execute()` takes `rawText` and `promptEntryId`; stores them; `handlePromptError()` calls `removePromptEntry(pendingPromptEntryId)` and `restorePromptText(pendingRawText)` when `!turnHadContent && !isCancelled`
- **`ChatToolWindowContent.kt`**: captures `entryId` from `addPromptEntry()`, passes `rawText` + `entryId` to `execute()`; `restorePromptText` callback takes the raw text as parameter
- **`EntryDataConverter.java`**: pass empty `id` when deserializing historical prompt entries