### PR TITLE
fix: use registry chip ID for sub-agent tool chip DOM correlation

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatConsolePanel.kt
@@ -527,12 +527,8 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
         kind: String?
     ) {
         val saDid = domId(subAgentId)
-        val toolDid = domId(toolId)
         val resolvedKind = kind ?: "other"
         val cleanTitle = title.trim('\'', '"')
-        val entry = EntryData.ToolCall(cleanTitle, arguments, resolvedKind)
-        toolCallNames[toolDid] = cleanTitle
-        toolCallEntries[toolDid] = entry
 
         val def = toolRegistry?.findById(cleanTitle)
         val info = TOOL_DISPLAY_INFO[cleanTitle]
@@ -543,7 +539,9 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
         val paramsJson = if (!arguments.isNullOrBlank() && !hasCustomRenderer) escJs(arguments) else ""
         val safeKind = escJs(resolvedKind)
 
-        // Check if MCP handled this via hash correlation
+        // Register with chip registry to get the hash-based chipId.
+        // The DOM chip MUST use "t-$chipId" so the kindStateListener can find it
+        // when MCP fires markMcpHandled with the same "t-$chipId".
         val argsObj = arguments?.let {
             try {
                 JsonParser.parseString(it).takeIf { e -> e.isJsonObject }?.asJsonObject
@@ -552,10 +550,20 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
             }
         }
         val registration = registry.registerClientSide(cleanTitle, argsObj, toolId)
+        val chipId = registration.chipId()
+        val toolDid = "t-$chipId"
         val isMcpHandled = registration.initialState() == ToolChipRegistry.ChipState.RUNNING
         val isExternal = !isMcpHandled
 
+        val entry = EntryData.ToolCall(cleanTitle, arguments, resolvedKind)
+        if (isMcpHandled) entry.mcpHandled = true
+        toolCallNames[toolDid] = cleanTitle
+        toolCallEntries[toolDid] = entry
+
         executeJs("ChatController.addSubAgentToolCall('$saDid','$toolDid','${escJs(label)}','$paramsJson','$safeKind',$isExternal)")
+        if (isMcpHandled) {
+            executeJs("ChatController.markMcpHandled('$toolDid')")
+        }
     }
 
     /** Update a sub-agent internal tool call (no segment break). */
@@ -567,7 +575,8 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
         autoDenied: Boolean,
         denialReason: String?
     ) {
-        val did = domId(toolId)
+        val chipId = registry.findChipIdByClientId(toolId)
+        val did = if (chipId != null) "t-$chipId" else domId(toolId)
         toolCallEntries[did]?.let {
             it.result = details
             it.status = status


### PR DESCRIPTION
## Root cause

The `kindStateListener` in `ChatConsolePanel.kt` fires `markMcpHandled("t-$chipId")` when the MCP side starts handling a tool call. This works for top-level tool calls because `addToolCallEntry` uses `"t-$chipId"` as the DOM element ID.

However, `addSubAgentToolCall` was using `domId(toolId)` — the ACP tool call ID — as the DOM element ID. Since the listener always constructs `"t-$chipId"`, the `markMcpHandled` JS call could never find the sub-agent's chip element, so the `is-agentbridge-tool` class was never added and the border stayed dashed.

## Fix

- **`addSubAgentToolCall`**: Use `"t-${registration.chipId()}"` as the DOM ID instead of `domId(toolId)`, matching the pattern in `addToolCallEntry` and the `kindStateListener`
- **`updateSubAgentToolCall`**: Resolve `toolId` → `chipId` via `registry.findChipIdByClientId()`, then use `"t-$chipId"` for DOM lookup (same pattern as `updateToolCall`)

## Verification

All 514 tests pass.

Closes #53

---
*This message was generated automatically by an AI language model (LLM) via the [IDE Agent for Copilot plugin](https://github.com/catatafishen/agentbridge). It may contain errors. Please review carefully before acting on it.*
