### PR TITLE
feat: open VCS log at commit when clicking git_commit tool chips

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatConsolePanel.kt
@@ -1341,6 +1341,9 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
             }
             return
         }
+        if (baseName?.trim('\'', '"') == "git_commit" && tryNavigateToCommit(entry?.result)) {
+            return
+        }
 
         val resultPanel =
             renderToolResultPanel(
@@ -1423,6 +1426,38 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
                 }
             }
         }
+    }
+
+    /**
+     * Extracts abbreviated commit hash from git commit output (e.g. `[master f63d935] ...`)
+     * resolves it to a full hash via `git rev-parse`, and navigates to it in the VCS Log.
+     * Returns true if a hash was found (navigation is async), false otherwise.
+     */
+    private fun tryNavigateToCommit(result: String?): Boolean {
+        if (result.isNullOrBlank()) return false
+        val match = Regex("""\[[\w/.#-]+\s+([0-9a-f]{7,40})]""").find(result) ?: return false
+        val abbreviatedHash = match.groupValues[1]
+        val basePath = project.basePath ?: return false
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+            try {
+                val process = ProcessBuilder("git", "rev-parse", abbreviatedHash)
+                    .directory(java.io.File(basePath))
+                    .redirectErrorStream(true)
+                    .start()
+                val fullHash = process.inputStream.bufferedReader().readText().trim()
+                process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)
+                if (fullHash.length == 40) {
+                    ApplicationManager.getApplication().invokeLater {
+                        com.github.catatafishen.ideagentforcopilot.psi.PlatformApiCompat
+                            .showRevisionInLog(project, fullHash)
+                    }
+                }
+            } catch (_: Exception) {
+                // best-effort navigation
+            }
+        }
+        return true
     }
 
     private fun isJson(text: String): Boolean =


### PR DESCRIPTION
## Root cause

Clicking a `git_commit` tool chip opened a text popup showing the commit output. Users had to manually find the commit in the VCS log.

## Fix

In `handleShowToolPopup()`, when the tool is `git_commit`:

1. `tryNavigateToCommit(result)` extracts the abbreviated hash from the git output using the `[branch hash]` pattern
2. Resolves it to a full 40-char hash via `git rev-parse` on a pooled thread
3. Calls `PlatformApiCompat.showRevisionInLog(project, fullHash)` on EDT to navigate the VCS Log to that commit
4. Returns early, skipping the popup

This follows the same pattern as `GitTool.showNewCommitInLog()` which already does hash resolution + VCS log navigation during tool execution.

Non-commit tool chips fall through to the existing popup.

Closes #51

---
*This message was generated automatically by an AI language model (LLM) via the [IDE Agent for Copilot plugin](https://github.com/catatafishen/agentbridge). It may contain errors. Please review carefully before acting on it.*
