### PR TITLE
fix: show turn count in session dropdown and remove redundant Resume prefix

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/v2/SessionStoreV2.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/v2/SessionStoreV2.java
@@ -57,6 +57,7 @@ public final class SessionStoreV2 implements Disposable {
     private static final String KEY_CREATED_AT = "createdAt";
     private static final String KEY_UPDATED_AT = "updatedAt";
     private static final String KEY_JSONL_PATH = "jsonlPath";
+    private static final String KEY_TURN_COUNT = "turnCount";
 
     private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
 
@@ -98,12 +99,14 @@ public final class SessionStoreV2 implements Disposable {
      * @param agent     display name of the agent (e.g. "GitHub Copilot")
      * @param createdAt epoch millis when the session was created
      * @param updatedAt epoch millis when the session was last updated
+     * @param turnCount number of user turns in the session (0 if unknown / old index entry)
      */
     public record SessionRecord(
         @NotNull String id,
         @NotNull String agent,
         long createdAt,
-        long updatedAt) {
+        long updatedAt,
+        int turnCount) {
     }
 
     @NotNull
@@ -117,7 +120,8 @@ public final class SessionStoreV2 implements Disposable {
             String agent = rec.has(KEY_AGENT) ? rec.get(KEY_AGENT).getAsString() : "Unknown";
             long createdAt = rec.has(KEY_CREATED_AT) ? rec.get(KEY_CREATED_AT).getAsLong() : 0;
             long updatedAt = rec.has(KEY_UPDATED_AT) ? rec.get(KEY_UPDATED_AT).getAsLong() : 0;
-            result.add(new SessionRecord(id, agent, createdAt, updatedAt));
+            int turnCount = rec.has(KEY_TURN_COUNT) ? rec.get(KEY_TURN_COUNT).getAsInt() : 0;
+            result.add(new SessionRecord(id, agent, createdAt, updatedAt, turnCount));
         }
         result.sort(Comparator.comparingLong(SessionRecord::updatedAt).reversed());
         return result;
@@ -270,13 +274,15 @@ public final class SessionStoreV2 implements Disposable {
 
             File jsonlFile = new File(sessionsDir, sessionId + JSONL_EXT);
             StringBuilder sb = new StringBuilder();
+            int turnCount = 0;
             for (SessionMessage msg : messages) {
                 sb.append(GSON.toJson(msg)).append('\n');
+                if ("user".equals(msg.role)) turnCount++;
             }
             Files.writeString(jsonlFile.toPath(), sb.toString(), StandardCharsets.UTF_8,
                 StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
 
-            updateSessionsIndex(basePath, sessionId, sessionsDir, jsonlFile.getName());
+            updateSessionsIndex(basePath, sessionId, sessionsDir, jsonlFile.getName(), turnCount);
 
         } catch (Exception e) {
             LOG.warn("Failed to write v2 session JSONL", e);
@@ -287,7 +293,8 @@ public final class SessionStoreV2 implements Disposable {
         @Nullable String basePath,
         @NotNull String sessionId,
         @NotNull File sessionsDir,
-        @NotNull String jsonlFileName) throws IOException {
+        @NotNull String jsonlFileName,
+        int turnCount) throws IOException {
 
         File indexFile = new File(sessionsDir, SESSIONS_INDEX);
         List<JsonObject> records = readIndexRecords(indexFile);
@@ -300,6 +307,7 @@ public final class SessionStoreV2 implements Disposable {
             if (rec.has(KEY_ID) && sessionId.equals(rec.get(KEY_ID).getAsString())) {
                 rec.addProperty(KEY_UPDATED_AT, now);
                 rec.addProperty(KEY_AGENT, currentAgent);
+                rec.addProperty(KEY_TURN_COUNT, turnCount);
                 found = true;
                 break;
             }
@@ -312,6 +320,7 @@ public final class SessionStoreV2 implements Disposable {
             newRec.addProperty(KEY_CREATED_AT, now);
             newRec.addProperty(KEY_UPDATED_AT, now);
             newRec.addProperty(KEY_JSONL_PATH, jsonlFileName);
+            newRec.addProperty(KEY_TURN_COUNT, turnCount);
             records.add(newRec);
         }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/AcpConnectPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/AcpConnectPanel.kt
@@ -46,16 +46,24 @@ class AcpConnectPanel(
     sealed class SessionChoice(val displayText: String) {
         /** Resume the most recent session (default). */
         class Latest(val record: SessionStoreV2.SessionRecord) :
-            SessionChoice("Resume: ${SESSION_DATE_FORMAT.format(Date(record.updatedAt))} (${record.agent})")
+            SessionChoice(formatSession(record))
 
         /** Start a fresh session without resuming. */
         data object None : SessionChoice("None (fresh session)")
 
         /** Resume a specific older session. */
         class Older(val record: SessionStoreV2.SessionRecord) :
-            SessionChoice("${SESSION_DATE_FORMAT.format(Date(record.updatedAt))} (${record.agent})")
+            SessionChoice(formatSession(record))
 
         override fun toString(): String = displayText
+
+        companion object {
+            private fun formatSession(record: SessionStoreV2.SessionRecord): String {
+                val date = SESSION_DATE_FORMAT.format(Date(record.updatedAt))
+                val base = "$date (${record.agent})"
+                return if (record.turnCount > 0) "$base — ${record.turnCount} turns" else base
+            }
+        }
     }
 
     private val agentManager = ActiveAgentManager.getInstance(project)


### PR DESCRIPTION
## Problem

Two UX issues with the session selection dropdown:
1. **No size indicator** — users can't tell which sessions are large vs small
2. **Redundant "Resume:" prefix** — the latest entry says "Resume: \<date\>" but the dropdown is already labeled "Resume session"

## Fix

### SessionStoreV2.java
- `SessionRecord` extended with `turnCount` field (int, 0 for old/unknown entries)
- `saveV2()` counts user messages (`role == "user"`) while serializing the JSONL
- `updateSessionsIndex()` stores `turnCount` in `sessions-index.json`
- `listSessions()` reads `turnCount` from the index (defaults to 0 for old entries)

### AcpConnectPanel.kt
- `SessionChoice` sealed class now uses a shared `formatSession()` helper
- Both `Latest` and `Older` display the same format: `"<date> (<agent>) — N turns"`
- Turn count suffix omitted when `turnCount == 0` (old sessions without metadata)
- "Resume:" prefix removed — the dropdown context is sufficient

### Backward compatibility
Old `sessions-index.json` entries without `turnCount` default to 0. These sessions display without the turn suffix. The turn count is populated on the next save.

Closes #47

---
*⚠️ This message was generated automatically by an AI language model (LLM) via the [IDE Agent for Copilot plugin](https://github.com/catatafishen/agentbridge). It may contain errors. Please review carefully before acting on it.*