### PR TITLE
fix: enable JaCoCo coverage for IntelliJ Platform tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,17 @@ jobs:
           cache-disabled: true
 
       - name: Run MCP server tests
-        run: ./gradlew :mcp-server:test --no-daemon --quiet --build-cache
+        run: ./gradlew :mcp-server:test :mcp-server:jacocoTestReport --no-daemon --quiet --build-cache
+
+      - name: Upload MCP server coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5.5.4
+        with:
+          files: mcp-server/build/reports/jacoco/test/jacocoTestReport.xml
+          flags: mcp-server
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build-and-test:
     name: Build, Test & Verify

--- a/mcp-server/build.gradle.kts
+++ b/mcp-server/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("java")
     application
+    jacoco
 }
 
 dependencies {
@@ -16,4 +17,17 @@ tasks.jar {
         attributes["Main-Class"] = "com.github.copilot.mcp.McpStdioProxy"
     }
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+tasks.test {
+    useJUnitPlatform()
+    finalizedBy(tasks.named("jacocoTestReport"))
+}
+
+tasks.named<JacocoReport>("jacocoTestReport") {
+    dependsOn(tasks.named("test"))
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
 }

--- a/plugin-core/build.gradle.kts
+++ b/plugin-core/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel
 import java.util.zip.ZipInputStream
@@ -420,6 +421,12 @@ tasks {
         useJUnitPlatform {
             excludeTags("integration")
         }
+        // IntelliJ Platform loads classes via a custom classloader that doesn't
+        // provide class file locations. Without this flag, JaCoCo reports 0% coverage.
+        extensions.configure<JacocoTaskExtension> {
+            isIncludeNoLocationClasses = true
+            excludes = listOf("jdk.internal.*")
+        }
         finalizedBy(named("jacocoTestReport"))
     }
 
@@ -429,6 +436,18 @@ tasks {
             xml.required.set(true)
             html.required.set(true)
         }
+        // Use only Java-compiled classes to avoid "Can't add different class with
+        // same name" errors from duplicate .class files in kotlin/main and java/main.
+        // Exclude UI and service classes that require the full IDE runtime — these
+        // can only be tested via integration tests, not unit tests.
+        val mainClasses = fileTree("${layout.buildDirectory.get()}/classes/java/main") {
+            exclude(
+                "**/ui/**",           // Swing/JCEF UI components
+                "**/actions/**",      // AnAction subclasses (need ActionManager)
+                "**/settings/**",     // Settings UI (configurable panels)
+            )
+        }
+        classDirectories.setFrom(mainClasses)
     }
 
     runIde {


### PR DESCRIPTION
## Problem
The Codecov badge on the README showed **0%** coverage. JaCoCo generated a report with all 672 classes listed but zero lines covered.

## Root Cause
IntelliJ Platform loads classes via a custom classloader (`PathClassLoader`) that doesn't provide class file locations. JaCoCo uses these locations to match execution data to class files. Without `isIncludeNoLocationClasses = true`, coverage data is silently discarded.

Additionally, the Kotlin JVM plugin produces duplicate `.class` files in both `kotlin/main` and `java/main` directories. JaCoCo fails with "Can't add different class with same name" when both are included.

## Changes
- **plugin-core**: Add `isIncludeNoLocationClasses = true` + `excludes = ["jdk.internal.*"]` to the test task's JaCoCo extension
- **plugin-core**: Configure `jacocoTestReport` to use only `java/main` classes (avoids duplicate class errors)
- **plugin-core**: Exclude `ui/`, `actions/`, `settings/` packages from coverage (require full IDE runtime)
- **mcp-server**: Add JaCoCo plugin with XML + HTML report generation
- **CI**: Upload mcp-server coverage to Codecov alongside plugin-core