### PR TITLE
fix: pass agent name explicitly through save chain to prevent stale labels

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/v2/SessionStoreV2.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/v2/SessionStoreV2.java
@@ -264,6 +264,9 @@ public final class SessionStoreV2 implements Disposable {
 
     private void saveV2(@Nullable String basePath, @NotNull String v1Json) {
         try {
+            // Capture agent name once at the start to avoid races with setCurrentAgent()
+            String agent = currentAgent;
+
             var entries = ConversationSerializer.INSTANCE.deserialize(v1Json);
             List<SessionMessage> messages = EntryDataConverter.toMessages(entries);
 
@@ -282,7 +285,7 @@ public final class SessionStoreV2 implements Disposable {
             Files.writeString(jsonlFile.toPath(), sb.toString(), StandardCharsets.UTF_8,
                 StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
 
-            updateSessionsIndex(basePath, sessionId, sessionsDir, jsonlFile.getName(), turnCount);
+            updateSessionsIndex(basePath, sessionId, sessionsDir, jsonlFile.getName(), agent, turnCount);
 
         } catch (Exception e) {
             LOG.warn("Failed to write v2 session JSONL", e);
@@ -294,6 +297,7 @@ public final class SessionStoreV2 implements Disposable {
         @NotNull String sessionId,
         @NotNull File sessionsDir,
         @NotNull String jsonlFileName,
+        @NotNull String agentName,
         int turnCount) throws IOException {
 
         File indexFile = new File(sessionsDir, SESSIONS_INDEX);
@@ -306,7 +310,7 @@ public final class SessionStoreV2 implements Disposable {
         for (JsonObject rec : records) {
             if (rec.has(KEY_ID) && sessionId.equals(rec.get(KEY_ID).getAsString())) {
                 rec.addProperty(KEY_UPDATED_AT, now);
-                rec.addProperty(KEY_AGENT, currentAgent);
+                rec.addProperty(KEY_AGENT, agentName);
                 rec.addProperty(KEY_TURN_COUNT, turnCount);
                 found = true;
                 break;
@@ -315,7 +319,7 @@ public final class SessionStoreV2 implements Disposable {
         if (!found) {
             JsonObject newRec = new JsonObject();
             newRec.addProperty(KEY_ID, sessionId);
-            newRec.addProperty(KEY_AGENT, currentAgent);
+            newRec.addProperty(KEY_AGENT, agentName);
             newRec.addProperty("directory", directory);
             newRec.addProperty(KEY_CREATED_AT, now);
             newRec.addProperty(KEY_UPDATED_AT, now);

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatToolWindowContent.kt
@@ -235,6 +235,10 @@ class ChatToolWindowContent(
         if (agentManager.activeProfileId != profileId) {
             agentManager.switchAgent(profileId)
         }
+        // Always sync the session store agent name on connect — switchAgent only fires
+        // the listener when the profile changes, so reconnecting to the same profile
+        // after a disconnect would leave currentAgent stale.
+        conversationStore.setCurrentAgent(agentManager.activeProfile.displayName)
         if (::promptOrchestrator.isInitialized) resetSessionState()
         // Stay on connect panel while spinner shows "Connecting…"
         // loadModelsAsync triggers agent.start() via getClient() — wait for it to complete


### PR DESCRIPTION
## Root Cause

`updateSessionsIndex()` read the volatile `currentAgent` field directly. Two timing issues caused wrong labels:

1. **Race condition**: `saveAsync()` runs on a pooled thread. If `setCurrentAgent()` is called between the save starting and `updateSessionsIndex()` reading the field, the wrong name is written.

2. **Missing sync on reconnect**: `connectToAgent()` only called `agentManager.switchAgent()` when the profile changed. Reconnecting to the same profile after a disconnect skipped the switch listener, leaving `currentAgent` stale from the previous connection.

## Fix

### SessionStoreV2.java
- `updateSessionsIndex()` now takes `agentName` as an explicit parameter (matching the pattern already used by `updateSessionAgent()`)
- `saveV2()` captures `currentAgent` once at the start and passes it through — a single volatile read eliminates the race

### ChatToolWindowContent.kt
- `connectToAgent()` now always calls `conversationStore.setCurrentAgent()` regardless of whether the profile changed, ensuring the field is up-to-date on every connection

Closes #48

---
*⚠️ This message was generated automatically by an AI language model (LLM) via the [IDE Agent for Copilot plugin](https://github.com/catatafishen/agentbridge). It may contain errors. Please review carefully before acting on it.*