### PR TITLE
fix: wait for VCS log indexing before navigating to commits

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
@@ -399,20 +399,6 @@ public final class PlatformApiCompat {
     }
 
     /**
-     * Navigates the VCS Log tool window to a specific commit by its full SHA hash.
-     *
-     * <p><b>Why extracted:</b> {@code com.intellij.vcs.log.Hash} and
-     * {@code com.intellij.vcs.log.impl.HashImpl} are resolved against the dev IDE's VCS plugin JAR,
-     * which may have different class metadata or {@code @NotNull} annotations than the target SDK.
-     * The IDE daemon reports "Unknown class: com.intellij.vcs.log.Hash" and cascading resolution
-     * failures on {@code showRevisionInMainLog}. The Gradle build compiles without errors.</p>
-     */
-    public static void showRevisionInLog(@NotNull Project project, @NotNull String fullHash) {
-        var vcsHash = com.intellij.vcs.log.impl.HashImpl.build(fullHash);
-        com.intellij.vcs.log.impl.VcsProjectLog.showRevisionInMainLog(project, vcsHash);
-    }
-
-    /**
      * Opens the Git Log tab and selects the commit with {@code fullHash} once the VCS log has
      * indexed it. Registers a {@link com.intellij.vcs.log.data.DataPackChangeListener} and waits
      * for the new commit to appear in the storage before calling

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
@@ -376,6 +376,8 @@ public abstract class GitTool extends Tool {
 
     /**
      * Extracts the first full commit hash from git output and navigates to it in the VCS Log tab.
+     * Uses {@link PlatformApiCompat#showRevisionInLogAfterRefresh} to wait for the VCS log to
+     * index the commit before navigating — avoids "commit could not be found" errors.
      */
     protected void showFirstCommitInLog(String gitOutput) {
         if (!ToolLayerSettings.getInstance(project).getFollowAgentFiles()) return;
@@ -394,7 +396,7 @@ public abstract class GitTool extends Tool {
         String finalHash = hash;
         EdtUtil.invokeLater(() -> {
             try {
-                PlatformApiCompat.showRevisionInLog(project, finalHash);
+                PlatformApiCompat.showRevisionInLogAfterRefresh(project, finalHash);
             } catch (Exception ignored) {
                 // best-effort UI follow-along
             }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -1539,7 +1539,7 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
                 if (fullHash.length == 40) {
                     ApplicationManager.getApplication().invokeLater {
                         PlatformApiCompat
-                            .showRevisionInLog(project, fullHash)
+                            .showRevisionInLogAfterRefresh(project, fullHash)
                     }
                 }
             } catch (_: Exception) {


### PR DESCRIPTION
## Problem

The "follow agent" feature showed a **"commit could not be found"** error when navigating to commits after git operations. The VCS log hadn't finished indexing the commit yet.

## Root cause

Three call sites used the direct `showRevisionInLog()` which calls `VcsProjectLog.showRevisionInMainLog()` immediately — before the VCS log has indexed the new commit:

| Call site | Trigger | Bug? |
|-----------|---------|------|
| `GitCommitTool` → `showNewCommitInLog()` | `git_commit` tool | ✅ Already used safe method |
| `GitLogTool`/`GitShowTool` → `showFirstCommitInLog()` | `git_log`/`git_show` tools | ❌ **Used unsafe direct call** |
| `ChatConsolePanel` → `tryNavigateToCommit()` | Clicking commit chip in chat | ❌ **Used unsafe direct call** |

## Fix

- Switch `showFirstCommitInLog()` and `tryNavigateToCommit()` to use `showRevisionInLogAfterRefresh()`, which registers a `DataPackChangeListener` and waits for the commit to appear in VCS storage before navigating (with a 10s timeout to prevent listener leaks)
- Remove the now-unused unsafe `showRevisionInLog()` method from `PlatformApiCompat`

**3 files changed, 4 insertions, 16 deletions** — net reduction in code.