### PR TITLE
fix: remove JaCoCo package exclusions for honest coverage reporting

### DIFF
--- a/plugin-core/build.gradle.kts
+++ b/plugin-core/build.gradle.kts
@@ -438,16 +438,9 @@ tasks {
         }
         // Use only Java-compiled classes to avoid "Can't add different class with
         // same name" errors from duplicate .class files in kotlin/main and java/main.
-        // Exclude UI and service classes that require the full IDE runtime — these
-        // can only be tested via integration tests, not unit tests.
-        val mainClasses = fileTree("${layout.buildDirectory.get()}/classes/java/main") {
-            exclude(
-                "**/ui/**",           // Swing/JCEF UI components
-                "**/actions/**",      // AnAction subclasses (need ActionManager)
-                "**/settings/**",     // Settings UI (configurable panels)
-            )
-        }
-        classDirectories.setFrom(mainClasses)
+        classDirectories.setFrom(
+            fileTree("${layout.buildDirectory.get()}/classes/java/main")
+        )
     }
 
     runIde {


### PR DESCRIPTION
## Problem

The JaCoCo report excluded `ui/`, `settings/`, and `actions/` packages (~12,000 coverable lines), making the denominator artificially small. Codecov showed coverage over 20,451 lines when the codebase actually has 32,380 coverable lines.

## Fix

Remove all package exclusions from `jacocoTestReport`. All classes are now included in the report, giving Codecov an accurate picture of the full codebase.

## Coverage summary (32,380 lines, 2.2% line coverage)

| Package | Covered | Total | % | Reason for gap |
|---------|---------|-------|---|----------------|
| `permissions` | 87 | 107 | **81.3%** | ✅ Well tested |
| `agentbridge` (root) | 7 | 15 | **46.7%** | `BuildInfo` — testable |
| `acp/model` | 66 | 309 | **21.4%** | DTOs + serializers — testable |
| `agent` | 11 | 85 | **12.9%** | Registry tested; clients need IDE |
| `psi` (root) | 167 | 2,247 | **7.4%** | `ToolUtils` tested; PSI services need IDE |
| `acp/client` | 120 | 1,685 | **7.1%** | 7 test classes; `AcpClient` needs IDE |
| `ui` | 216 | 6,772 | **3.2%** | Swing/JCEF — needs IDE runtime |
| `settings` | 25 | 2,621 | **1.0%** | Settings panels — needs IDE runtime |
| `services` | 4 | 2,733 | **0.1%** | Embedded servers/registries — needs IDE |
| `psi/tools/*` (12 pkgs) | 0 | ~6,200 | **0.0%** | All tool impls need PSI/IDE |
| `ui/renderers` | 0 | 2,505 | **0.0%** | HTML renderers — needs IDE |
| `bridge` | 0 | 506 | **0.0%** | Config — partially testable |
| `session/*` | 0 | ~2,100 | **0.0%** | Exporters tested but JaCoCo misses (classloader) |
| `agent/claude`, `codex`, `junie` | 0 | ~1,500 | **0.0%** | Agent clients — need IDE |

**Why coverage is low:** This is an IntelliJ plugin — ~80% of the code directly uses IDE APIs (PSI, VFS, EDT, services). Unit tests only work for pure logic classes. Integration tests require the full IDE runtime.