### PR TITLE
fix: revert sending notification body through push service (security)

### DIFF
--- a/plugin-core/chat-ui/src/sw.ts
+++ b/plugin-core/chat-ui/src/sw.ts
@@ -43,9 +43,19 @@ self.addEventListener('fetch', (e) => {
 
 // ── Web Push ────────────────────────────────────────────────────────────────
 
+// SECURITY: The push payload contains only {seq, title} — never the notification
+// body. Push payloads travel through third-party push services (Google FCM, Apple
+// APNs, Mozilla autopush) and may contain sensitive information (code snippets,
+// file paths, error messages). We fetch the body from the local server via /state,
+// keeping sensitive content on the local network only.
+
 interface PushData {
     title?: string;
-    body?: string;
+    seq?: number;
+}
+
+interface StateResponse {
+    events?: Array<{ notification?: boolean; seq?: number; body?: string }>;
 }
 
 self.addEventListener('push', (e) => {
@@ -55,22 +65,33 @@ self.addEventListener('push', (e) => {
         try {
             const data: PushData = e.data ? JSON.parse(e.data.text()) : {};
             title = data.title || 'AgentBridge';
-            body = data.body || '';
+            if (data.seq) {
+                const r = await fetch('/state');
+                const st: StateResponse = await r.json();
+                const ev = (st.events || []).slice().reverse()
+                    .find(ev => ev.notification && ev.seq != null && ev.seq >= data.seq!);
+                if (ev?.body) body = ev.body;
+            }
         } catch {
-            // ignore parse errors — show notification with defaults
+            // ignore parse/fetch errors — show notification with defaults
         }
         // showNotification MUST always be called (Chrome enforces userVisibleOnly: true).
+        // Wrap in try-catch so the waitUntil promise always resolves — if it rejects,
+        // Chrome logs a violation and may eventually revoke the push subscription.
         try {
             await self.registration.showNotification(title, {
                 body,
                 icon: '/icon-192.png',
                 badge: '/badge-96.png',
                 tag: 'agentbridge',
+                // Required: alerts the user even when replacing an existing notification
+                // with the same tag (otherwise the replacement is completely silent).
                 renotify: true,
                 requireInteraction: false,
             });
         } catch {
             // Permission may have been revoked between subscription and push delivery.
+            // Nothing we can do — Chrome will show its generic fallback notification.
         }
     })());
 });

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/services/ChatWebServer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/services/ChatWebServer.java
@@ -447,6 +447,13 @@ public final class ChatWebServer implements Disposable {
     /**
      * Pushes a notification to live SSE clients and, if any Web Push subscriptions are registered,
      * sends a Web Push to devices that may have the browser closed.
+     *
+     * <p><b>Security:</b> The Web Push payload intentionally contains only the event sequence
+     * number and title — never the notification body. Push payloads travel through third-party
+     * push services (Google FCM, Apple APNs, Mozilla autopush) and may contain sensitive
+     * information (code snippets, file paths, error messages). The service worker fetches the
+     * actual body from the local server via {@code /state} after receiving the push, keeping
+     * sensitive content on the local network only.</p>
      */
     public void pushNotification(@NotNull String title, @NotNull String body) {
         if (!running) return;
@@ -457,11 +464,12 @@ public final class ChatWebServer implements Disposable {
         String json = "{\"seq\":" + seq + ",\"notification\":true,\"title\":"
             + GSON.toJson(title) + ",\"body\":" + GSON.toJson(body) + "}";
         broadcast(json);
-        // Also send via Web Push for devices with the browser closed
+        // Also send via Web Push for devices with the browser closed.
+        // Only seq + title — never body (see Javadoc above).
         WebPushSender wp = webPush; // read volatile once; null if not yet initialised
         if (wp != null) {
             if (wp.hasSubscriptions()) {
-                String payload = "{\"title\":" + GSON.toJson(title) + ",\"body\":" + GSON.toJson(body) + "}";
+                String payload = "{\"seq\":" + seq + ",\"title\":" + GSON.toJson(title) + "}";
                 wp.sendToAll(payload);
             } else {
                 LOG.debug("[Chat] Web Push configured but no subscriptions registered for: " + title);


### PR DESCRIPTION
## Problem

PR #80 changed the Web Push payload to include the notification body directly:
```json
{"title": "Turn complete", "body": "Here is the code snippet..."}
```

This is a **security risk**: push payloads travel through third-party push services (Google FCM, Apple APNs, Mozilla autopush) and may contain sensitive information — code snippets, file paths, error messages, etc. We explicitly do not want to send content through third parties.

## Fix

Restore the original design where the push payload contains only `{seq, title}`:
```json
{"seq": 42, "title": "Turn complete"}
```

The service worker fetches the actual body from the local server via `/state` after receiving the push, keeping sensitive content on the local network only.

## What's kept from PR #80

The SSE reconnect-on-visibility-change and visibility check improvements are **retained** — those are correct fixes for mobile browsers freezing background connections.

## Documentation

Added security rationale in both:
- `ChatWebServer.java` — Javadoc on `pushNotification()`
- `sw.ts` — comment block above the Web Push section

This ensures the design decision is documented and won't be accidentally reverted.