### PR TITLE
feat: MCP session management, recovery, and lifecycle (from PR #95)

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpClient.java
@@ -317,7 +317,7 @@ public final class CustomMcpClient implements AutoCloseable {
             // Double-check: another thread may have already re-initialized while we waited for the lock.
             // Only re-initialize if the current session is still the expired one (or has been cleared).
             // If a different (newer) session is active, skip re-init and fall through to retry with it.
-            if (expiredSessionId.equals(sessionId) || sessionId == null) {
+            if (sessionId == null || expiredSessionId.equals(sessionId)) {
                 sessionId = null;
                 initialize();
             }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpClient.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonParser;
 import com.intellij.openapi.diagnostic.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,22 +19,41 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * HTTP JSON-RPC 2.0 MCP client for communicating with an external MCP server
  * using the streamable HTTP transport (single POST endpoint).
- * All connections are short-lived (created and closed per request).
+ * <p>
+ * All HTTP connections are short-lived (created and closed per request).
+ * Session state is maintained via the {@code Mcp-Session-Id} header as defined by the
+ * MCP Streamable HTTP transport specification. Servers that do not return a session ID
+ * during initialization are treated as stateless — no session header is ever sent.
+ * <p>
+ * Thread-safe: concurrent {@link #callTool} invocations are supported. Session recovery
+ * (on HTTP 404) uses a {@link ReentrantLock} to ensure only one thread re-initializes.
  */
-public final class CustomMcpClient {
+public final class CustomMcpClient implements AutoCloseable {
 
     private static final Logger LOG = Logger.getInstance(CustomMcpClient.class);
     private static final Gson GSON = new Gson();
     private static final int CONNECT_TIMEOUT_MS = 5_000;
     private static final int READ_TIMEOUT_MS = 60_000;
+    private static final int CLOSE_TIMEOUT_MS = 2_000;
     private static final String PROTOCOL_VERSION = "2025-11-25";
+    static final String SESSION_HEADER = "Mcp-Session-Id";
 
     private final String url;
     private final AtomicInteger requestId = new AtomicInteger(1);
+
+    /**
+     * Session ID received from the server during initialization.
+     * Volatile because it is read by concurrent {@link #callTool} threads
+     * and written under {@link #reinitLock} during session recovery.
+     */
+    private volatile String sessionId;
+
+    private final ReentrantLock reinitLock = new ReentrantLock();
 
     public CustomMcpClient(@NotNull String url) {
         this.url = url;
@@ -50,8 +70,22 @@ public final class CustomMcpClient {
     }
 
     /**
+     * Returns the current session ID, or {@code null} if no session is active.
+     * Visible for testing only.
+     */
+    @VisibleForTesting
+    @Nullable
+    String getSessionId() {
+        return sessionId;
+    }
+
+    /**
      * Sends the MCP {@code initialize} handshake.
      * Must be called once before {@link #listTools()}.
+     * <p>
+     * Per spec, the initialize request is sent <b>without</b> a session ID header.
+     * If the server returns an {@code Mcp-Session-Id} response header, it is captured
+     * and included in all subsequent requests.
      *
      * @throws IOException if the server is unreachable or returns an error response
      */
@@ -66,7 +100,8 @@ public final class CustomMcpClient {
         clientInfo.addProperty("version", "1.0");
         params.add("clientInfo", clientInfo);
 
-        JsonObject response = sendRequest("initialize", params);
+        // Per spec: InitializeRequest MUST NOT include a session ID
+        JsonObject response = sendRequestInternal("initialize", params, false, false);
         if (response.has("error")) {
             throw new IOException("MCP initialize failed: " + errorMessage(response));
         }
@@ -134,6 +169,149 @@ public final class CustomMcpClient {
     }
 
     /**
+     * Explicitly terminates the MCP session by sending an HTTP DELETE to the server endpoint.
+     * <p>
+     * Per spec, clients <b>SHOULD</b> send DELETE with the {@code Mcp-Session-Id} header when
+     * they no longer need the session. The server may respond with 405 (Method Not Allowed) if
+     * it does not support client-initiated session termination — this is expected and silenced.
+     * <p>
+     * Safe to call multiple times; no-op if no session is active.
+     */
+    @Override
+    public void close() {
+        String sid = sessionId;
+        if (sid == null) return;
+        sessionId = null;
+
+        try {
+            HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
+            try {
+                conn.setRequestMethod("DELETE");
+                conn.setConnectTimeout(CLOSE_TIMEOUT_MS);
+                conn.setReadTimeout(CLOSE_TIMEOUT_MS);
+                conn.setRequestProperty(SESSION_HEADER, sid);
+                conn.getResponseCode();
+            } finally {
+                conn.disconnect();
+            }
+        } catch (Exception e) {
+            LOG.debug("Session termination for " + url + " failed (expected if server doesn't support DELETE): "
+                + e.getMessage());
+        }
+    }
+
+    /**
+     * Public entry point for non-initialize requests. Includes the session header
+     * when a session is active and supports automatic session recovery on HTTP 404.
+     */
+    @NotNull
+    private JsonObject sendRequest(@NotNull String method, @NotNull JsonObject params) throws IOException {
+        return sendRequestInternal(method, params, true, false);
+    }
+
+    /**
+     * Sends a JSON-RPC 2.0 POST request and returns the parsed response object.
+     * Handles optional SSE envelope ({@code data: …}) transparently.
+     *
+     * @param method               the MCP method name (e.g. "tools/list", "tools/call")
+     * @param params               the JSON-RPC params object
+     * @param includeSessionHeader whether to include the Mcp-Session-Id header (false for initialize)
+     * @param isRetry              true if this is a retry after session recovery — prevents infinite loops
+     * @return the parsed JSON-RPC response object
+     * @throws IOException on communication or unrecoverable protocol error
+     */
+    @NotNull
+    private JsonObject sendRequestInternal(
+        @NotNull String method,
+        @NotNull JsonObject params,
+        boolean includeSessionHeader,
+        boolean isRetry
+    ) throws IOException {
+        JsonObject request = new JsonObject();
+        request.addProperty("jsonrpc", "2.0");
+        request.addProperty("id", requestId.getAndIncrement());
+        request.addProperty("method", method);
+        request.add("params", params);
+
+        URI uri = URI.create(url);
+        String scheme = uri.getScheme();
+        if (scheme == null || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))) {
+            throw new IOException("Unsupported URL scheme: " + scheme
+                + " (only http and https are supported). URL: " + url);
+        }
+
+        byte[] bodyBytes = GSON.toJson(request).getBytes(StandardCharsets.UTF_8);
+        HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
+        try {
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(READ_TIMEOUT_MS);
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("Accept", "application/json, text/event-stream");
+
+            if (includeSessionHeader && sessionId != null) {
+                conn.setRequestProperty(SESSION_HEADER, sessionId);
+            }
+
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(bodyBytes);
+            }
+
+            int status = conn.getResponseCode();
+
+            // Capture session ID from response headers (may be set on any response, primarily initialize)
+            String newSessionId = conn.getHeaderField(SESSION_HEADER);
+            if (newSessionId != null && !newSessionId.isBlank()) {
+                sessionId = newSessionId;
+            }
+
+            // Session expired — server terminated the session (MCP spec: MUST return 404)
+            if (status == 404 && !isRetry && includeSessionHeader) {
+                return handleSessionExpiry(method, params);
+            }
+
+            if (status == 202) {
+                return new JsonObject();
+            }
+
+            InputStream stream = status >= 400 ? conn.getErrorStream() : conn.getInputStream();
+            if (stream == null) return new JsonObject();
+
+            String responseBody;
+            try (stream) {
+                responseBody = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            }
+
+            return JsonParser.parseString(stripSseEnvelope(responseBody)).getAsJsonObject();
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    /**
+     * Handles session expiry by re-initializing and retrying the original request.
+     * Uses a {@link ReentrantLock} so that concurrent threads encountering 404 do not
+     * all attempt to re-initialize — only the first one does, and others wait and reuse
+     * the new session.
+     */
+    @NotNull
+    private JsonObject handleSessionExpiry(@NotNull String method, @NotNull JsonObject params) throws IOException {
+        LOG.info("Session expired on " + url + " (HTTP 404), re-initializing");
+        reinitLock.lock();
+        try {
+            // Double-check: another thread may have already re-initialized while we waited for the lock
+            if (sessionId != null) {
+                sessionId = null;
+            }
+            initialize();
+        } finally {
+            reinitLock.unlock();
+        }
+        return sendRequestInternal(method, params, true, true);
+    }
+
+    /**
      * Extracts concatenated text from an MCP {@code content} array.
      */
     @NotNull
@@ -161,59 +339,6 @@ public final class CustomMcpClient {
             return err.has("message") ? err.get("message").getAsString() : err.toString();
         }
         return "unknown error";
-    }
-
-    /**
-     * Sends a JSON-RPC 2.0 POST request and returns the parsed response object.
-     * Handles optional SSE envelope ({@code data: …}) transparently.
-     */
-    @NotNull
-    private JsonObject sendRequest(@NotNull String method, @NotNull JsonObject params) throws IOException {
-        JsonObject request = new JsonObject();
-        request.addProperty("jsonrpc", "2.0");
-        request.addProperty("id", requestId.getAndIncrement());
-        request.addProperty("method", method);
-        request.add("params", params);
-
-        URI uri = URI.create(url);
-        String scheme = uri.getScheme();
-        if (scheme == null || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))) {
-            throw new IOException("Unsupported URL scheme: " + scheme
-                + " (only http and https are supported). URL: " + url);
-        }
-
-        byte[] bodyBytes = GSON.toJson(request).getBytes(StandardCharsets.UTF_8);
-        HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
-        try {
-            conn.setRequestMethod("POST");
-            conn.setDoOutput(true);
-            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
-            conn.setReadTimeout(READ_TIMEOUT_MS);
-            conn.setRequestProperty("Content-Type", "application/json");
-            conn.setRequestProperty("Accept", "application/json, text/event-stream");
-
-            try (OutputStream os = conn.getOutputStream()) {
-                os.write(bodyBytes);
-            }
-
-            int status = conn.getResponseCode();
-            if (status == 202) {
-                // Notification accepted — no response body
-                return new JsonObject();
-            }
-
-            InputStream stream = status >= 400 ? conn.getErrorStream() : conn.getInputStream();
-            if (stream == null) return new JsonObject();
-
-            String responseBody;
-            try (stream) {
-                responseBody = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
-            }
-
-            return JsonParser.parseString(stripSseEnvelope(responseBody)).getAsJsonObject();
-        } finally {
-            conn.disconnect();
-        }
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpClient.java
@@ -240,6 +240,10 @@ public final class CustomMcpClient implements AutoCloseable {
                 + " (only http and https are supported). URL: " + url);
         }
 
+        // Capture the session ID to use for this specific request before sending it.
+        // This is used both to set the header and to detect genuine session expiry on 404.
+        String sentSessionId = sessionId;
+
         byte[] bodyBytes = GSON.toJson(request).getBytes(StandardCharsets.UTF_8);
         HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
         try {
@@ -250,8 +254,8 @@ public final class CustomMcpClient implements AutoCloseable {
             conn.setRequestProperty("Content-Type", "application/json");
             conn.setRequestProperty("Accept", "application/json, text/event-stream");
 
-            if (includeSessionHeader && sessionId != null) {
-                conn.setRequestProperty(SESSION_HEADER, sessionId);
+            if (includeSessionHeader && sentSessionId != null) {
+                conn.setRequestProperty(SESSION_HEADER, sentSessionId);
             }
 
             try (OutputStream os = conn.getOutputStream()) {
@@ -266,9 +270,11 @@ public final class CustomMcpClient implements AutoCloseable {
                 sessionId = newSessionId;
             }
 
-            // Session expired — server terminated the session (MCP spec: MUST return 404)
-            if (status == 404 && !isRetry && includeSessionHeader) {
-                return handleSessionExpiry(method, params);
+            // Session expired — only treat 404 as session expiry when we actually sent a session header.
+            // Without this guard, a real 404 (wrong URL) would be mistaken for session expiry
+            // and trigger a spurious re-initialize + retry.
+            if (status == 404 && !isRetry && sentSessionId != null) {
+                return handleSessionExpiry(method, params, sentSessionId);
             }
 
             if (status == 202) {
@@ -294,17 +300,27 @@ public final class CustomMcpClient implements AutoCloseable {
      * Uses a {@link ReentrantLock} so that concurrent threads encountering 404 do not
      * all attempt to re-initialize — only the first one does, and others wait and reuse
      * the new session.
+     *
+     * @param expiredSessionId the session ID that was sent with the failed request, used for
+     *                         a double-check under the lock to skip re-initialization when a
+     *                         concurrent thread has already established a new session
      */
     @NotNull
-    private JsonObject handleSessionExpiry(@NotNull String method, @NotNull JsonObject params) throws IOException {
+    private JsonObject handleSessionExpiry(
+        @NotNull String method,
+        @NotNull JsonObject params,
+        @NotNull String expiredSessionId
+    ) throws IOException {
         LOG.info("Session expired on " + url + " (HTTP 404), re-initializing");
         reinitLock.lock();
         try {
-            // Double-check: another thread may have already re-initialized while we waited for the lock
-            if (sessionId != null) {
+            // Double-check: another thread may have already re-initialized while we waited for the lock.
+            // Only re-initialize if the current session is still the expired one (or has been cleared).
+            // If a different (newer) session is active, skip re-init and fall through to retry with it.
+            if (expiredSessionId.equals(sessionId) || sessionId == null) {
                 sessionId = null;
+                initialize();
             }
-            initialize();
         } finally {
             reinitLock.unlock();
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpConfigurable.java
@@ -153,8 +153,7 @@ public final class CustomMcpConfigurable implements Configurable {
         }
         testButton.setEnabled(false);
         ApplicationManager.getApplication().executeOnPooledThread(() -> {
-            try {
-                CustomMcpClient client = new CustomMcpClient(server.getUrl());
+            try (CustomMcpClient client = new CustomMcpClient(server.getUrl())) {
                 client.initialize();
                 List<CustomMcpClient.ToolInfo> tools = client.listTools();
                 String toolList = tools.stream()

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpRegistrar.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpRegistrar.java
@@ -19,6 +19,9 @@ import java.util.Set;
  * Connects to each enabled server at startup, discovers its tools, and registers
  * {@link CustomMcpToolProxy} instances in {@link PsiBridgeService}.
  * Also handles re-sync when settings are updated.
+ * <p>
+ * Maintains a {@link CustomMcpClient} per server so that MCP sessions are preserved
+ * across tool calls and properly terminated when servers are removed or disabled.
  */
 @Service(Service.Level.PROJECT)
 public final class CustomMcpRegistrar {
@@ -26,10 +29,17 @@ public final class CustomMcpRegistrar {
     private static final Logger LOG = Logger.getInstance(CustomMcpRegistrar.class);
 
     private final Project project;
+
     /**
      * Maps server ID → set of proxy tool IDs currently registered for that server.
      */
     private final Map<String, Set<String>> registeredByServer = new HashMap<>();
+
+    /**
+     * Maps server ID → the active MCP client for that server.
+     * Used to close sessions when a server is unregistered or replaced.
+     */
+    private final Map<String, CustomMcpClient> clientByServer = new HashMap<>();
 
     public CustomMcpRegistrar(@NotNull Project project) {
         this.project = project;
@@ -46,7 +56,7 @@ public final class CustomMcpRegistrar {
      * newly enabled servers and registers their tools.
      * <p>
      * Safe to call on any thread (uses pooled HTTP connections, no EDT usage).
-     * Synchronized to prevent concurrent modification of {@link #registeredByServer}
+     * Synchronized to prevent concurrent modification of internal maps
      * when called from both startup and settings-apply threads.
      */
     public synchronized void syncRegistrations() {
@@ -81,6 +91,7 @@ public final class CustomMcpRegistrar {
     /**
      * Connects to one server, discovers its tools, and registers proxy instances.
      * Replaces any previously registered tools for the same server ID.
+     * Closes the old client's session before creating a new one.
      * Logs a warning and skips silently on connection failure.
      */
     private void connectAndRegister(@NotNull PsiBridgeService bridge, @NotNull CustomMcpServerConfig server) {
@@ -91,10 +102,11 @@ public final class CustomMcpRegistrar {
 
             if (tools.isEmpty()) {
                 LOG.info("Custom MCP server '" + server.getName() + "' reported no tools");
+                client.close();
                 return;
             }
 
-            // Replace any stale registrations for this server
+            // Close old client session and replace stale registrations for this server
             unregisterServerTools(bridge, server.getId());
 
             Set<String> registered = new HashSet<>();
@@ -108,19 +120,30 @@ public final class CustomMcpRegistrar {
                 LOG.info("Registered custom MCP proxy: " + proxy.id() + " → " + server.getUrl());
             }
             registeredByServer.put(server.getId(), registered);
+            clientByServer.put(server.getId(), client);
 
         } catch (Exception e) {
+            client.close();
             LOG.warn("Failed to connect to custom MCP server '" + server.getName()
                 + "' at " + server.getUrl() + ": " + e.getMessage());
         }
     }
 
+    /**
+     * Unregisters proxy tools for a server and terminates the MCP session.
+     */
     private void unregisterServerTools(@NotNull PsiBridgeService bridge, @NotNull String serverId) {
         Set<String> toolIds = registeredByServer.get(serverId);
-        if (toolIds == null) return;
-        for (String toolId : toolIds) {
-            bridge.unregisterTool(toolId);
-            LOG.info("Unregistered custom MCP proxy: " + toolId);
+        if (toolIds != null) {
+            for (String toolId : toolIds) {
+                bridge.unregisterTool(toolId);
+                LOG.info("Unregistered custom MCP proxy: " + toolId);
+            }
+        }
+
+        CustomMcpClient oldClient = clientByServer.remove(serverId);
+        if (oldClient != null) {
+            oldClient.close();
         }
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpRegistrar.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpRegistrar.java
@@ -116,8 +116,11 @@ public final class CustomMcpRegistrar implements Disposable {
             if (tools.isEmpty()) {
                 LOG.info("Custom MCP server '" + server.getName() + "' reported no tools");
                 client.close();
-                unregisterServerTools(bridge, server.getId());
-                registeredByServer.remove(server.getId());
+                // Clean up any stale registration/client from a prior successful connection
+                if (registeredByServer.containsKey(server.getId()) || clientByServer.containsKey(server.getId())) {
+                    unregisterServerTools(bridge, server.getId());
+                    registeredByServer.remove(server.getId());
+                }
                 return;
             }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpRegistrar.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpRegistrar.java
@@ -1,7 +1,7 @@
 package com.github.catatafishen.agentbridge.custommcp;
 
 import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
-import com.intellij.openapi.components.ComponentManager;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -24,7 +24,7 @@ import java.util.Set;
  * across tool calls and properly terminated when servers are removed or disabled.
  */
 @Service(Service.Level.PROJECT)
-public final class CustomMcpRegistrar {
+public final class CustomMcpRegistrar implements Disposable {
 
     private static final Logger LOG = Logger.getInstance(CustomMcpRegistrar.class);
 
@@ -45,9 +45,8 @@ public final class CustomMcpRegistrar {
         this.project = project;
     }
 
-    @SuppressWarnings("java:S1905") // Cast needed: IDE doesn't resolve Project→ComponentManager supertype
     public static CustomMcpRegistrar getInstance(@NotNull Project project) {
-        return ((ComponentManager) project).getService(CustomMcpRegistrar.class);
+        return project.getService(CustomMcpRegistrar.class);
     }
 
     /**
@@ -89,9 +88,23 @@ public final class CustomMcpRegistrar {
     }
 
     /**
+     * Closes all tracked MCP client sessions when the project/service is disposed.
+     * Called by IntelliJ on project close or IDE shutdown.
+     */
+    @Override
+    public synchronized void dispose() {
+        for (CustomMcpClient client : clientByServer.values()) {
+            client.close();
+        }
+        clientByServer.clear();
+        registeredByServer.clear();
+    }
+
+    /**
      * Connects to one server, discovers its tools, and registers proxy instances.
      * Replaces any previously registered tools for the same server ID.
-     * Closes the old client's session before creating a new one.
+     * Creates and validates the replacement client first, then closes the old client's
+     * session and replaces stale registrations for that server ID.
      * Logs a warning and skips silently on connection failure.
      */
     private void connectAndRegister(@NotNull PsiBridgeService bridge, @NotNull CustomMcpServerConfig server) {
@@ -103,6 +116,8 @@ public final class CustomMcpRegistrar {
             if (tools.isEmpty()) {
                 LOG.info("Custom MCP server '" + server.getName() + "' reported no tools");
                 client.close();
+                unregisterServerTools(bridge, server.getId());
+                registeredByServer.remove(server.getId());
                 return;
             }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpClientSessionTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpClientSessionTest.java
@@ -1,0 +1,432 @@
+package com.github.catatafishen.agentbridge.custommcp;
+
+import com.google.gson.JsonObject;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link CustomMcpClient} session handling.
+ * Uses {@link HttpServer} (JDK built-in) as a lightweight embedded MCP server stub.
+ */
+class CustomMcpClientSessionTest {
+
+    private HttpServer server;
+    private String serverUrl;
+    private final CopyOnWriteArrayList<RecordedRequest> requests = new CopyOnWriteArrayList<>();
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        int port = server.getAddress().getPort();
+        serverUrl = "http://127.0.0.1:" + port + "/mcp";
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    // ── Phase 1: Session ID capture & propagation ─────────────────────
+
+    @Test
+    void initialize_capturesSessionIdFromResponseHeader() throws IOException {
+        String sessionId = "test-session-abc123";
+        setupHandler((exchange) -> {
+            requests.add(recordRequest(exchange));
+            exchange.getResponseHeaders().add(CustomMcpClient.SESSION_HEADER, sessionId);
+            respondJson(exchange, initializeResult());
+        });
+        server.start();
+
+        try (CustomMcpClient client = new CustomMcpClient(serverUrl)) {
+            client.initialize();
+            assertEquals(sessionId, client.getSessionId(), "Session ID should be captured from initialize response");
+        }
+    }
+
+    @Test
+    void initialize_noSessionHeader_sessionIdRemainsNull() throws IOException {
+        setupHandler((exchange) -> {
+            requests.add(recordRequest(exchange));
+            respondJson(exchange, initializeResult());
+        });
+        server.start();
+
+        try (CustomMcpClient client = new CustomMcpClient(serverUrl)) {
+            client.initialize();
+            assertNull(client.getSessionId(), "Session ID should remain null when server doesn't send it");
+        }
+    }
+
+    @Test
+    void listTools_sendsSessionIdWhenPresent() throws IOException {
+        String sessionId = "session-for-list";
+        AtomicInteger callCount = new AtomicInteger();
+
+        setupHandler((exchange) -> {
+            RecordedRequest req = recordRequest(exchange);
+            requests.add(req);
+            int call = callCount.incrementAndGet();
+
+            if (call == 1) {
+                exchange.getResponseHeaders().add(CustomMcpClient.SESSION_HEADER, sessionId);
+                respondJson(exchange, initializeResult());
+            } else {
+                respondJson(exchange, toolsListResult("echo", "Echo tool"));
+            }
+        });
+        server.start();
+
+        try (CustomMcpClient client = new CustomMcpClient(serverUrl)) {
+            client.initialize();
+            client.listTools();
+
+            assertEquals(2, requests.size());
+            assertNull(requests.get(0).sessionHeader, "initialize must not send session header");
+            assertEquals(sessionId, requests.get(1).sessionHeader, "listTools must send session header");
+        }
+    }
+
+    @Test
+    void callTool_sendsSessionIdWhenPresent() throws IOException {
+        String sessionId = "session-for-call";
+        AtomicInteger callCount = new AtomicInteger();
+
+        setupHandler((exchange) -> {
+            RecordedRequest req = recordRequest(exchange);
+            requests.add(req);
+            int call = callCount.incrementAndGet();
+
+            if (call == 1) {
+                exchange.getResponseHeaders().add(CustomMcpClient.SESSION_HEADER, sessionId);
+                respondJson(exchange, initializeResult());
+            } else if (call == 2) {
+                respondJson(exchange, toolsListResult("echo", "Echo tool"));
+            } else {
+                respondJson(exchange, toolCallResult("hello"));
+            }
+        });
+        server.start();
+
+        try (CustomMcpClient client = new CustomMcpClient(serverUrl)) {
+            client.initialize();
+            client.listTools();
+            client.callTool("echo", new JsonObject());
+
+            assertEquals(3, requests.size());
+            assertNull(requests.get(0).sessionHeader, "initialize must not send session header");
+            assertEquals(sessionId, requests.get(1).sessionHeader, "listTools must send session header");
+            assertEquals(sessionId, requests.get(2).sessionHeader, "callTool must send session header");
+        }
+    }
+
+    @Test
+    void statelessServer_noSessionHeaderSentOnSubsequentRequests() throws IOException {
+        AtomicInteger callCount = new AtomicInteger();
+
+        setupHandler((exchange) -> {
+            requests.add(recordRequest(exchange));
+            int call = callCount.incrementAndGet();
+
+            if (call == 1) {
+                respondJson(exchange, initializeResult());
+            } else {
+                respondJson(exchange, toolsListResult("ping", "Ping"));
+            }
+        });
+        server.start();
+
+        try (CustomMcpClient client = new CustomMcpClient(serverUrl)) {
+            client.initialize();
+            client.listTools();
+
+            assertNull(client.getSessionId());
+            assertNull(requests.get(0).sessionHeader);
+            assertNull(requests.get(1).sessionHeader);
+        }
+    }
+
+    // ── Phase 2: Session expiry recovery (404 retry) ──────────────────
+
+    @Test
+    void callTool_recoversFromSessionExpiry() throws IOException {
+        String firstSession = "session-old";
+        String secondSession = "session-new";
+        AtomicInteger callCount = new AtomicInteger();
+
+        setupHandler((exchange) -> {
+            RecordedRequest req = recordRequest(exchange);
+            requests.add(req);
+            int call = callCount.incrementAndGet();
+
+            if (call == 1) {
+                exchange.getResponseHeaders().add(CustomMcpClient.SESSION_HEADER, firstSession);
+                respondJson(exchange, initializeResult());
+            } else if (call == 2) {
+                // tools/call → 404 (session expired)
+                exchange.sendResponseHeaders(404, -1);
+            } else if (call == 3) {
+                exchange.getResponseHeaders().add(CustomMcpClient.SESSION_HEADER, secondSession);
+                respondJson(exchange, initializeResult());
+            } else {
+                respondJson(exchange, toolCallResult("recovered"));
+            }
+        });
+        server.start();
+
+        try (CustomMcpClient client = new CustomMcpClient(serverUrl)) {
+            client.initialize();
+            String result = client.callTool("echo", new JsonObject());
+
+            assertEquals("recovered", result);
+            assertEquals(secondSession, client.getSessionId());
+            assertEquals(4, requests.size(), "Should be: init → call(404) → reinit → retry");
+            assertNull(requests.get(2).sessionHeader, "Re-initialize must not send session header");
+            assertEquals(secondSession, requests.get(3).sessionHeader, "Retry must use new session");
+        }
+    }
+
+    @Test
+    void callTool_doesNotRetryMoreThanOnce() throws IOException {
+        String session = "session-doomed";
+        AtomicInteger callCount = new AtomicInteger();
+
+        setupHandler((exchange) -> {
+            requests.add(recordRequest(exchange));
+            int call = callCount.incrementAndGet();
+
+            if (call == 1) {
+                exchange.getResponseHeaders().add(CustomMcpClient.SESSION_HEADER, session);
+                respondJson(exchange, initializeResult());
+            } else if (call == 2) {
+                exchange.sendResponseHeaders(404, -1);
+            } else if (call == 3) {
+                exchange.getResponseHeaders().add(CustomMcpClient.SESSION_HEADER, "session-new");
+                respondJson(exchange, initializeResult());
+            } else {
+                // Retry also gets 404 — should NOT trigger another retry
+                exchange.sendResponseHeaders(404, -1);
+            }
+        });
+        server.start();
+
+        try (CustomMcpClient client = new CustomMcpClient(serverUrl)) {
+            client.initialize();
+            String result = client.callTool("echo", new JsonObject());
+
+            assertEquals(4, requests.size(), "Should not retry more than once");
+            assertTrue(result.contains("Failed") || result.contains("Error") || result.isEmpty(),
+                "Should surface error when retry also fails");
+        }
+    }
+
+    @Test
+    void listTools_recoversFromSessionExpiry() throws IOException {
+        String firstSession = "sess-1";
+        String secondSession = "sess-2";
+        AtomicInteger callCount = new AtomicInteger();
+
+        setupHandler((exchange) -> {
+            requests.add(recordRequest(exchange));
+            int call = callCount.incrementAndGet();
+
+            if (call == 1) {
+                exchange.getResponseHeaders().add(CustomMcpClient.SESSION_HEADER, firstSession);
+                respondJson(exchange, initializeResult());
+            } else if (call == 2) {
+                exchange.sendResponseHeaders(404, -1);
+            } else if (call == 3) {
+                exchange.getResponseHeaders().add(CustomMcpClient.SESSION_HEADER, secondSession);
+                respondJson(exchange, initializeResult());
+            } else {
+                respondJson(exchange, toolsListResult("ping", "Ping tool"));
+            }
+        });
+        server.start();
+
+        try (CustomMcpClient client = new CustomMcpClient(serverUrl)) {
+            client.initialize();
+            List<CustomMcpClient.ToolInfo> tools = client.listTools();
+
+            assertEquals(1, tools.size());
+            assertEquals("ping", tools.getFirst().name());
+            assertEquals(secondSession, client.getSessionId());
+        }
+    }
+
+    // ── Phase 3: Session termination (close) ──────────────────────────
+
+    @Test
+    void close_sendsDeleteWithSessionId() throws IOException {
+        String sessionId = "session-to-close";
+        AtomicReference<String> deleteMethod = new AtomicReference<>();
+        AtomicReference<String> deleteSessionHeader = new AtomicReference<>();
+
+        setupHandler((exchange) -> {
+            requests.add(recordRequest(exchange));
+            if ("DELETE".equals(exchange.getRequestMethod())) {
+                deleteMethod.set(exchange.getRequestMethod());
+                deleteSessionHeader.set(exchange.getRequestHeaders().getFirst(CustomMcpClient.SESSION_HEADER));
+                exchange.sendResponseHeaders(200, -1);
+            } else {
+                exchange.getResponseHeaders().add(CustomMcpClient.SESSION_HEADER, sessionId);
+                respondJson(exchange, initializeResult());
+            }
+        });
+        server.start();
+
+        try (CustomMcpClient client = new CustomMcpClient(serverUrl)) {
+            client.initialize();
+            assertEquals(sessionId, client.getSessionId());
+
+            client.close();
+
+            assertNull(client.getSessionId(), "Session ID should be cleared after close");
+            assertEquals("DELETE", deleteMethod.get());
+            assertEquals(sessionId, deleteSessionHeader.get());
+        }
+    }
+
+    @Test
+    void close_noopWhenNoSession() throws IOException {
+        setupHandler((exchange) -> {
+            requests.add(recordRequest(exchange));
+            respondJson(exchange, initializeResult());
+        });
+        server.start();
+
+        try (CustomMcpClient client = new CustomMcpClient(serverUrl)) {
+            client.initialize();
+            assertNull(client.getSessionId());
+
+            int requestsBefore = requests.size();
+            client.close();
+
+            assertEquals(requestsBefore, requests.size(), "close should not send DELETE when no session");
+        }
+    }
+
+    @Test
+    void close_swallows405FromServer() throws IOException {
+        String sessionId = "session-405";
+
+        setupHandler((exchange) -> {
+            requests.add(recordRequest(exchange));
+            if ("DELETE".equals(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(405, -1);
+            } else {
+                exchange.getResponseHeaders().add(CustomMcpClient.SESSION_HEADER, sessionId);
+                respondJson(exchange, initializeResult());
+            }
+        });
+        server.start();
+
+        try (CustomMcpClient client = new CustomMcpClient(serverUrl)) {
+            client.initialize();
+            client.close();
+            assertNull(client.getSessionId());
+        }
+    }
+
+    @Test
+    void close_isIdempotent() throws IOException {
+        String sessionId = "session-idempotent";
+        AtomicInteger deleteCount = new AtomicInteger();
+
+        setupHandler((exchange) -> {
+            requests.add(recordRequest(exchange));
+            if ("DELETE".equals(exchange.getRequestMethod())) {
+                deleteCount.incrementAndGet();
+                exchange.sendResponseHeaders(200, -1);
+            } else {
+                exchange.getResponseHeaders().add(CustomMcpClient.SESSION_HEADER, sessionId);
+                respondJson(exchange, initializeResult());
+            }
+        });
+        server.start();
+
+        try (CustomMcpClient client = new CustomMcpClient(serverUrl)) {
+            client.initialize();
+
+            client.close();
+            client.close();
+            client.close();
+
+            assertEquals(1, deleteCount.get(), "Only the first close should send DELETE");
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private void setupHandler(RequestHandler handler) {
+        server.createContext("/mcp", exchange -> {
+            try (exchange) {
+                handler.handle(exchange);
+            }
+        });
+    }
+
+    @FunctionalInterface
+    private interface RequestHandler {
+        void handle(HttpExchange exchange) throws IOException;
+    }
+
+    private record RecordedRequest(String method, String sessionHeader, String body) {
+    }
+
+    private static RecordedRequest recordRequest(HttpExchange exchange) {
+        String method = exchange.getRequestMethod();
+        String sessionHeader = exchange.getRequestHeaders().getFirst(CustomMcpClient.SESSION_HEADER);
+        String body = "";
+        try {
+            body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException ignored) {
+            // DELETE may have no body
+        }
+        return new RecordedRequest(method, sessionHeader, body);
+    }
+
+    private static void respondJson(HttpExchange exchange, String json) throws IOException {
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    private static String initializeResult() {
+        return """
+            {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"test","version":"1.0"}}}""";
+    }
+
+    private static String toolsListResult(String toolName, String description) {
+        return """
+            {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"%s","description":"%s","inputSchema":{"type":"object","properties":{}}}]}}"""
+            .formatted(toolName, description);
+    }
+
+    private static String toolCallResult(String text) {
+        return """
+            {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"%s"}]}}"""
+            .formatted(text);
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpClientSessionTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/custommcp/CustomMcpClientSessionTest.java
@@ -378,8 +378,10 @@ class CustomMcpClientSessionTest {
 
     private void setupHandler(RequestHandler handler) {
         server.createContext("/mcp", exchange -> {
-            try (exchange) {
+            try {
                 handler.handle(exchange);
+            } finally {
+                exchange.close();
             }
         });
     }


### PR DESCRIPTION
Rebased from community PR https://github.com/catatafishen/agentbridge/pull/95 by @nievesj onto current master.

Fixed package name conflicts (`ideagentforcopilot` → `agentbridge`) during rebase.

### Changes
- `CustomMcpClient` now implements `AutoCloseable` with explicit HTTP DELETE session termination on close
- Thread-safe session recovery via `ReentrantLock` — only one thread re-initializes on HTTP 404
- `CustomMcpRegistrar` now implements `Disposable` — terminates all MCP sessions when the project closes
- Improved `connectAndRegister` lifecycle: validates new connection before closing old session
- Empty-tools case properly cleans up stale registrations
- Comprehensive test suite: `CustomMcpClientSessionTest` covers session capture, propagation, recovery, and close semantics

Co-authored-by: nievesj <nievesj@users.noreply.github.com>