### PR TITLE
feat: auto-cleanup agent-created scratch files and tool tabs

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/psi/tools/Tool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/psi/tools/Tool.java
@@ -2,6 +2,7 @@ package com.github.catatafishen.ideagentforcopilot.psi.tools;
 
 import com.github.catatafishen.ideagentforcopilot.psi.EdtUtil;
 import com.github.catatafishen.ideagentforcopilot.psi.ToolUtils;
+import com.github.catatafishen.ideagentforcopilot.services.AgentTabTracker;
 import com.github.catatafishen.ideagentforcopilot.services.ToolDefinition;
 import com.google.gson.JsonObject;
 import com.intellij.execution.RunContentExecutor;
@@ -160,6 +161,8 @@ public abstract class Tool implements ToolDefinition {
                 processHandler.startNotify();
             }
         });
+
+        AgentTabTracker.getInstance(project).trackTab("Run", title);
 
         try {
             int exitCode = exitFuture.get(timeoutSec, TimeUnit.SECONDS);

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/psi/tools/editor/CreateScratchFileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/psi/tools/editor/CreateScratchFileTool.java
@@ -2,6 +2,7 @@ package com.github.catatafishen.ideagentforcopilot.psi.tools.editor;
 
 import com.github.catatafishen.ideagentforcopilot.psi.EdtUtil;
 import com.github.catatafishen.ideagentforcopilot.psi.ToolLayerSettings;
+import com.github.catatafishen.ideagentforcopilot.services.AgentScratchTracker;
 import com.github.catatafishen.ideagentforcopilot.psi.tools.file.FileTool;
 import com.github.catatafishen.ideagentforcopilot.ui.renderers.ScratchFileRenderer;
 import com.google.gson.JsonObject;
@@ -45,7 +46,7 @@ public final class CreateScratchFileTool extends EditorTool {
         return "Create a temporary scratch file with the given name and content";
     }
 
-    
+
 
     @Override
     public @NotNull Kind kind() {
@@ -122,6 +123,7 @@ public final class CreateScratchFileTool extends EditorTool {
             if (resultFile[0] != null) {
                 boolean focusScratch = ToolLayerSettings.getInstance(project).getFollowAgentFiles();
                 FileEditorManager.getInstance(project).openFile(resultFile[0], focusScratch);
+                AgentScratchTracker.getInstance(project).trackScratchFile(resultFile[0].getPath());
             }
         } catch (Exception e) {
             LOG.warn("Failed in EDT execution", e);

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/psi/tools/navigation/SearchTextTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/psi/tools/navigation/SearchTextTool.java
@@ -2,6 +2,7 @@ package com.github.catatafishen.ideagentforcopilot.psi.tools.navigation;
 
 import com.github.catatafishen.ideagentforcopilot.psi.ToolUtils;
 import com.github.catatafishen.ideagentforcopilot.services.ActiveAgentManager;
+import com.github.catatafishen.ideagentforcopilot.services.AgentTabTracker;
 import com.github.catatafishen.ideagentforcopilot.ui.renderers.SearchResultRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.application.ApplicationManager;
@@ -168,8 +169,10 @@ public final class SearchTextTool extends NavigationTool {
                 .toArray(Usage[]::new);
 
             UsageViewPresentation pres = new UsageViewPresentation();
-            pres.setTabText("Search: " + query);
+            String tabText = "Search: " + query;
+            pres.setTabText(tabText);
             UsageViewManager.getInstance(project).showUsages(UsageTarget.EMPTY_ARRAY, usages, pres);
+            AgentTabTracker.getInstance(project).trackTab("Find", tabText);
         });
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/psi/tools/terminal/TerminalTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/psi/tools/terminal/TerminalTool.java
@@ -2,6 +2,7 @@ package com.github.catatafishen.ideagentforcopilot.psi.tools.terminal;
 
 import com.github.catatafishen.ideagentforcopilot.psi.ToolUtils;
 import com.github.catatafishen.ideagentforcopilot.psi.tools.Tool;
+import com.github.catatafishen.ideagentforcopilot.services.AgentTabTracker;
 import com.github.catatafishen.ideagentforcopilot.services.ToolRegistry;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -104,6 +105,7 @@ public abstract class TerminalTool extends Tool {
         var createSession = managerClass.getMethod("createNewSession",
             String.class, String.class, List.class, boolean.class, boolean.class);
         Object widget = createSession.invoke(manager, project.getBasePath(), title, shellCommand, true, true);
+        AgentTabTracker.getInstance(project).trackTab(TERMINAL_TOOL_WINDOW_ID, title);
         return new TerminalWidgetResult(widget, title + " (new)");
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/services/AgentScratchTracker.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/services/AgentScratchTracker.java
@@ -1,0 +1,120 @@
+package com.github.catatafishen.ideagentforcopilot.services;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tracks agent-created scratch files and deletes expired ones.
+ *
+ * <p>Persists tracked files across IDE restarts so that cleanup can happen
+ * even after the IDE is restarted.</p>
+ */
+@Service(Service.Level.PROJECT)
+@State(name = "AgentScratchTracker", storages = @Storage("ideAgentScratchTracker.xml"))
+public final class AgentScratchTracker implements PersistentStateComponent<AgentScratchTracker.State>, Disposable {
+
+    private static final Logger LOG = Logger.getInstance(AgentScratchTracker.class);
+    private static final long MILLIS_PER_HOUR = 3_600_000L;
+
+    public static final class State {
+        /**
+         * Map of scratch file path → creation epoch millis.
+         */
+        public Map<String, Long> trackedFiles = new LinkedHashMap<>();
+    }
+
+    private final Project project;
+    private State state = new State();
+
+    public AgentScratchTracker(@NotNull Project project) {
+        this.project = project;
+    }
+
+    public static @NotNull AgentScratchTracker getInstance(@NotNull Project project) {
+        return project.getService(AgentScratchTracker.class);
+    }
+
+    @Override
+    public @NotNull State getState() {
+        return state;
+    }
+
+    @Override
+    public void loadState(@NotNull State loaded) {
+        this.state = loaded;
+    }
+
+    /**
+     * Registers a scratch file as agent-created.
+     */
+    public void trackScratchFile(@NotNull String path) {
+        state.trackedFiles.put(path, System.currentTimeMillis());
+    }
+
+    /**
+     * Deletes tracked scratch files older than the configured retention period.
+     * Files that no longer exist on disk are silently removed from tracking.
+     */
+    public void cleanupExpired() {
+        int retentionHours = CleanupSettings.getInstance(project).getScratchRetentionHours();
+        if (retentionHours <= 0) return;
+
+        long cutoffMillis = System.currentTimeMillis() - (retentionHours * MILLIS_PER_HOUR);
+        List<String> toRemove = new ArrayList<>();
+
+        for (Map.Entry<String, Long> entry : state.trackedFiles.entrySet()) {
+            if (entry.getValue() < cutoffMillis) {
+                toRemove.add(entry.getKey());
+            }
+        }
+
+        for (String path : toRemove) {
+            state.trackedFiles.remove(path);
+            deleteScratchFile(path);
+        }
+    }
+
+    private void deleteScratchFile(String path) {
+        ApplicationManager.getApplication().invokeLater(() -> {
+            VirtualFile file = LocalFileSystem.getInstance().findFileByPath(path);
+            if (file == null || !file.exists()) return;
+            try {
+                WriteAction.compute(() -> {
+                    file.delete(this);
+                    return null;
+                });
+                LOG.info("Deleted expired scratch file: " + path);
+            } catch (IOException e) {
+                LOG.warn("Failed to delete scratch file: " + path, e);
+            }
+        });
+    }
+
+    /**
+     * Returns the number of currently tracked scratch files.
+     */
+    public int getTrackedCount() {
+        return state.trackedFiles.size();
+    }
+
+    @Override
+    public void dispose() {
+        // State is persisted by the platform; nothing to clean up
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/services/AgentTabTracker.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/services/AgentTabTracker.java
@@ -1,0 +1,119 @@
+package com.github.catatafishen.ideagentforcopilot.services;
+
+import com.intellij.execution.ui.RunContentManager;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.ui.RunContentDescriptor;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentManager;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tracks tool window tabs created by the agent and closes them at turn boundaries.
+ *
+ * <p>Tools call {@link #trackTab(String, String)} when they create a tab.
+ * At the start of a new turn, {@link #closeTrackedTabs()} closes all tracked
+ * tabs from previous turns, respecting {@link CleanupSettings} for terminal
+ * and running-process behavior.</p>
+ */
+public final class AgentTabTracker implements Disposable {
+
+    private static final Logger LOG = Logger.getInstance(AgentTabTracker.class);
+
+    private record TabRef(String toolWindowId, String tabName) {
+    }
+
+    private final Project project;
+    private final List<TabRef> trackedTabs = new ArrayList<>();
+
+    public AgentTabTracker(@NotNull Project project) {
+        this.project = project;
+    }
+
+    public static @NotNull AgentTabTracker getInstance(@NotNull Project project) {
+        return project.getService(AgentTabTracker.class);
+    }
+
+    /**
+     * Registers a tab as agent-created. Call this after the tool creates the tab.
+     */
+    public synchronized void trackTab(@NotNull String toolWindowId, @NotNull String tabName) {
+        trackedTabs.add(new TabRef(toolWindowId, tabName));
+    }
+
+    /**
+     * Closes all tracked tabs from previous turns. Must be called at the start
+     * of a new turn. Respects cleanup settings.
+     */
+    public void closeTrackedTabs() {
+        CleanupSettings settings = CleanupSettings.getInstance(project);
+        if (!settings.isAutoCloseAgentTabs()) return;
+
+        List<TabRef> toClose;
+        synchronized (this) {
+            toClose = new ArrayList<>(trackedTabs);
+            trackedTabs.clear();
+        }
+
+        if (toClose.isEmpty()) return;
+
+        boolean closeRunningTerminals = settings.isAutoCloseRunningTerminals();
+        ApplicationManager.getApplication().invokeLater(() -> {
+            for (TabRef ref : toClose) {
+                try {
+                    closeTab(ref, closeRunningTerminals);
+                } catch (Exception e) {
+                    LOG.debug("Failed to close tab " + ref.toolWindowId + "/" + ref.tabName, e);
+                }
+            }
+        });
+    }
+
+    private void closeTab(TabRef ref, boolean closeRunningTerminals) {
+        if ("Terminal".equals(ref.toolWindowId) && !closeRunningTerminals) {
+            return;
+        }
+
+        if ("Run".equals(ref.toolWindowId) && isRunProcessStillActive(ref.tabName)) {
+            return;
+        }
+
+        ToolWindow tw = ToolWindowManager.getInstance(project).getToolWindow(ref.toolWindowId);
+        if (tw == null) return;
+
+        ContentManager cm = tw.getContentManager();
+        for (Content content : cm.getContents()) {
+            String displayName = content.getDisplayName();
+            if (displayName != null && displayName.equals(ref.tabName)) {
+                cm.removeContent(content, true);
+                LOG.debug("Closed agent tab: " + ref.toolWindowId + "/" + ref.tabName);
+                break;
+            }
+        }
+    }
+
+    private boolean isRunProcessStillActive(String tabName) {
+        for (RunContentDescriptor desc : RunContentManager.getInstance(project).getAllDescriptors()) {
+            if (tabName.equals(desc.getDisplayName())) {
+                ProcessHandler handler = desc.getProcessHandler();
+                return handler != null && !handler.isProcessTerminated();
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void dispose() {
+        synchronized (this) {
+            trackedTabs.clear();
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/services/CleanupSettings.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/services/CleanupSettings.java
@@ -1,0 +1,74 @@
+package com.github.catatafishen.ideagentforcopilot.services;
+
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Persistent settings controlling automatic cleanup of agent-created resources.
+ */
+@Service(Service.Level.PROJECT)
+@State(name = "CleanupSettings", storages = @Storage("ideAgentCleanup.xml"))
+public final class CleanupSettings implements PersistentStateComponent<CleanupSettings.State> {
+
+    public static final class State {
+        /**
+         * Hours to retain agent-created scratch files. 0 = keep forever.
+         */
+        public int scratchRetentionHours = 24;
+
+        /**
+         * If true, close agent-created tool window tabs when a new turn starts.
+         */
+        public boolean autoCloseAgentTabs = true;
+
+        /**
+         * If true, also close terminal tabs that may still be running.
+         * Only applies when {@link #autoCloseAgentTabs} is true.
+         */
+        public boolean autoCloseRunningTerminals = false;
+    }
+
+    private State state = new State();
+
+    public static @NotNull CleanupSettings getInstance(@NotNull Project project) {
+        return project.getService(CleanupSettings.class);
+    }
+
+    @Override
+    public @NotNull State getState() {
+        return state;
+    }
+
+    @Override
+    public void loadState(@NotNull State loaded) {
+        this.state = loaded;
+    }
+
+    public int getScratchRetentionHours() {
+        return state.scratchRetentionHours;
+    }
+
+    public void setScratchRetentionHours(int hours) {
+        state.scratchRetentionHours = Math.max(0, hours);
+    }
+
+    public boolean isAutoCloseAgentTabs() {
+        return state.autoCloseAgentTabs;
+    }
+
+    public void setAutoCloseAgentTabs(boolean value) {
+        state.autoCloseAgentTabs = value;
+    }
+
+    public boolean isAutoCloseRunningTerminals() {
+        return state.autoCloseRunningTerminals;
+    }
+
+    public void setAutoCloseRunningTerminals(boolean value) {
+        state.autoCloseRunningTerminals = value;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/settings/CleanupConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/settings/CleanupConfigurable.java
@@ -1,0 +1,83 @@
+package com.github.catatafishen.ideagentforcopilot.settings;
+
+import com.github.catatafishen.ideagentforcopilot.services.CleanupSettings;
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.ui.FormBuilder;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+/**
+ * Settings page for agent resource cleanup (scratch files and tool tabs).
+ */
+public final class CleanupConfigurable implements Configurable {
+
+    private final Project project;
+    private JSpinner scratchRetentionSpinner;
+    private JCheckBox autoCloseTabsCheckbox;
+    private JCheckBox closeRunningTerminalsCheckbox;
+
+    public CleanupConfigurable(@NotNull Project project) {
+        this.project = project;
+    }
+
+    @Nls(capitalization = Nls.Capitalization.Title)
+    @Override
+    public String getDisplayName() {
+        return "Cleanup";
+    }
+
+    @Override
+    public @Nullable JComponent createComponent() {
+        CleanupSettings settings = CleanupSettings.getInstance(project);
+
+        scratchRetentionSpinner = new JSpinner(new SpinnerNumberModel(
+            settings.getScratchRetentionHours(), 0, 8760, 1
+        ));
+
+        autoCloseTabsCheckbox = new JCheckBox("Auto-close agent tabs between turns",
+            settings.isAutoCloseAgentTabs());
+
+        closeRunningTerminalsCheckbox = new JCheckBox("Also close running terminal tabs",
+            settings.isAutoCloseRunningTerminals());
+        closeRunningTerminalsCheckbox.setEnabled(settings.isAutoCloseAgentTabs());
+
+        autoCloseTabsCheckbox.addChangeListener(e ->
+            closeRunningTerminalsCheckbox.setEnabled(autoCloseTabsCheckbox.isSelected()));
+
+        return FormBuilder.createFormBuilder()
+            .addLabeledComponent("Scratch file retention (hours, 0 = forever):", scratchRetentionSpinner)
+            .addComponent(autoCloseTabsCheckbox)
+            .addComponent(closeRunningTerminalsCheckbox)
+            .addComponentFillVertically(new JPanel(), 0)
+            .getPanel();
+    }
+
+    @Override
+    public boolean isModified() {
+        CleanupSettings settings = CleanupSettings.getInstance(project);
+        return (int) scratchRetentionSpinner.getValue() != settings.getScratchRetentionHours()
+            || autoCloseTabsCheckbox.isSelected() != settings.isAutoCloseAgentTabs()
+            || closeRunningTerminalsCheckbox.isSelected() != settings.isAutoCloseRunningTerminals();
+    }
+
+    @Override
+    public void apply() {
+        CleanupSettings settings = CleanupSettings.getInstance(project);
+        settings.setScratchRetentionHours((int) scratchRetentionSpinner.getValue());
+        settings.setAutoCloseAgentTabs(autoCloseTabsCheckbox.isSelected());
+        settings.setAutoCloseRunningTerminals(closeRunningTerminalsCheckbox.isSelected());
+    }
+
+    @Override
+    public void reset() {
+        CleanupSettings settings = CleanupSettings.getInstance(project);
+        scratchRetentionSpinner.setValue(settings.getScratchRetentionHours());
+        autoCloseTabsCheckbox.setSelected(settings.isAutoCloseAgentTabs());
+        closeRunningTerminalsCheckbox.setSelected(settings.isAutoCloseRunningTerminals());
+        closeRunningTerminalsCheckbox.setEnabled(settings.isAutoCloseAgentTabs());
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/PromptOrchestrator.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/ui/PromptOrchestrator.kt
@@ -10,6 +10,8 @@ import com.github.catatafishen.ideagentforcopilot.bridge.PermissionResponse
 import com.github.catatafishen.ideagentforcopilot.psi.CodeChangeTracker
 import com.github.catatafishen.ideagentforcopilot.psi.PsiBridgeService
 import com.github.catatafishen.ideagentforcopilot.services.ActiveAgentManager
+import com.github.catatafishen.ideagentforcopilot.services.AgentScratchTracker
+import com.github.catatafishen.ideagentforcopilot.services.AgentTabTracker
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
@@ -122,6 +124,10 @@ class PromptOrchestrator(
 
     private fun executePrompt(prompt: String, contextItems: List<ContextItemData>, selectedModelId: String) {
         try {
+            // Clean up agent resources from previous turns before starting a new one
+            AgentTabTracker.getInstance(project).closeTrackedTabs()
+            AgentScratchTracker.getInstance(project).cleanupExpired()
+
             if (isBlockedByAuth()) return
 
             val pending = pendingBanner

--- a/plugin-core/src/main/resources/META-INF/plugin.xml
+++ b/plugin-core/src/main/resources/META-INF/plugin.xml
@@ -333,6 +333,14 @@
     <projectService
       serviceImplementation="com.github.catatafishen.ideagentforcopilot.session.v2.SessionStoreV2"/>
 
+    <!-- Agent resource cleanup services -->
+    <projectService
+      serviceImplementation="com.github.catatafishen.ideagentforcopilot.services.CleanupSettings"/>
+    <projectService
+      serviceImplementation="com.github.catatafishen.ideagentforcopilot.services.AgentTabTracker"/>
+    <projectService
+      serviceImplementation="com.github.catatafishen.ideagentforcopilot.services.AgentScratchTracker"/>
+
     <!-- Settings: AgentBridge (root) -->
     <projectConfigurable
       parentId="tools"
@@ -364,6 +372,12 @@
       instance="com.github.catatafishen.ideagentforcopilot.settings.ChatHistoryConfigurable"
       id="com.github.catatafishen.ideagentforcopilot.chatHistory"
       displayName="Chat History"/>
+
+    <projectConfigurable
+      parentId="com.github.catatafishen.ideagentforcopilot.settings"
+      instance="com.github.catatafishen.ideagentforcopilot.settings.CleanupConfigurable"
+      id="com.github.catatafishen.ideagentforcopilot.cleanup"
+      displayName="Cleanup"/>
 
     <!-- ── MCP section ── -->
     <projectConfigurable


### PR DESCRIPTION
## Problem

The plugin creates many scratch files and tool tabs during agent operation. Over time these accumulate and clutter the IDE. (#78)

## Solution

### Scratch file cleanup
- `CreateScratchFileTool` tracks each created file (path + timestamp) in `AgentScratchTracker` (persisted in `ideAgentScratchTracker.xml`)
- At each new turn start, files older than the retention period are deleted
- Default retention: 24 hours, configurable (0 = keep forever)

### Tool tab cleanup
- Tools that create tabs register them in `AgentTabTracker`:
  - `run_command` → Run panel tabs
  - `run_in_terminal` → Terminal tabs
  - `search_text` → Find/Usages tabs
- At each new turn start, all tracked tabs from previous turns are closed
- Terminal tabs are **skipped by default** (configurable)
- Run tabs with still-running processes are **never closed**

### Settings (Settings → AgentBridge → Cleanup)
| Setting | Default | Description |
|---------|---------|-------------|
| Scratch file retention (hours) | 24 | 0 = keep forever |
| Auto-close agent tabs between turns | ✅ | Closes Run/Find tabs at turn start |
| Also close running terminal tabs | ❌ | Terminal tabs skipped by default |

## New files
- `CleanupSettings.java` — `PersistentStateComponent` for cleanup config
- `AgentTabTracker.java` — tracks/closes agent tool window tabs
- `AgentScratchTracker.java` — tracks/deletes expired scratch files
- `CleanupConfigurable.java` — settings UI panel

## Modified files
- `Tool.java` — tracks Run tabs in `executeInRunPanel()`
- `TerminalTool.java` — tracks Terminal tabs on creation
- `SearchTextTool.java` — tracks Find tabs
- `CreateScratchFileTool.java` — tracks scratch files on creation
- `PromptOrchestrator.kt` — calls cleanup at turn start
- `plugin.xml` — registers 3 services + 1 configurable

Closes #78