### PR TITLE
fix: render thought bubbles as markdown; add streaming markdown renderer

### DIFF
--- a/plugin-core/chat-ui/src/ChatController.ts
+++ b/plugin-core/chat-ui/src/ChatController.ts
@@ -223,8 +223,12 @@ const ChatController = {
         this._container()?.scrollIfNeeded();
     },
 
-    collapseThinking(turnId: string, agentId: string): void {
+    collapseThinking(turnId: string, agentId: string, encodedHtml?: string): void {
         const ctx = this._getCtx(turnId, agentId);
+        if (encodedHtml && ctx.thinkingBlock) {
+            const content = (ctx.thinkingBlock as any).contentEl as Element | null;
+            if (content) content.innerHTML = b64(encodedHtml);
+        }
         this._collapseThinkingFor(ctx);
     },
 

--- a/plugin-core/chat-ui/src/chat.css
+++ b/plugin-core/chat-ui/src/chat.css
@@ -318,7 +318,7 @@ working-indicator .working-text {
 }
 
 .thinking-content {
-    white-space: pre-wrap;
+    overflow-wrap: break-word;
     color: var(--think);
 }
 

--- a/plugin-core/chat-ui/src/components/MessageBubble.ts
+++ b/plugin-core/chat-ui/src/components/MessageBubble.ts
@@ -1,4 +1,5 @@
 import {collapseAllChips} from '../helpers';
+import {renderMarkdown} from '../renderMarkdown';
 
 export default class MessageBubble extends HTMLElement {
     static get observedAttributes(): string[] {
@@ -6,7 +7,10 @@ export default class MessageBubble extends HTMLElement {
     }
 
     private _init = false;
-    private _pre: HTMLPreElement | null = null;
+    /** Accumulated raw Markdown text during streaming. */
+    private _rawText = '';
+    /** True while a requestAnimationFrame re-render is pending. */
+    private _renderPending = false;
 
     connectedCallback(): void {
         if (this._init) return;
@@ -21,31 +25,37 @@ export default class MessageBubble extends HTMLElement {
                 collapseAllChips(parent);
             };
         }
-
-        if (this.hasAttribute('streaming')) this._setupStreaming();
     }
 
-    private _setupStreaming(): void {
-        if (!this._pre) {
-            this._pre = document.createElement('pre');
-            this._pre.className = 'streaming';
-            this.innerHTML = '';
-            this.appendChild(this._pre);
+    /**
+     * Append a streaming text token and schedule a Markdown re-render via
+     * requestAnimationFrame.  Batching re-renders to at most one per frame
+     * avoids the O(n²) cost of naïve textContent-replacement while still
+     * providing a smooth, readable streaming experience.
+     */
+    appendStreamingText(text: string): void {
+        this._rawText += text;
+        // Synchronous append keeps textContent up-to-date between frames so
+        // callers can always read text content immediately.
+        this.appendChild(document.createTextNode(text));
+        if (!this._renderPending) {
+            this._renderPending = true;
+            requestAnimationFrame(() => {
+                this._renderPending = false;
+                this.innerHTML = renderMarkdown(this._rawText);
+            });
         }
     }
 
-    appendStreamingText(text: string): void {
-        if (!this._pre) this._setupStreaming();
-        // Append a new text node instead of `textContent +=` to avoid O(n²) behaviour:
-        // textContent= reads all existing content then replaces it, making each token
-        // append O(n) in total accumulated length. With long responses this saturates
-        // the renderer thread and causes the whole JCEF panel to appear frozen.
-        this._pre!.appendChild(document.createTextNode(text));
-    }
-
+    /**
+     * Replace the streaming content with the fully server-rendered HTML.
+     * Called by ChatController.finalizeAgentText once the Kotlin side has
+     * produced the authoritative HTML (with file-path links, git SHA links, etc.).
+     */
     finalize(html: string): void {
         this.removeAttribute('streaming');
-        this._pre = null;
+        this._rawText = '';
+        this._renderPending = false;
         this.innerHTML = html;
     }
 
@@ -53,11 +63,7 @@ export default class MessageBubble extends HTMLElement {
         return this.innerHTML;
     }
 
-    attributeChangedCallback(name: string): void {
-        if (name === 'streaming' && this._init) {
-            if (this.hasAttribute('streaming')) {
-                this._setupStreaming();
-            }
-        }
+    attributeChangedCallback(_name: string): void {
+        // No DOM setup needed — streaming state is tracked via _rawText/_renderPending.
     }
 }

--- a/plugin-core/chat-ui/src/renderMarkdown.ts
+++ b/plugin-core/chat-ui/src/renderMarkdown.ts
@@ -1,0 +1,210 @@
+/**
+ * Lightweight client-side Markdown-to-HTML renderer used during streaming.
+ *
+ * Intentionally mirrors the output of the Kotlin `MarkdownRenderer` for visual
+ * consistency between the streaming phase and the server-finalized HTML that
+ * replaces it once the full response has been received.
+ *
+ * Server-specific features (file-path link resolution, git-SHA detection) are
+ * intentionally omitted here; those are added by the Kotlin finalization step.
+ */
+
+function escHtmlMd(s: string): string {
+    return s
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;');
+}
+
+/**
+ * Format inline Markdown elements: bold, inline-code, links, bare URLs.
+ * Matches the Kotlin MarkdownRenderer.formatInline logic.
+ */
+function formatInline(text: string): string {
+    const result: string[] = [];
+    // Combined regex (same order/priority as Kotlin implementation):
+    //  1. **bold**
+    //  2. `inline code`
+    //  3. [text](url)
+    //  4. bare https?:// URL
+    const PATTERN = /\*\*(.+?)\*\*|`([^`]+)`|\[([^\]]+)]\(([^)]+)\)|(https?:\/\/[^\s<>[\]()]+)/g;
+    let last = 0;
+    let m: RegExpExecArray | null;
+    while ((m = PATTERN.exec(text)) !== null) {
+        if (m.index > last) result.push(escHtmlMd(text.slice(last, m.index)));
+        if (m[1]) {
+            // Bold: **content**
+            result.push('<b>', formatInline(m[1]), '</b>');
+        } else if (m[2]) {
+            // Inline code: `content`
+            result.push('<code>', escHtmlMd(m[2]), '</code>');
+        } else if (m[3]) {
+            // Markdown link: [text](url)
+            const url = escHtmlMd(m[4].trim());
+            const label = escHtmlMd(m[3]);
+            result.push(`<a href='${url}'>${label}</a>`);
+        } else if (m[5]) {
+            // Bare URL
+            const url = escHtmlMd(m[5]);
+            result.push(`<a href='${url}'>${url}</a>`);
+        }
+        last = m.index + m[0].length;
+    }
+    if (last < text.length) result.push(escHtmlMd(text.slice(last)));
+    return result.join('');
+}
+
+/**
+ * Convert a Markdown string to an HTML string.
+ *
+ * Supported constructs (matching Kotlin MarkdownRenderer):
+ *   - Fenced code blocks (``` lang)
+ *   - ATX headings (# – ####), mapped to h2–h5 (# → h2)
+ *   - Horizontal rules (---, ***, ___)
+ *   - Blockquotes (> text)
+ *   - GFM tables (| col | col |)
+ *   - Unordered lists (- item  /  * item)
+ *   - Paragraphs (everything else)
+ *   - Inline: **bold**, `code`, [text](url), bare URLs
+ *
+ * Gracefully handles *incomplete* Markdown that appears mid-stream (open code
+ * blocks, unclosed lists, etc.) by closing all open constructs at the end.
+ */
+export function renderMarkdown(text: string): string {
+    const lines = text.split('\n');
+    const out: string[] = [];
+    let inCode = false;
+    let inList = false;
+    let inTable = false;
+    let firstTableRow = true;
+    let inBlockquote = false;
+
+    const closeListTable = (): void => {
+        if (inList) {
+            out.push('</ul>');
+            inList = false;
+        }
+        if (inTable) {
+            out.push('</table>');
+            inTable = false;
+            firstTableRow = true;
+        }
+    };
+
+    const closeAllInline = (): void => {
+        closeListTable();
+        if (inBlockquote) {
+            out.push('</blockquote>');
+            inBlockquote = false;
+        }
+    };
+
+    for (const line of lines) {
+        const t = line.trim();
+
+        // ── Code fence ─────────────────────────────────────────────
+        if (t.startsWith('```')) {
+            if (inCode) {
+                out.push('</code></pre>');
+                inCode = false;
+            } else {
+                closeAllInline();
+                const lang = t.slice(3).trim().toLowerCase();
+                out.push(lang
+                    ? `<pre><code data-lang="${escHtmlMd(lang)}">`
+                    : '<pre><code>');
+                inCode = true;
+            }
+            continue;
+        }
+
+        if (inCode) {
+            out.push(escHtmlMd(line) + '\n');
+            continue;
+        }
+
+        // ── Blank line → close inline blocks ───────────────────────
+        if (t === '') {
+            closeAllInline();
+            continue;
+        }
+
+        // ── Horizontal rule ─────────────────────────────────────────
+        if (/^(-{3,}|\*{3,}|_{3,})$/.test(t)) {
+            closeAllInline();
+            out.push('<hr>');
+            continue;
+        }
+
+        // ── ATX heading ─────────────────────────────────────────────
+        const hm = /^(#{1,4})\s+(.+)/.exec(t);
+        if (hm) {
+            closeAllInline();
+            const level = hm[1].length + 1; // # → h2 (matches Kotlin renderer)
+            out.push(`<h${level}>${formatInline(hm[2])}</h${level}>`);
+            continue;
+        }
+
+        // ── Blockquote ──────────────────────────────────────────────
+        if (t.startsWith('> ') || t === '>') {
+            closeListTable();
+            if (!inBlockquote) {
+                out.push('<blockquote>');
+                inBlockquote = true;
+            }
+            const content = t.replace(/^>\s?/, '').trim();
+            if (content) out.push(`<p>${formatInline(content)}</p>`);
+            continue;
+        }
+
+        if (inBlockquote) {
+            out.push('</blockquote>');
+            inBlockquote = false;
+        }
+
+        // ── GFM table ───────────────────────────────────────────────
+        if (t.startsWith('|') && t.endsWith('|') && (t.match(/\|/g) ?? []).length >= 3) {
+            closeListTable();
+            if (!t.replaceAll(/[|\-: ]/g, '').trim()) continue; // separator row
+            if (!inTable) {
+                out.push('<table>');
+                inTable = true;
+                firstTableRow = true;
+            }
+            const cells = t.split('|').slice(1, -1).map(c => c.trim());
+            const tag = firstTableRow ? 'th' : 'td';
+            out.push('<tr>' + cells.map(c => `<${tag}>${formatInline(c)}</${tag}>`).join('') + '</tr>');
+            firstTableRow = false;
+            continue;
+        } else if (inTable) {
+            out.push('</table>');
+            inTable = false;
+            firstTableRow = true;
+        }
+
+        // ── Unordered list ──────────────────────────────────────────
+        if (t.startsWith('- ') || t.startsWith('* ')) {
+            if (!inList) {
+                out.push('<ul>');
+                inList = true;
+            }
+            out.push(`<li>${formatInline(t.slice(2))}</li>`);
+            continue;
+        } else if (inList) {
+            out.push('</ul>');
+            inList = false;
+        }
+
+        // ── Paragraph ───────────────────────────────────────────────
+        out.push(`<p>${formatInline(t)}</p>`);
+    }
+
+    // Close any constructs left open by incomplete/streaming content
+    if (inCode) out.push('</code></pre>');
+    if (inList) out.push('</ul>');
+    if (inTable) out.push('</table>');
+    if (inBlockquote) out.push('</blockquote>');
+
+    return out.join('');
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/ChatConsolePanel.kt
@@ -330,8 +330,10 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
 
     override fun collapseThinking() {
         if (currentThinkingData == null) return
+        val raw = currentThinkingData!!.raw.toString()
         currentThinkingData = null
-        executeJs("ChatController.collapseThinking('$currentTurnId','main')")
+        val encoded = b64(markdownToHtml(raw))
+        executeJs("ChatController.collapseThinking('$currentTurnId','main','$encoded')")
     }
 
     override fun appendText(text: String) {
@@ -914,9 +916,7 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
                     metaChips.append("<thinking-chip label='Thought' status='complete' data-chip-for='$id'></thinking-chip>")
                     detailsContent.append(
                         "<thinking-block id='$id' class='thinking-section turn-hidden'><div class='thinking-content'>${
-                            esc(
-                                raw
-                            )
+                            markdownToHtml(raw)
                         }</div></thinking-block>"
                     )
                 }


### PR DESCRIPTION
## What

- **Thought bubbles** now render as markdown. `collapseThinking()` passes raw text through `markdownToHtml()` and sends base64-encoded HTML to `ChatController.collapseThinking()`. The batch restore path (`appendAgentEntry`) is also fixed so historical thinking blocks render correctly on load.

- **TypeScript streaming renderer** (from #36): messages render as markdown in real-time during streaming, then are replaced by Kotlin-rendered HTML (with file/git links) on completion.
  - `renderMarkdown.ts`: lightweight Markdown→HTML parser mirroring the Kotlin `MarkdownRenderer`; handles code fences, headings, lists, tables, blockquotes, inline formatting; gracefully closes open constructs at EOF for incomplete mid-stream content.
  - `MessageBubble.ts`: accumulates raw text in `_rawText`, batch re-renders via `requestAnimationFrame`, then replaces with server-finalised HTML on `finalize()`.

## Why

Thought bubbles showed raw unformatted text. Streaming messages showed a raw `<pre>` block with no formatting until the message was complete.

Closes #36