### PR TITLE
fix: surface Kiro crash reason in UI and fix consecutive AssistantMessages in history export

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/acp/client/KiroClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/acp/client/KiroClient.java
@@ -14,6 +14,14 @@ public final class KiroClient extends AcpClient {
 
     private static final Logger LOG = Logger.getInstance(KiroClient.class);
     private static final String KEY_RAW_INPUT = "rawInput";
+    private static final String KEY_AGENTBRIDGE = "@agentbridge/";
+    private static final String KEY_STATUS = "status";
+
+    /**
+     * Rolling buffer of the last few stderr lines for crash diagnostics.
+     */
+    private final java.util.Deque<String> recentStderr = new java.util.ArrayDeque<>();
+    private static final int STDERR_BUFFER_SIZE = 30;
 
     public KiroClient(Project project) {
         super(project);
@@ -34,8 +42,13 @@ public final class KiroClient extends AcpClient {
 
         // Register request and stderr handlers from parent
         transport.onRequest(this::handleAgentRequest);
-        transport.onStderr(line ->
-            LOG.warn("[" + agentId() + " stderr] " + line));
+        transport.onStderr(line -> {
+            LOG.warn("[" + agentId() + " stderr] " + line);
+            synchronized (recentStderr) {
+                recentStderr.addLast(line);
+                if (recentStderr.size() > STDERR_BUFFER_SIZE) recentStderr.removeFirst();
+            }
+        });
     }
 
     private void handleKiroNotification(String method, JsonObject params) {
@@ -71,18 +84,6 @@ public final class KiroClient extends AcpClient {
         });
     }
 
-    public void getCommandOptions(String partial, java.util.function.Consumer<JsonArray> callback) {
-        JsonObject params = new JsonObject();
-        params.addProperty("partial", partial);
-        transport.sendRequest("_kiro.dev/commands/options", params).thenAccept(response -> {
-            JsonArray options = (response != null && response.isJsonObject()
-                && response.getAsJsonObject().has("options"))
-                ? response.getAsJsonObject().getAsJsonArray("options")
-                : new JsonArray();
-            callback.accept(options);
-        });
-    }
-
     public JsonArray getAvailableCommands() {
         return availableCommands;
     }
@@ -91,7 +92,7 @@ public final class KiroClient extends AcpClient {
         if (params != null && params.has("url")) {
             String oauthUrl = params.get("url").getAsString();
             LOG.info("MCP OAuth required: " + oauthUrl);
-            // TODO: Show notification with clickable link
+            // OAuth for MCP servers is not yet exposed via ACP — log and ignore for now.
         }
     }
 
@@ -103,15 +104,15 @@ public final class KiroClient extends AcpClient {
     }
 
     private void handleCompactionStatus(JsonObject params) {
-        if (params != null && params.has("status")) {
-            String status = params.get("status").getAsString();
+        if (params != null && params.has(KEY_STATUS)) {
+            String status = params.get(KEY_STATUS).getAsString();
             LOG.debug("Context compaction: " + status);
         }
     }
 
     private void handleClearStatus(JsonObject params) {
-        if (params != null && params.has("status")) {
-            String status = params.get("status").getAsString();
+        if (params != null && params.has(KEY_STATUS)) {
+            String status = params.get(KEY_STATUS).getAsString();
             LOG.debug("Clear session: " + status);
         }
     }
@@ -150,8 +151,8 @@ public final class KiroClient extends AcpClient {
 
     @Override
     protected String resolveToolId(String protocolTitle) {
-        if (protocolTitle.startsWith("@agentbridge/")) {
-            return protocolTitle.substring("@agentbridge/".length());
+        if (protocolTitle.startsWith(KEY_AGENTBRIDGE)) {
+            return protocolTitle.substring(KEY_AGENTBRIDGE.length());
         }
         String cleaned = protocolTitle.replaceFirst("^Running: @agentbridge/", "");
         // Map Kiro's human-readable titles to actual tool names
@@ -164,8 +165,8 @@ public final class KiroClient extends AcpClient {
 
     @Override
     protected boolean isMcpToolTitle(@org.jetbrains.annotations.NotNull String protocolTitle) {
-        return protocolTitle.startsWith("Running: @agentbridge/")
-            || protocolTitle.startsWith("@agentbridge/");
+        return protocolTitle.startsWith("Running: " + KEY_AGENTBRIDGE)
+            || protocolTitle.startsWith(KEY_AGENTBRIDGE);
     }
 
     @Override
@@ -224,11 +225,11 @@ public final class KiroClient extends AcpClient {
     protected SessionUpdate processUpdate(SessionUpdate update) {
         // Kiro sends thinking as agent_message_chunk with ContentBlock.Thinking blocks —
         // convert to agent_thought_chunk for proper UI rendering.
-        if (update instanceof SessionUpdate.AgentMessageChunk chunk) {
-            boolean hasThinking = chunk.content().stream()
+        if (update instanceof SessionUpdate.AgentMessageChunk(var content)) {
+            boolean hasThinking = content.stream()
                 .anyMatch(block -> block instanceof ContentBlock.Thinking);
             if (hasThinking) {
-                return new SessionUpdate.AgentThoughtChunk(chunk.content());
+                return new SessionUpdate.AgentThoughtChunk(content);
             }
         }
         if (update instanceof SessionUpdate.ToolCall tc) {
@@ -242,6 +243,27 @@ public final class KiroClient extends AcpClient {
             return extractPurpose(tc);
         }
         return update;  // Pass through all other update types unchanged
+    }
+
+    /**
+     * When Kiro crashes (Rust panic), the process writes the panic message to stderr and the
+     * transport stops. The generic "Transport stopped" message is unhelpful; this override
+     * inspects the buffered stderr lines and surfaces the actual panic reason to the UI.
+     */
+    @Override
+    protected @org.jetbrains.annotations.Nullable com.github.catatafishen.ideagentforcopilot.acp.model.PromptResponse
+    tryRecoverPromptException(Exception cause) {
+        String panicLine;
+        synchronized (recentStderr) {
+            panicLine = recentStderr.stream()
+                .filter(l -> l.contains("panicked") || l.contains("Message:"))
+                .reduce((first, second) -> second) // keep last matching line
+                .orElse(null);
+        }
+        if (panicLine == null) return null;
+        // Throw an unchecked exception whose message surfaces in the UI via handlePromptError.
+        throw new java.io.UncheckedIOException(
+            new java.io.IOException("Kiro crashed: " + panicLine.trim(), cause));
     }
 
     private SessionUpdate.ToolCall extractPurpose(SessionUpdate.ToolCall tc) {

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/KiroClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/KiroClientExporter.java
@@ -198,6 +198,11 @@ public final class KiroClientExporter {
         // Merge any consecutive Prompts by appending the later content into the earlier one.
         mergeConsecutivePrompts(result);
 
+        // Kiro may also reject consecutive AssistantMessages (two v2 assistant turns in a row
+        // with no user message between them produces this when the last part of turn N is text
+        // and the first part of turn N+1 opens with tool calls). Merge them by concatenating content.
+        mergeConsecutiveAssistantMessages(result);
+
         return result;
     }
 
@@ -219,6 +224,35 @@ public final class KiroClientExporter {
                 LOG.warn("Kiro export: removing duplicate consecutive Prompt at index " + i);
                 messages.remove(i);
                 // don't advance i — the item now at i may also be followed by another Prompt
+            } else {
+                i++;
+            }
+        }
+    }
+
+    /**
+     * Merges consecutive {@code AssistantMessage} entries in-place by appending the later
+     * message's content into the earlier one.
+     *
+     * <p>Two consecutive AssistantMessages can occur when two v2 assistant turns appear
+     * back-to-back (no user Prompt between them) and the first turn's last part was plain text
+     * while the second turn opens with tool calls. In Kiro's format this is invalid —
+     * AssistantMessages must alternate with Prompts (and optional ToolResults in between).</p>
+     */
+    private static void mergeConsecutiveAssistantMessages(@NotNull List<JsonObject> messages) {
+        int i = 0;
+        while (i < messages.size() - 1) {
+            JsonObject current = messages.get(i);
+            JsonObject next = messages.get(i + 1);
+            if (KIND_ASSISTANT_MESSAGE.equals(current.get("kind").getAsString())
+                && KIND_ASSISTANT_MESSAGE.equals(next.get("kind").getAsString())) {
+                LOG.warn("Kiro export: merging consecutive AssistantMessages at index " + i);
+                JsonArray mergedContent = current.getAsJsonObject("data").getAsJsonArray(KEY_CONTENT).deepCopy();
+                next.getAsJsonObject("data").getAsJsonArray(KEY_CONTENT)
+                    .forEach(mergedContent::add);
+                current.getAsJsonObject("data").add(KEY_CONTENT, mergedContent);
+                messages.remove(i + 1);
+                // don't advance i — the merged message may still be followed by another AssistantMessage
             } else {
                 i++;
             }

--- a/plugin-core/src/test/java/com/github/catatafishen/ideagentforcopilot/session/exporters/KiroClientExporterTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/ideagentforcopilot/session/exporters/KiroClientExporterTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -385,6 +386,34 @@ class KiroClientExporterTest {
             .getAsJsonObject("data").getAsJsonArray("content")
             .get(0).getAsJsonObject().get("data").getAsString();
         assertEquals("Msg C", text, "Should keep the last Prompt's text");
+    }
+
+    @Test
+    void consecutiveAssistantMessagesMerged() {
+        // Regression test: two v2 assistant messages in a row (no user Prompt between them)
+        // can produce consecutive AssistantMessages that Kiro rejects as "invalid conversation history".
+        // The last part of turn 1 is plain text → AssistantMessage[text].
+        // Turn 2 opens with tool use → AssistantMessage[toolUse] + ToolResults.
+        // Without the fix these would be adjacent AssistantMessages.
+        SessionMessage user = userMessage("Do something");
+        SessionMessage assistant1 = assistantMessage("Starting work...");
+        SessionMessage assistant2 = new SessionMessage(
+            "a2", "assistant",
+            List.of(toolInvocationPart("tc1", "read_file", "{}", "{\"result\":\"ok\"}")),
+            System.currentTimeMillis(), null, null);
+
+        List<JsonObject> kiroMessages = KiroClientExporter.toKiroMessages(
+            List.of(user, assistant1, assistant2));
+
+        List<String> kinds = kiroMessages.stream()
+            .map(m -> m.get("kind").getAsString())
+            .toList();
+        // Consecutive AssistantMessages must be merged — no two AssistantMessages in a row
+        for (int i = 0; i < kinds.size() - 1; i++) {
+            assertFalse(
+                "AssistantMessage".equals(kinds.get(i)) && "AssistantMessage".equals(kinds.get(i + 1)),
+                "Consecutive AssistantMessages at index " + i + ": " + kinds);
+        }
     }
 
     // ── Helper methods ──────────────────────────────────────────────


### PR DESCRIPTION
## Problem

When Kiro panics (e.g. "invalid conversation history received"), the only message shown in the UI was "Prompt failed for Kiro: Transport stopped" — completely unhelpful.

The panic is caused by our plugin generating invalid Kiro conversation history: two consecutive `AssistantMessage` entries when two v2 assistant turns appear back-to-back.

## Changes

### KiroClient.java
- Buffers the last 30 stderr lines per session
- Overrides `tryRecoverPromptException` to detect a Rust panic in stderr and rethrow with the actual message, e.g. `"Kiro crashed: Message: first agent loop request should never fail…"`. The UI surfaces this via the existing error path.
- Cleaned up pre-existing warnings: extracted `KEY_AGENTBRIDGE`/`KEY_STATUS` constants, removed dead `getCommandOptions()`, fixed TODO comment, applied record-pattern instanceof.

### KiroClientExporter.java
- Added `mergeConsecutiveAssistantMessages()` pass (mirrors existing `mergeConsecutivePrompts()`). Two v2 assistant turns in a row produce adjacent `AssistantMessage` entries — the last text segment of turn N plus the first tool-use segment of turn N+1. Kiro rejects this structure. The new pass merges them by concatenating their content arrays.

### KiroClientExporterTest.java
- Added regression test `consecutiveAssistantMessagesMerged` verifying no two `AssistantMessage` kinds appear consecutively in the output.