### PR TITLE
fix: PWA background notifications — include body in push payload, add visibility checks

### DIFF
--- a/plugin-core/chat-ui/src/sw.ts
+++ b/plugin-core/chat-ui/src/sw.ts
@@ -45,11 +45,7 @@ self.addEventListener('fetch', (e) => {
 
 interface PushData {
     title?: string;
-    seq?: number;
-}
-
-interface StateResponse {
-    events?: Array<{ notification?: boolean; seq?: number; body?: string }>;
+    body?: string;
 }
 
 self.addEventListener('push', (e) => {
@@ -59,33 +55,22 @@ self.addEventListener('push', (e) => {
         try {
             const data: PushData = e.data ? JSON.parse(e.data.text()) : {};
             title = data.title || 'AgentBridge';
-            if (data.seq) {
-                const r = await fetch('/state');
-                const st: StateResponse = await r.json();
-                const ev = (st.events || []).slice().reverse()
-                    .find(ev => ev.notification && ev.seq != null && ev.seq >= data.seq!);
-                if (ev?.body) body = ev.body;
-            }
+            body = data.body || '';
         } catch {
-            // ignore parse/fetch errors
+            // ignore parse errors — show notification with defaults
         }
         // showNotification MUST always be called (Chrome enforces userVisibleOnly: true).
-        // Wrap in try-catch so the waitUntil promise always resolves — if it rejects,
-        // Chrome logs a violation and may eventually revoke the push subscription.
         try {
             await self.registration.showNotification(title, {
                 body,
                 icon: '/icon-192.png',
                 badge: '/badge-96.png',
                 tag: 'agentbridge',
-                // Required: alerts the user even when replacing an existing notification
-                // with the same tag (otherwise the replacement is completely silent).
                 renotify: true,
                 requireInteraction: false,
             });
         } catch {
             // Permission may have been revoked between subscription and push delivery.
-            // Nothing we can do — Chrome will show its generic fallback notification.
         }
     })());
 });

--- a/plugin-core/chat-ui/src/web-app.ts
+++ b/plugin-core/chat-ui/src/web-app.ts
@@ -357,8 +357,15 @@ function processEvent(ev: SseEvent, replaying: boolean): void {
 
 // ── SSE ─────────────────────────────────────────────────────────────────────
 
+let currentEs: EventSource | null = null;
+
 function connectSSE(): void {
+    if (currentEs) {
+        currentEs.close();
+        currentEs = null;
+    }
     const es = new EventSource('/events?from=' + lastSeq);
+    currentEs = es;
     es.onopen = () => {
         statusDot.className = agentRunning ? 'running' : 'connected';
         offlineEl.classList.remove('visible');
@@ -376,6 +383,7 @@ function connectSSE(): void {
     };
     es.onerror = () => {
         es.close();
+        if (currentEs === es) currentEs = null;
         statusDot.className = '';
         offlineEl.classList.add('visible');
         if (sseRetry) clearTimeout(sseRetry);
@@ -383,9 +391,22 @@ function connectSSE(): void {
     };
 }
 
+// Reconnect SSE when the page becomes visible again — mobile browsers
+// freeze/kill background connections, so we need to re-establish on wake.
+document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') {
+        if (!currentEs || currentEs.readyState === EventSource.CLOSED) {
+            if (sseRetry) clearTimeout(sseRetry);
+            connectSSE();
+        }
+    }
+});
+
 // ── Notifications ───────────────────────────────────────────────────────────
 
 function showNotification(title: string, body: string): void {
+    // Skip if the page is visible — the user can see the chat directly
+    if (document.visibilityState === 'visible') return;
     if (navigator.serviceWorker?.controller) {
         navigator.serviceWorker.controller.postMessage({
             type: 'SHOW_NOTIFICATION', title, body,

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/services/ChatWebServer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/services/ChatWebServer.java
@@ -461,7 +461,7 @@ public final class ChatWebServer implements Disposable {
         WebPushSender wp = webPush; // read volatile once; null if not yet initialised
         if (wp != null) {
             if (wp.hasSubscriptions()) {
-                String payload = "{\"seq\":" + seq + ",\"title\":" + GSON.toJson(title) + "}";
+                String payload = "{\"title\":" + GSON.toJson(title) + ",\"body\":" + GSON.toJson(body) + "}";
                 wp.sendToAll(payload);
             } else {
                 LOG.debug("[Chat] Web Push configured but no subscriptions registered for: " + title);


### PR DESCRIPTION
## Problem

PWA notifications only work when the app is in the foreground. When the user switches away (locks phone, opens another app), no notifications are delivered for turn completion or ask-user events.

## Root Cause

The Web Push infrastructure was fully implemented, but the service worker's `push` handler tried to `fetch('/state')` from the local LAN server to get the notification body. When the phone isn't on the same network as the server (or the connection is flaky), this fetch fails silently — and the notification either shows with an empty body or doesn't appear at all.

Additionally, SSE connections freeze when mobile browsers background a tab, and there was no mechanism to reconnect on wake.

## Fix

### 1. Include body in push payload (server-side)
`ChatWebServer.pushNotification()` now sends `{title, body}` in the Web Push payload instead of `{seq, title}`. The SW no longer needs to fetch the body from the server — it's right there in the push message.

### 2. Visibility check on SSE notifications
`showNotification()` in `web-app.ts` now checks `document.visibilityState` and skips the notification when the page is visible (the user can see the chat directly).

### 3. SSE reconnect on visibility change
A `visibilitychange` listener reconnects the EventSource when the page becomes visible again. Mobile browsers freeze/kill background connections, so on wake the SSE may be in a CLOSED state with no retry scheduled.

### 4. Simplified SW push handler
Removed the `/state` fetch and `StateResponse` interface — the body comes directly from the push payload now.

## Files Changed
- `ChatWebServer.java` — include `body` in push payload
- `sw.ts` — simplified push handler, removed `/state` fetch
- `web-app.ts` — visibility check, SSE reconnect on wake

Closes #79