### PR TITLE
feat: add usage statistics dialog with per-agent charts

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/v2/EntryDataJsonAdapter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/v2/EntryDataJsonAdapter.java
@@ -146,6 +146,7 @@ public final class EntryDataJsonAdapter {
         } else if (entry instanceof EntryData.TurnStats ts) {
             json.addProperty("type", TYPE_TURN_STATS);
             json.addProperty("turnId", ts.getTurnId());
+            addNonEmpty(json, "timestamp", ts.getTimestamp());
             addIfNonZero(json, "durationMs", ts.getDurationMs());
             addIfNonZero(json, "inputTokens", ts.getInputTokens());
             addIfNonZero(json, "outputTokens", ts.getOutputTokens());
@@ -302,6 +303,7 @@ public final class EntryDataJsonAdapter {
                 intVal(json, "totalToolCalls"),
                 intVal(json, "totalLinesAdded"),
                 intVal(json, "totalLinesRemoved"),
+                str(json, "timestamp"),
                 entryId);
             case TYPE_NUDGE -> new EntryData.Nudge(
                 str(json, "text"),

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -712,6 +712,7 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
                 totalToolCalls = (prev?.totalToolCalls ?: 0) + toolCallCount,
                 totalLinesAdded = (prev?.totalLinesAdded ?: 0) + linesAdded,
                 totalLinesRemoved = (prev?.totalLinesRemoved ?: 0) + linesRemoved,
+                timestamp = java.time.Instant.now().toString(),
             )
         )
         // Render the turn summary footer in the chat panel

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatDataModel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatDataModel.kt
@@ -124,6 +124,7 @@ sealed class EntryData {
         val totalToolCalls: Int = 0,
         val totalLinesAdded: Int = 0,
         val totalLinesRemoved: Int = 0,
+        override val timestamp: String = "",
         override val entryId: String = java.util.UUID.randomUUID().toString()
     ) : EntryData()
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -189,6 +189,7 @@ class ChatToolWindowContent(
             Separator.create(),
             ProjectFilesDropdownAction(),
             Separator.create(),
+            StatisticsAction(),
             SettingsAction()
         )
         toolWindow.setTitleActions(actions)
@@ -1188,6 +1189,17 @@ class ChatToolWindowContent(
                 com.intellij.openapi.ui.popup.JBPopupFactory.ActionSelectionAid.SPEEDSEARCH, false
             )
             popup.showUnderneathOf(component)
+        }
+    }
+
+    /** Toolbar button that opens the usage statistics dialog. */
+    private inner class StatisticsAction : AnAction(
+        "Usage Statistics", "View usage statistics across agent sessions",
+        AllIcons.Actions.ProfileCPU
+    ) {
+        override fun getActionUpdateThread() = ActionUpdateThread.EDT
+        override fun actionPerformed(e: AnActionEvent) {
+            com.github.catatafishen.agentbridge.ui.statistics.UsageStatisticsDialog(project).show()
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsChart.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsChart.java
@@ -21,17 +21,17 @@ import java.util.stream.Collectors;
 
 /**
  * Chart component that renders usage metrics over time using Java2D.
- * Each agent gets its own colored line and fill area, stacked from the baseline.
+ * Each agent gets its own colored line and fill area rendered independently and filled to the baseline.
  */
 class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
 
     private static final Logger LOG = Logger.getInstance(UsageStatisticsChart.class);
     private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("MM/dd");
 
-    private static final int MARGIN_LEFT = 48;
-    private static final int MARGIN_RIGHT = 12;
-    private static final int MARGIN_TOP = 8;
-    private static final int MARGIN_BOTTOM = 24;
+    private static final int MARGIN_LEFT = JBUI.scale(48);
+    private static final int MARGIN_RIGHT = JBUI.scale(12);
+    private static final int MARGIN_TOP = JBUI.scale(8);
+    private static final int MARGIN_BOTTOM = JBUI.scale(24);
 
     private static final Color GRID_LINE_COLOR = new JBColor(
         new Color(220, 220, 220), new Color(60, 60, 60));
@@ -163,7 +163,7 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
 
     private long extractMetricValue(UsageStatisticsData.DailyAgentStats stats) {
         return switch (metric) {
-            case PREMIUM_REQUESTS -> (long) stats.premiumRequests();
+            case PREMIUM_REQUESTS -> Math.round(stats.premiumRequests());
             case TURNS -> stats.turns();
             case TOKENS -> stats.inputTokens() + stats.outputTokens();
             case TOOL_CALLS -> stats.toolCalls();
@@ -218,9 +218,9 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
             }
             xMin = xLo;
             xMax = xHi;
-            // Always include zero on the Y axis so bars are grounded
+            // Always include zero on the Y axis so fills are grounded at the baseline
             yMin = Math.min(0, yLo);
-            yMax = yHi;
+            yMax = Math.max(0, yHi);
             // Pad top/bottom by 10% so peaks aren't clipped against the border
             if (yMax > yMin) {
                 long padding = (yMax - yMin) / 10;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsChart.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsChart.java
@@ -100,6 +100,7 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
         }
 
         chart.setDatasets(datasets);
+        chart.update();
         revalidate();
         repaint();
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsChart.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsChart.java
@@ -1,0 +1,138 @@
+package com.github.catatafishen.agentbridge.ui.statistics;
+
+import com.github.catatafishen.agentbridge.ui.ChatTheme;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.charts.Coordinates;
+import com.intellij.ui.charts.XYLineChart;
+import com.intellij.ui.charts.XYLineDataset;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBPanel;
+import com.intellij.util.ui.JBUI;
+
+import java.awt.*;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Chart component that wraps JetBrains' {@link XYLineChart} to display usage
+ * metrics over time, with per-agent color coding.
+ * <p>
+ * {@code com.intellij.ui.charts} is marked {@code @ApiStatus.Experimental} but is the only
+ * native JetBrains charting API. It has been stable since IntelliJ 2020.2 and there is no
+ * non-experimental alternative. If the API changes in a future platform version, only this
+ * class needs updating.
+ */
+@SuppressWarnings("UnstableApiUsage")
+class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
+
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("MM/dd");
+
+    private final UsageStatisticsData.Metric metric;
+    private final XYLineChart<Long, Long> chart;
+    private final JBLabel emptyLabel;
+
+    UsageStatisticsChart(String title, UsageStatisticsData.Metric metric) {
+        super(new BorderLayout());
+        this.metric = metric;
+
+        setPreferredSize(JBUI.size(350, 200));
+
+        JBLabel titleLabel = new JBLabel(title);
+        titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD));
+        add(titleLabel, BorderLayout.NORTH);
+
+        chart = new XYLineChart<>();
+        configureGrid();
+        add(chart.getComponent(), BorderLayout.CENTER);
+
+        emptyLabel = new JBLabel("No data");
+        emptyLabel.setHorizontalAlignment(JBLabel.CENTER);
+        emptyLabel.setVisible(false);
+    }
+
+    void update(UsageStatisticsData.StatisticsSnapshot snapshot) {
+        if (snapshot == null || snapshot.dailyStats().isEmpty()) {
+            remove(chart.getComponent());
+            emptyLabel.setVisible(true);
+            add(emptyLabel, BorderLayout.CENTER);
+            revalidate();
+            repaint();
+            return;
+        }
+
+        emptyLabel.setVisible(false);
+        remove(emptyLabel);
+        add(chart.getComponent(), BorderLayout.CENTER);
+
+        Map<String, List<UsageStatisticsData.DailyAgentStats>> byAgent = snapshot.dailyStats().stream()
+            .collect(Collectors.groupingBy(UsageStatisticsData.DailyAgentStats::agentId));
+
+        List<XYLineDataset<Long, Long>> datasets = new ArrayList<>();
+
+        for (Map.Entry<String, List<UsageStatisticsData.DailyAgentStats>> entry : byAgent.entrySet()) {
+            String agentId = entry.getKey();
+            List<UsageStatisticsData.DailyAgentStats> agentStats = entry.getValue();
+
+            XYLineDataset<Long, Long> dataset = new XYLineDataset<>();
+            dataset.setLabel(agentId);
+            dataset.setStacked(true);
+            dataset.setStroke(new BasicStroke(2.0f));
+
+            int colorIndex = ChatTheme.INSTANCE.agentColorIndex(agentId);
+            JBColor agentColor = ChatTheme.INSTANCE.getSA_COLORS()[colorIndex];
+            dataset.setLineColor(agentColor);
+            dataset.setFillColor(new Color(agentColor.getRed(), agentColor.getGreen(), agentColor.getBlue(), 38));
+
+            for (UsageStatisticsData.DailyAgentStats stats : agentStats) {
+                long x = stats.date().atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+                long y = extractMetricValue(stats);
+                //noinspection unchecked — varargs generic erasure in XYLineDataset.add(T...)
+                dataset.add(Coordinates.of(x, y));
+            }
+
+            datasets.add(dataset);
+        }
+
+        chart.setDatasets(datasets);
+        revalidate();
+        repaint();
+    }
+
+    private long extractMetricValue(UsageStatisticsData.DailyAgentStats stats) {
+        return switch (metric) {
+            case PREMIUM_REQUESTS -> (long) stats.premiumRequests();
+            case TURNS -> stats.turns();
+            case TOKENS -> stats.inputTokens() + stats.outputTokens();
+            case TOOL_CALLS -> stats.toolCalls();
+            case CODE_CHANGES -> stats.linesAdded() + stats.linesRemoved();
+            case AGENT_TIME -> stats.durationMs() / 1000;
+        };
+    }
+
+    private void configureGrid() {
+        chart.getRanges().setXPainter(gl -> {
+            long millis = gl.getValue();
+            gl.setLabel(LocalDate.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault())
+                .format(DATE_FMT));
+        });
+        chart.getRanges().setYPainter(gl -> gl.setLabel(formatCompact(gl.getValue())));
+    }
+
+    private static String formatCompact(long value) {
+        if (value >= 1_000_000) {
+            double v = value / 1_000_000.0;
+            return v == (long) v ? (long) v + "M" : String.format("%.1fM", v);
+        }
+        if (value >= 1_000) {
+            double v = value / 1_000.0;
+            return v == (long) v ? (long) v + "K" : String.format("%.1fK", v);
+        }
+        return Long.toString(value);
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsChart.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsChart.java
@@ -14,6 +14,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -51,7 +52,7 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
         titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD));
         add(titleLabel, BorderLayout.NORTH);
 
-        canvas = new ChartCanvas();
+        canvas = new ChartCanvas(metric);
         add(canvas, BorderLayout.CENTER);
 
         emptyLabel = new JBLabel("No data");
@@ -73,6 +74,9 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
         remove(emptyLabel);
         add(canvas, BorderLayout.CENTER);
 
+        LocalDate rangeStart = snapshot.startDate();
+        LocalDate rangeEnd = snapshot.endDate();
+
         Map<String, List<UsageStatisticsData.DailyAgentStats>> byAgent = snapshot.dailyStats().stream()
             .collect(Collectors.groupingBy(UsageStatisticsData.DailyAgentStats::agentId));
 
@@ -85,11 +89,18 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
             int colorIndex = ChatTheme.INSTANCE.agentColorIndex(agentId);
             JBColor agentColor = ChatTheme.INSTANCE.getSA_COLORS()[colorIndex];
 
-            List<DataPoint> points = new ArrayList<>();
+            // Index metric values by date for O(1) lookup
+            Map<LocalDate, Long> valuesByDate = new LinkedHashMap<>();
             for (UsageStatisticsData.DailyAgentStats stats : agentStats) {
-                long x = stats.date().atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
-                long y = extractMetricValue(stats);
-                points.add(new DataPoint(x, y, stats.date()));
+                valuesByDate.merge(stats.date(), extractMetricValue(stats), Long::sum);
+            }
+
+            // Fill every day in the selected range, using zero for days without data
+            List<DataPoint> points = new ArrayList<>();
+            for (LocalDate d = rangeStart; !d.isAfter(rangeEnd); d = d.plusDays(1)) {
+                long x = d.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+                long y = valuesByDate.getOrDefault(d, 0L);
+                points.add(new DataPoint(x, y, d));
             }
 
             seriesList.add(new DataSeries(agentId, agentColor, points));
@@ -111,7 +122,7 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
             case TOKENS -> stats.inputTokens() + stats.outputTokens();
             case TOOL_CALLS -> stats.toolCalls();
             case CODE_CHANGES -> stats.linesAdded() + stats.linesRemoved();
-            case AGENT_TIME -> stats.durationMs() / 1000;
+            case AGENT_TIME -> stats.durationMs() / 60_000;
         };
     }
 
@@ -126,11 +137,14 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
      */
     private static final class ChartCanvas extends JPanel {
 
+        private final UsageStatisticsData.Metric metric;
         private List<DataSeries> seriesList = List.of();
         private long xMin, xMax, yMin, yMax;
 
-        ChartCanvas() {
-            setOpaque(false);
+        ChartCanvas(UsageStatisticsData.Metric metric) {
+            this.metric = metric;
+            // Must stay opaque so Swing's RepaintManager always
+            // repaints this component when repaint() is called.
         }
 
         void setData(List<DataSeries> seriesList) {
@@ -174,13 +188,13 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
             super.paintComponent(g);
             if (seriesList.isEmpty()) return;
 
+            int w = getWidth();
+            int h = getHeight();
+
             Graphics2D g2 = (Graphics2D) g.create();
             try {
                 g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
                 g2.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
-
-                int w = getWidth();
-                int h = getHeight();
                 int plotLeft = MARGIN_LEFT;
                 int plotRight = w - MARGIN_RIGHT;
                 int plotTop = MARGIN_TOP;
@@ -213,7 +227,7 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
                     g2.setColor(GRID_LINE_COLOR);
                     g2.drawLine(plotLeft, py, plotRight, py);
                     g2.setColor(GRID_LABEL_COLOR);
-                    String label = formatCompact(yVal);
+                    String label = formatYLabel(yVal, metric);
                     int labelW = fm.stringWidth(label);
                     g2.drawString(label, plotLeft - labelW - 4, py + fm.getAscent() / 2);
                 }
@@ -333,5 +347,21 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
             return v == (long) v ? (long) v + "K" : String.format("%.1fK", v);
         }
         return Long.toString(value);
+    }
+
+    private static String formatDuration(long minutes) {
+        if (minutes >= 60) {
+            long h = minutes / 60;
+            long m = minutes % 60;
+            return m == 0 ? h + "h" : h + "h " + m + "m";
+        }
+        return minutes + "m";
+    }
+
+    private static String formatYLabel(long value, UsageStatisticsData.Metric metric) {
+        if (metric == UsageStatisticsData.Metric.AGENT_TIME) {
+            return formatDuration(value);
+        }
+        return formatCompact(value);
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsChart.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsChart.java
@@ -77,33 +77,11 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
         LocalDate rangeStart = snapshot.startDate();
         LocalDate rangeEnd = snapshot.endDate();
 
-        Map<String, List<UsageStatisticsData.DailyAgentStats>> byAgent = snapshot.dailyStats().stream()
-            .collect(Collectors.groupingBy(UsageStatisticsData.DailyAgentStats::agentId));
-
-        List<DataSeries> seriesList = new ArrayList<>();
-
-        for (Map.Entry<String, List<UsageStatisticsData.DailyAgentStats>> entry : byAgent.entrySet()) {
-            String agentId = entry.getKey();
-            List<UsageStatisticsData.DailyAgentStats> agentStats = entry.getValue();
-
-            int colorIndex = ChatTheme.INSTANCE.agentColorIndex(agentId);
-            JBColor agentColor = ChatTheme.INSTANCE.getSA_COLORS()[colorIndex];
-
-            // Index metric values by date for O(1) lookup
-            Map<LocalDate, Long> valuesByDate = new LinkedHashMap<>();
-            for (UsageStatisticsData.DailyAgentStats stats : agentStats) {
-                valuesByDate.merge(stats.date(), extractMetricValue(stats), Long::sum);
-            }
-
-            // Fill every day in the selected range, using zero for days without data
-            List<DataPoint> points = new ArrayList<>();
-            for (LocalDate d = rangeStart; !d.isAfter(rangeEnd); d = d.plusDays(1)) {
-                long x = d.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
-                long y = valuesByDate.getOrDefault(d, 0L);
-                points.add(new DataPoint(x, y, d));
-            }
-
-            seriesList.add(new DataSeries(agentId, agentColor, points));
+        List<DataSeries> seriesList;
+        if (metric == UsageStatisticsData.Metric.CODE_CHANGES) {
+            seriesList = buildCodeChangeSeries(snapshot.dailyStats(), rangeStart, rangeEnd);
+        } else {
+            seriesList = buildStandardSeries(snapshot.dailyStats(), rangeStart, rangeEnd);
         }
 
         canvas.setData(seriesList);
@@ -113,6 +91,74 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
 
         revalidate();
         repaint();
+    }
+
+    private List<DataSeries> buildStandardSeries(
+        List<UsageStatisticsData.DailyAgentStats> dailyStats,
+        LocalDate rangeStart, LocalDate rangeEnd) {
+
+        Map<String, List<UsageStatisticsData.DailyAgentStats>> byAgent = dailyStats.stream()
+            .collect(Collectors.groupingBy(UsageStatisticsData.DailyAgentStats::agentId));
+
+        List<DataSeries> seriesList = new ArrayList<>();
+        for (var entry : byAgent.entrySet()) {
+            String agentId = entry.getKey();
+
+            Map<LocalDate, Long> valuesByDate = new LinkedHashMap<>();
+            for (UsageStatisticsData.DailyAgentStats stats : entry.getValue()) {
+                valuesByDate.merge(stats.date(), extractMetricValue(stats), Long::sum);
+            }
+
+            seriesList.add(new DataSeries(agentId, agentColor(agentId),
+                fillDateRange(valuesByDate, rangeStart, rangeEnd)));
+        }
+        return seriesList;
+    }
+
+    private List<DataSeries> buildCodeChangeSeries(
+        List<UsageStatisticsData.DailyAgentStats> dailyStats,
+        LocalDate rangeStart, LocalDate rangeEnd) {
+
+        Map<String, List<UsageStatisticsData.DailyAgentStats>> byAgent = dailyStats.stream()
+            .collect(Collectors.groupingBy(UsageStatisticsData.DailyAgentStats::agentId));
+
+        List<DataSeries> seriesList = new ArrayList<>();
+        for (var entry : byAgent.entrySet()) {
+            String agentId = entry.getKey();
+            JBColor color = agentColor(agentId);
+
+            Map<LocalDate, Long> addByDate = new LinkedHashMap<>();
+            Map<LocalDate, Long> removeByDate = new LinkedHashMap<>();
+            for (UsageStatisticsData.DailyAgentStats stats : entry.getValue()) {
+                addByDate.merge(stats.date(), (long) stats.linesAdded(), Long::sum);
+                removeByDate.merge(stats.date(), (long) stats.linesRemoved(), Long::sum);
+            }
+
+            seriesList.add(new DataSeries(agentId, color,
+                fillDateRange(addByDate, rangeStart, rangeEnd)));
+            // Negate removals so they render below the zero baseline
+            Map<LocalDate, Long> negRemoveByDate = new LinkedHashMap<>();
+            removeByDate.forEach((date, val) -> negRemoveByDate.put(date, -val));
+            seriesList.add(new DataSeries(agentId, color,
+                fillDateRange(negRemoveByDate, rangeStart, rangeEnd)));
+        }
+        return seriesList;
+    }
+
+    private static JBColor agentColor(String agentId) {
+        int colorIndex = ChatTheme.INSTANCE.agentColorIndex(agentId);
+        return ChatTheme.INSTANCE.getSA_COLORS()[colorIndex];
+    }
+
+    private static List<DataPoint> fillDateRange(Map<LocalDate, Long> valuesByDate,
+                                                 LocalDate start, LocalDate end) {
+        List<DataPoint> points = new ArrayList<>();
+        for (LocalDate d = start; !d.isAfter(end); d = d.plusDays(1)) {
+            long x = d.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+            long y = valuesByDate.getOrDefault(d, 0L);
+            points.add(new DataPoint(x, y, d));
+        }
+        return points;
     }
 
     private long extractMetricValue(UsageStatisticsData.DailyAgentStats stats) {
@@ -175,9 +221,11 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
             // Always include zero on the Y axis so bars are grounded
             yMin = Math.min(0, yLo);
             yMax = yHi;
-            // Pad the top by 10% so the peak isn't clipped against the border
+            // Pad top/bottom by 10% so peaks aren't clipped against the border
             if (yMax > yMin) {
-                yMax += (yMax - yMin) / 10;
+                long padding = (yMax - yMin) / 10;
+                yMax += padding;
+                if (yMin < 0) yMin -= padding;
             } else {
                 yMax = yMin + 1;
             }
@@ -233,6 +281,15 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
                 }
             }
 
+            // Draw a prominent zero baseline when the chart spans negative values
+            if (yMin < 0 && yMax > 0) {
+                int zeroY = plotBottom - (int) ((double) (-yMin) / (yMax - yMin) * plotH);
+                g2.setColor(GRID_LABEL_COLOR);
+                g2.setStroke(new BasicStroke(1.5f));
+                g2.drawLine(plotLeft, zeroY, plotRight, zeroY);
+                g2.setStroke(new BasicStroke(1.0f));
+            }
+
             // X-axis date labels
             List<LocalDate> dates = collectUniqueDates();
             if (!dates.isEmpty()) {
@@ -279,14 +336,15 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
                     }
                 }
 
-                // Build the fill path (extend line to bottom, close)
+                // Build the fill path (extend line to zero baseline, close)
                 Path2D.Double fillPath = new Path2D.Double(linePath);
                 DataPoint lastPt = points.getLast();
                 DataPoint firstPt = points.getFirst();
                 int lastPx = plotLeft + mapX(lastPt.x, plotW);
                 int firstPx = plotLeft + mapX(firstPt.x, plotW);
-                fillPath.lineTo(lastPx, plotBottom);
-                fillPath.lineTo(firstPx, plotBottom);
+                int zeroY = plotBottom - mapY(0, plotH);
+                fillPath.lineTo(lastPx, zeroY);
+                fillPath.lineTo(firstPx, zeroY);
                 fillPath.closePath();
 
                 // Clip to the plot area
@@ -338,6 +396,7 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
     }
 
     private static String formatCompact(long value) {
+        if (value < 0) return "-" + formatCompact(-value);
         if (value >= 1_000_000) {
             double v = value / 1_000_000.0;
             return v == (long) v ? (long) v + "M" : String.format("%.1fM", v);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsChart.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsChart.java
@@ -1,16 +1,15 @@
 package com.github.catatafishen.agentbridge.ui.statistics;
 
 import com.github.catatafishen.agentbridge.ui.ChatTheme;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.ui.JBColor;
-import com.intellij.ui.charts.Coordinates;
-import com.intellij.ui.charts.XYLineChart;
-import com.intellij.ui.charts.XYLineDataset;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBPanel;
 import com.intellij.util.ui.JBUI;
 
+import javax.swing.*;
 import java.awt.*;
-import java.time.Instant;
+import java.awt.geom.Path2D;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -20,21 +19,26 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * Chart component that wraps JetBrains' {@link XYLineChart} to display usage
- * metrics over time, with per-agent color coding.
- * <p>
- * {@code com.intellij.ui.charts} is marked {@code @ApiStatus.Experimental} but is the only
- * native JetBrains charting API. It has been stable since IntelliJ 2020.2 and there is no
- * non-experimental alternative. If the API changes in a future platform version, only this
- * class needs updating.
+ * Chart component that renders usage metrics over time using Java2D.
+ * Each agent gets its own colored line and fill area, stacked from the baseline.
  */
-@SuppressWarnings("UnstableApiUsage")
 class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
 
+    private static final Logger LOG = Logger.getInstance(UsageStatisticsChart.class);
     private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("MM/dd");
 
+    private static final int MARGIN_LEFT = 48;
+    private static final int MARGIN_RIGHT = 12;
+    private static final int MARGIN_TOP = 8;
+    private static final int MARGIN_BOTTOM = 24;
+
+    private static final Color GRID_LINE_COLOR = new JBColor(
+        new Color(220, 220, 220), new Color(60, 60, 60));
+    private static final Color GRID_LABEL_COLOR = new JBColor(
+        new Color(120, 120, 120), new Color(150, 150, 150));
+
     private final UsageStatisticsData.Metric metric;
-    private final XYLineChart<Long, Long> chart;
+    private final ChartCanvas canvas;
     private final JBLabel emptyLabel;
 
     UsageStatisticsChart(String title, UsageStatisticsData.Metric metric) {
@@ -47,9 +51,8 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
         titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD));
         add(titleLabel, BorderLayout.NORTH);
 
-        chart = new XYLineChart<>();
-        configureGrid();
-        add(chart.getComponent(), BorderLayout.CENTER);
+        canvas = new ChartCanvas();
+        add(canvas, BorderLayout.CENTER);
 
         emptyLabel = new JBLabel("No data");
         emptyLabel.setHorizontalAlignment(JBLabel.CENTER);
@@ -58,7 +61,7 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
 
     void update(UsageStatisticsData.StatisticsSnapshot snapshot) {
         if (snapshot == null || snapshot.dailyStats().isEmpty()) {
-            remove(chart.getComponent());
+            remove(canvas);
             emptyLabel.setVisible(true);
             add(emptyLabel, BorderLayout.CENTER);
             revalidate();
@@ -68,39 +71,35 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
 
         emptyLabel.setVisible(false);
         remove(emptyLabel);
-        add(chart.getComponent(), BorderLayout.CENTER);
+        add(canvas, BorderLayout.CENTER);
 
         Map<String, List<UsageStatisticsData.DailyAgentStats>> byAgent = snapshot.dailyStats().stream()
             .collect(Collectors.groupingBy(UsageStatisticsData.DailyAgentStats::agentId));
 
-        List<XYLineDataset<Long, Long>> datasets = new ArrayList<>();
+        List<DataSeries> seriesList = new ArrayList<>();
 
         for (Map.Entry<String, List<UsageStatisticsData.DailyAgentStats>> entry : byAgent.entrySet()) {
             String agentId = entry.getKey();
             List<UsageStatisticsData.DailyAgentStats> agentStats = entry.getValue();
 
-            XYLineDataset<Long, Long> dataset = new XYLineDataset<>();
-            dataset.setLabel(agentId);
-            dataset.setStacked(true);
-            dataset.setStroke(new BasicStroke(2.0f));
-
             int colorIndex = ChatTheme.INSTANCE.agentColorIndex(agentId);
             JBColor agentColor = ChatTheme.INSTANCE.getSA_COLORS()[colorIndex];
-            dataset.setLineColor(agentColor);
-            dataset.setFillColor(new Color(agentColor.getRed(), agentColor.getGreen(), agentColor.getBlue(), 38));
 
+            List<DataPoint> points = new ArrayList<>();
             for (UsageStatisticsData.DailyAgentStats stats : agentStats) {
                 long x = stats.date().atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
                 long y = extractMetricValue(stats);
-                //noinspection unchecked — varargs generic erasure in XYLineDataset.add(T...)
-                dataset.add(Coordinates.of(x, y));
+                points.add(new DataPoint(x, y, stats.date()));
             }
 
-            datasets.add(dataset);
+            seriesList.add(new DataSeries(agentId, agentColor, points));
         }
 
-        chart.setDatasets(datasets);
-        chart.update();
+        canvas.setData(seriesList);
+
+        long totalPoints = seriesList.stream().mapToInt(s -> s.points.size()).sum();
+        LOG.info("Chart '" + metric + "': " + seriesList.size() + " series, " + totalPoints + " points");
+
         revalidate();
         repaint();
     }
@@ -116,13 +115,212 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
         };
     }
 
-    private void configureGrid() {
-        chart.getRanges().setXPainter(gl -> {
-            long millis = gl.getValue();
-            gl.setLabel(LocalDate.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault())
-                .format(DATE_FMT));
-        });
-        chart.getRanges().setYPainter(gl -> gl.setLabel(formatCompact(gl.getValue())));
+    private record DataPoint(long x, long y, LocalDate date) {
+    }
+
+    private record DataSeries(String agentId, JBColor color, List<DataPoint> points) {
+    }
+
+    /**
+     * Custom JPanel that renders the chart using Java2D.
+     */
+    private static final class ChartCanvas extends JPanel {
+
+        private List<DataSeries> seriesList = List.of();
+        private long xMin, xMax, yMin, yMax;
+
+        ChartCanvas() {
+            setOpaque(false);
+        }
+
+        void setData(List<DataSeries> seriesList) {
+            this.seriesList = seriesList;
+            computeMinMax();
+            repaint();
+        }
+
+        private void computeMinMax() {
+            boolean first = true;
+            long xLo = 0, xHi = 0, yLo = 0, yHi = 0;
+            for (DataSeries series : seriesList) {
+                for (DataPoint pt : series.points) {
+                    if (first) {
+                        xLo = xHi = pt.x;
+                        yLo = yHi = pt.y;
+                        first = false;
+                    } else {
+                        xLo = Math.min(xLo, pt.x);
+                        xHi = Math.max(xHi, pt.x);
+                        yLo = Math.min(yLo, pt.y);
+                        yHi = Math.max(yHi, pt.y);
+                    }
+                }
+            }
+            xMin = xLo;
+            xMax = xHi;
+            // Always include zero on the Y axis so bars are grounded
+            yMin = Math.min(0, yLo);
+            yMax = yHi;
+            // Pad the top by 10% so the peak isn't clipped against the border
+            if (yMax > yMin) {
+                yMax += (yMax - yMin) / 10;
+            } else {
+                yMax = yMin + 1;
+            }
+        }
+
+        @Override
+        protected void paintComponent(Graphics g) {
+            super.paintComponent(g);
+            if (seriesList.isEmpty()) return;
+
+            Graphics2D g2 = (Graphics2D) g.create();
+            try {
+                g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+                g2.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+
+                int w = getWidth();
+                int h = getHeight();
+                int plotLeft = MARGIN_LEFT;
+                int plotRight = w - MARGIN_RIGHT;
+                int plotTop = MARGIN_TOP;
+                int plotBottom = h - MARGIN_BOTTOM;
+                int plotW = plotRight - plotLeft;
+                int plotH = plotBottom - plotTop;
+
+                if (plotW <= 0 || plotH <= 0) return;
+
+                paintGrid(g2, plotLeft, plotTop, plotW, plotH);
+                paintData(g2, plotLeft, plotTop, plotW, plotH);
+                paintBorder(g2, plotLeft, plotTop, plotW, plotH);
+            } finally {
+                g2.dispose();
+            }
+        }
+
+        private void paintGrid(Graphics2D g2, int plotLeft, int plotTop, int plotW, int plotH) {
+            g2.setFont(g2.getFont().deriveFont(Font.PLAIN, JBUI.scale(10f)));
+            FontMetrics fm = g2.getFontMetrics();
+            int plotBottom = plotTop + plotH;
+            int plotRight = plotLeft + plotW;
+
+            // Y-axis grid lines
+            int yTicks = computeNiceTickCount(plotH);
+            if (yTicks > 0 && yMax > yMin) {
+                for (int i = 0; i <= yTicks; i++) {
+                    long yVal = yMin + (yMax - yMin) * i / yTicks;
+                    int py = plotBottom - (int) ((double) (yVal - yMin) / (yMax - yMin) * plotH);
+                    g2.setColor(GRID_LINE_COLOR);
+                    g2.drawLine(plotLeft, py, plotRight, py);
+                    g2.setColor(GRID_LABEL_COLOR);
+                    String label = formatCompact(yVal);
+                    int labelW = fm.stringWidth(label);
+                    g2.drawString(label, plotLeft - labelW - 4, py + fm.getAscent() / 2);
+                }
+            }
+
+            // X-axis date labels
+            List<LocalDate> dates = collectUniqueDates();
+            if (!dates.isEmpty()) {
+                g2.setColor(GRID_LABEL_COLOR);
+                int labelY = plotBottom + fm.getAscent() + 4;
+                int prevLabelEnd = Integer.MIN_VALUE;
+                for (LocalDate date : dates) {
+                    long xVal = date.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+                    int px = plotLeft + mapX(xVal, plotW);
+                    String label = date.format(DATE_FMT);
+                    int labelW = fm.stringWidth(label);
+                    int labelStart = px - labelW / 2;
+                    // Skip overlapping labels
+                    if (labelStart > prevLabelEnd + 4) {
+                        g2.drawString(label, labelStart, labelY);
+                        prevLabelEnd = labelStart + labelW;
+                    }
+                }
+            }
+        }
+
+        private void paintData(Graphics2D g2, int plotLeft, int plotTop, int plotW, int plotH) {
+            int plotBottom = plotTop + plotH;
+
+            for (DataSeries series : seriesList) {
+                List<DataPoint> points = series.points;
+                if (points.isEmpty()) continue;
+
+                Color lineColor = series.color;
+                Color fillColor = new Color(
+                    lineColor.getRed(), lineColor.getGreen(), lineColor.getBlue(), 38);
+
+                // Build the line path
+                Path2D.Double linePath = new Path2D.Double();
+                boolean first = true;
+                for (DataPoint pt : points) {
+                    int px = plotLeft + mapX(pt.x, plotW);
+                    int py = plotBottom - mapY(pt.y, plotH);
+                    if (first) {
+                        linePath.moveTo(px, py);
+                        first = false;
+                    } else {
+                        linePath.lineTo(px, py);
+                    }
+                }
+
+                // Build the fill path (extend line to bottom, close)
+                Path2D.Double fillPath = new Path2D.Double(linePath);
+                DataPoint lastPt = points.getLast();
+                DataPoint firstPt = points.getFirst();
+                int lastPx = plotLeft + mapX(lastPt.x, plotW);
+                int firstPx = plotLeft + mapX(firstPt.x, plotW);
+                fillPath.lineTo(lastPx, plotBottom);
+                fillPath.lineTo(firstPx, plotBottom);
+                fillPath.closePath();
+
+                // Clip to the plot area
+                Shape oldClip = g2.getClip();
+                g2.clipRect(plotLeft, plotTop, plotW, plotH);
+
+                // Fill area
+                g2.setColor(fillColor);
+                g2.fill(fillPath);
+
+                // Draw line
+                g2.setColor(lineColor);
+                g2.setStroke(new BasicStroke(2.0f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+                g2.draw(linePath);
+
+                g2.setClip(oldClip);
+            }
+        }
+
+        private void paintBorder(Graphics2D g2, int plotLeft, int plotTop, int plotW, int plotH) {
+            g2.setColor(GRID_LINE_COLOR);
+            g2.drawRect(plotLeft, plotTop, plotW, plotH);
+        }
+
+        private int mapX(long xVal, int plotW) {
+            if (xMax == xMin) return plotW / 2;
+            return (int) ((double) (xVal - xMin) / (xMax - xMin) * plotW);
+        }
+
+        private int mapY(long yVal, int plotH) {
+            if (yMax == yMin) return plotH / 2;
+            return (int) ((double) (yVal - yMin) / (yMax - yMin) * plotH);
+        }
+
+        private List<LocalDate> collectUniqueDates() {
+            return seriesList.stream()
+                .flatMap(s -> s.points.stream())
+                .map(DataPoint::date)
+                .distinct()
+                .sorted()
+                .collect(Collectors.toList());
+        }
+
+        private static int computeNiceTickCount(int plotH) {
+            int minSpacing = JBUI.scale(40);
+            int maxTicks = Math.max(1, plotH / minSpacing);
+            return Math.min(maxTicks, 5);
+        }
     }
 
     private static String formatCompact(long value) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsChart.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsChart.java
@@ -199,7 +199,7 @@ class UsageStatisticsChart extends JBPanel<UsageStatisticsChart> {
         }
 
         private void paintGrid(Graphics2D g2, int plotLeft, int plotTop, int plotW, int plotH) {
-            g2.setFont(g2.getFont().deriveFont(Font.PLAIN, JBUI.scale(10f)));
+            g2.setFont(g2.getFont().deriveFont(Font.PLAIN, (float) JBUI.scale(10)));
             FontMetrics fm = g2.getFontMetrics();
             int plotBottom = plotTop + plotH;
             int plotRight = plotLeft + plotW;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsData.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsData.java
@@ -17,16 +17,16 @@ final class UsageStatisticsData {
      * Aggregated metrics for a single day and a single agent.
      */
     record DailyAgentStats(
-            LocalDate date,
-            String agentId,
-            int turns,
-            long inputTokens,
-            long outputTokens,
-            int toolCalls,
-            long durationMs,
-            int linesAdded,
-            int linesRemoved,
-            double premiumRequests
+        LocalDate date,
+        String agentId,
+        int turns,
+        long inputTokens,
+        long outputTokens,
+        int toolCalls,
+        long durationMs,
+        int linesAdded,
+        int linesRemoved,
+        double premiumRequests
     ) {
     }
 
@@ -34,11 +34,11 @@ final class UsageStatisticsData {
      * Complete statistics snapshot for a date range, ready for chart rendering.
      */
     record StatisticsSnapshot(
-            List<DailyAgentStats> dailyStats,
-            LocalDate startDate,
-            LocalDate endDate,
-            Set<String> agentIds,
-            Map<String, String> agentDisplayNames
+        List<DailyAgentStats> dailyStats,
+        LocalDate startDate,
+        LocalDate endDate,
+        Set<String> agentIds,
+        Map<String, String> agentDisplayNames
     ) {
         long totalTurns() {
             return dailyStats.stream().mapToInt(DailyAgentStats::turns).sum();
@@ -46,8 +46,8 @@ final class UsageStatisticsData {
 
         long totalTokens() {
             return dailyStats.stream()
-                    .mapToLong(s -> s.inputTokens() + s.outputTokens())
-                    .sum();
+                .mapToLong(s -> s.inputTokens() + s.outputTokens())
+                .sum();
         }
 
         long totalToolCalls() {
@@ -87,7 +87,7 @@ final class UsageStatisticsData {
 
         LocalDate startDate() {
             if (days < 0) return LocalDate.of(2020, 1, 1);
-            return LocalDate.now().minusDays(days);
+            return LocalDate.now().minusDays(days - 1L);
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsData.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsData.java
@@ -1,0 +1,112 @@
+package com.github.catatafishen.agentbridge.ui.statistics;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Data model for aggregated usage statistics.
+ */
+final class UsageStatisticsData {
+
+    private UsageStatisticsData() {
+    }
+
+    /**
+     * Aggregated metrics for a single day and a single agent.
+     */
+    record DailyAgentStats(
+            LocalDate date,
+            String agentId,
+            int turns,
+            long inputTokens,
+            long outputTokens,
+            int toolCalls,
+            long durationMs,
+            int linesAdded,
+            int linesRemoved,
+            double premiumRequests
+    ) {
+    }
+
+    /**
+     * Complete statistics snapshot for a date range, ready for chart rendering.
+     */
+    record StatisticsSnapshot(
+            List<DailyAgentStats> dailyStats,
+            LocalDate startDate,
+            LocalDate endDate,
+            Set<String> agentIds,
+            Map<String, String> agentDisplayNames
+    ) {
+        long totalTurns() {
+            return dailyStats.stream().mapToInt(DailyAgentStats::turns).sum();
+        }
+
+        long totalTokens() {
+            return dailyStats.stream()
+                    .mapToLong(s -> s.inputTokens() + s.outputTokens())
+                    .sum();
+        }
+
+        long totalToolCalls() {
+            return dailyStats.stream().mapToInt(DailyAgentStats::toolCalls).sum();
+        }
+
+        long totalDurationMs() {
+            return dailyStats.stream().mapToLong(DailyAgentStats::durationMs).sum();
+        }
+
+        double totalPremiumRequests() {
+            return dailyStats.stream().mapToDouble(DailyAgentStats::premiumRequests).sum();
+        }
+    }
+
+    enum TimeRange {
+        WEEK_7("7 days", 7),
+        MONTH_30("30 days", 30),
+        QUARTER_90("90 days", 90),
+        ALL("All time", -1);
+
+        private final String label;
+        private final int days;
+
+        TimeRange(String label, int days) {
+            this.label = label;
+            this.days = days;
+        }
+
+        String label() {
+            return label;
+        }
+
+        int days() {
+            return days;
+        }
+
+        LocalDate startDate() {
+            if (days < 0) return LocalDate.of(2020, 1, 1);
+            return LocalDate.now().minusDays(days);
+        }
+    }
+
+    enum Metric {
+        PREMIUM_REQUESTS("Premium Requests"),
+        TURNS("Turns"),
+        TOKENS("Tokens"),
+        TOOL_CALLS("Tool Calls"),
+        CODE_CHANGES("Code Changes (lines)"),
+        AGENT_TIME("Agent Time");
+
+        private final String displayName;
+
+        Metric(String displayName) {
+            this.displayName = displayName;
+        }
+
+        String displayName() {
+            return displayName;
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsDialog.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsDialog.java
@@ -1,0 +1,47 @@
+package com.github.catatafishen.agentbridge.ui.statistics;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.util.ui.JBUI;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Dialog that hosts a {@link UsageStatisticsPanel} for viewing aggregated usage
+ * statistics across all agent sessions.
+ */
+public class UsageStatisticsDialog extends DialogWrapper {
+
+    private final Project project;
+
+    public UsageStatisticsDialog(@NotNull Project project) {
+        super(project, false);
+        this.project = project;
+        setTitle("Usage Statistics");
+        setOKButtonText("Close");
+        init();
+    }
+
+    @Override
+    protected @Nullable JComponent createCenterPanel() {
+        return new UsageStatisticsPanel(project);
+    }
+
+    @Override
+    protected @NotNull String getDimensionServiceKey() {
+        return "AgentBridge.UsageStatistics";
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return JBUI.size(900, 600);
+    }
+
+    @Override
+    protected Action @NotNull [] createActions() {
+        return new Action[]{getOKAction()};
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonParser;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -18,7 +19,13 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Loads session data from V2 JSONL files and aggregates into daily per-agent statistics.
@@ -31,9 +38,6 @@ final class UsageStatisticsLoader {
     private UsageStatisticsLoader() {
     }
 
-    /**
-     * Loads and aggregates usage statistics for the given project and time range.
-     */
     static UsageStatisticsData.StatisticsSnapshot load(@NotNull Project project,
                                                        @NotNull UsageStatisticsData.TimeRange range) {
         LocalDate startDate = range.startDate();
@@ -41,8 +45,9 @@ final class UsageStatisticsLoader {
 
         String basePath = project.getBasePath();
         List<SessionStoreV2.SessionRecord> sessions =
-                SessionStoreV2.getInstance(project).listSessions(basePath);
+            SessionStoreV2.getInstance(project).listSessions(basePath);
         if (sessions.isEmpty()) {
+            LOG.debug("Statistics: no sessions found for basePath=" + basePath);
             return emptySnapshot(startDate, endDate);
         }
 
@@ -59,32 +64,38 @@ final class UsageStatisticsLoader {
             agentDisplayNames.putIfAbsent(agentId, agentDisplay);
 
             Path jsonlPath = sessionsDir.toPath().resolve(session.id() + ".jsonl");
-            if (!Files.exists(jsonlPath)) continue;
+            if (!Files.exists(jsonlPath)) {
+                LOG.debug("Statistics: JSONL file not found: " + jsonlPath);
+                continue;
+            }
 
             collectTurnStats(jsonlPath, agentId, startDate, endDate, accumulators);
         }
 
         List<UsageStatisticsData.DailyAgentStats> dailyStats = buildDailyStats(accumulators);
+        LOG.debug("Statistics: loaded " + sessions.size() + " sessions, "
+            + accumulators.size() + " day/agent buckets, "
+            + dailyStats.stream().mapToInt(UsageStatisticsData.DailyAgentStats::turns).sum() + " total turns");
 
         return new UsageStatisticsData.StatisticsSnapshot(
-                dailyStats, startDate, endDate, agentIds, agentDisplayNames);
+            dailyStats, startDate, endDate, agentIds, agentDisplayNames);
     }
 
     private static List<UsageStatisticsData.DailyAgentStats> buildDailyStats(
-            Map<DayAgentKey, Accumulator> accumulators) {
+        Map<DayAgentKey, Accumulator> accumulators) {
         List<UsageStatisticsData.DailyAgentStats> result = new ArrayList<>();
         for (var entry : accumulators.entrySet()) {
             DayAgentKey key = entry.getKey();
             Accumulator acc = entry.getValue();
             result.add(new UsageStatisticsData.DailyAgentStats(
-                    key.date, key.agentId,
-                    acc.turns, acc.inputTokens, acc.outputTokens,
-                    acc.toolCalls, acc.durationMs,
-                    acc.linesAdded, acc.linesRemoved, acc.premiumRequests
+                key.date, key.agentId,
+                acc.turns, acc.inputTokens, acc.outputTokens,
+                acc.toolCalls, acc.durationMs,
+                acc.linesAdded, acc.linesRemoved, acc.premiumRequests
             ));
         }
         result.sort(Comparator.comparing(UsageStatisticsData.DailyAgentStats::date)
-                .thenComparing(UsageStatisticsData.DailyAgentStats::agentId));
+            .thenComparing(UsageStatisticsData.DailyAgentStats::agentId));
         return result;
     }
 
@@ -92,42 +103,67 @@ final class UsageStatisticsLoader {
                                          LocalDate startDate, LocalDate endDate,
                                          Map<DayAgentKey, Accumulator> accumulators) {
         try (BufferedReader reader = Files.newBufferedReader(jsonlPath)) {
+            String lastSeenTimestamp = null;
             String line;
             while ((line = reader.readLine()) != null) {
+                // Track timestamps from all entries for date attribution.
+                // TurnStats entries lack their own timestamp, so we use the
+                // most recent timestamp from a preceding entry (prompt/text/tool).
+                int tsIdx = line.indexOf("\"timestamp\":\"");
+                if (tsIdx >= 0) {
+                    int start = tsIdx + "\"timestamp\":\"".length();
+                    int end = line.indexOf('"', start);
+                    if (end > start) {
+                        String candidate = line.substring(start, end);
+                        if (!candidate.isEmpty()) {
+                            lastSeenTimestamp = candidate;
+                        }
+                    }
+                }
+
                 if (!line.contains("\"turnStats\"")) continue;
 
-                JsonObject obj = JsonParser.parseString(line).getAsJsonObject();
-                EntryData entry = EntryDataJsonAdapter.deserialize(obj);
-                if (!(entry instanceof EntryData.TurnStats stats)) continue;
+                try {
+                    JsonObject obj = JsonParser.parseString(line).getAsJsonObject();
+                    EntryData entry = EntryDataJsonAdapter.deserialize(obj);
+                    if (!(entry instanceof EntryData.TurnStats stats)) continue;
 
-                LocalDate date = extractDate(obj);
-                if (date == null || date.isBefore(startDate) || date.isAfter(endDate)) continue;
+                    LocalDate date = extractDate(obj, lastSeenTimestamp);
+                    if (date.isBefore(startDate) || date.isAfter(endDate)) continue;
 
-                DayAgentKey key = new DayAgentKey(date, agentId);
-                Accumulator acc = accumulators.computeIfAbsent(key, k -> new Accumulator());
-                acc.turns++;
-                acc.inputTokens += stats.getInputTokens();
-                acc.outputTokens += stats.getOutputTokens();
-                acc.toolCalls += stats.getToolCallCount();
-                acc.durationMs += stats.getDurationMs();
-                acc.linesAdded += stats.getLinesAdded();
-                acc.linesRemoved += stats.getLinesRemoved();
-                acc.premiumRequests += parsePremiumMultiplier(stats.getMultiplier());
+                    DayAgentKey key = new DayAgentKey(date, agentId);
+                    Accumulator acc = accumulators.computeIfAbsent(key, k -> new Accumulator());
+                    acc.turns++;
+                    acc.inputTokens += stats.getInputTokens();
+                    acc.outputTokens += stats.getOutputTokens();
+                    acc.toolCalls += stats.getToolCallCount();
+                    acc.durationMs += stats.getDurationMs();
+                    acc.linesAdded += stats.getLinesAdded();
+                    acc.linesRemoved += stats.getLinesRemoved();
+                    acc.premiumRequests += parsePremiumMultiplier(stats.getMultiplier());
+                } catch (Exception e) {
+                    LOG.debug("Skipping malformed JSONL line in " + jsonlPath.getFileName() + ": " + e.getMessage());
+                }
             }
         } catch (IOException e) {
             LOG.warn("Failed to read session file: " + jsonlPath, e);
         }
     }
 
-    private static LocalDate extractDate(JsonObject obj) {
+    private static LocalDate extractDate(JsonObject obj, @Nullable String fallbackTimestamp) {
+        String ts = null;
         if (obj.has("timestamp")) {
-            String ts = obj.get("timestamp").getAsString();
-            if (!ts.isEmpty()) {
-                try {
-                    return Instant.parse(ts).atZone(ZoneId.systemDefault()).toLocalDate();
-                } catch (Exception ignored) {
-                    // Fall through to default
-                }
+            String val = obj.get("timestamp").getAsString();
+            if (!val.isEmpty()) ts = val;
+        }
+        if (ts == null && fallbackTimestamp != null) {
+            ts = fallbackTimestamp;
+        }
+        if (ts != null) {
+            try {
+                return Instant.parse(ts).atZone(ZoneId.systemDefault()).toLocalDate();
+            } catch (Exception ignored) {
+                // Unparseable timestamp — fall through
             }
         }
         return LocalDate.now();
@@ -151,8 +187,12 @@ final class UsageStatisticsLoader {
 
     private static double parsePremiumMultiplier(String multiplier) {
         if (multiplier == null || multiplier.isEmpty()) return 1.0;
+        // Strip trailing "x" suffix (e.g. "1x", "0.5x") before parsing
+        String cleaned = multiplier.endsWith("x")
+            ? multiplier.substring(0, multiplier.length() - 1)
+            : multiplier;
         try {
-            return Double.parseDouble(multiplier);
+            return Double.parseDouble(cleaned);
         } catch (NumberFormatException e) {
             return 1.0;
         }
@@ -160,7 +200,7 @@ final class UsageStatisticsLoader {
 
     private static UsageStatisticsData.StatisticsSnapshot emptySnapshot(LocalDate start, LocalDate end) {
         return new UsageStatisticsData.StatisticsSnapshot(
-                List.of(), start, end, Set.of(), Map.of());
+            List.of(), start, end, Set.of(), Map.of());
     }
 
     private record DayAgentKey(LocalDate date, String agentId) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
@@ -116,8 +116,8 @@ final class UsageStatisticsLoader {
             String line;
             while ((line = reader.readLine()) != null) {
                 // Track timestamps from all entries for date attribution.
-                // TurnStats entries lack their own timestamp, so we use the
-                // most recent timestamp from a preceding entry (prompt/text/tool).
+                // TurnStats entries added before v2.5 lack their own timestamp, so we also
+                // track the most recent timestamp seen in any preceding entry as a fallback.
                 int tsIdx = line.indexOf("\"timestamp\":\"");
                 if (tsIdx >= 0) {
                     int start = tsIdx + "\"timestamp\":\"".length();
@@ -138,6 +138,10 @@ final class UsageStatisticsLoader {
                     if (!(entry instanceof EntryData.TurnStats stats)) continue;
 
                     LocalDate date = extractDate(obj, lastSeenTimestamp);
+                    if (date == null) {
+                        LOG.debug("Skipping TurnStats entry with no resolvable timestamp in " + jsonlPath.getFileName());
+                        continue;
+                    }
                     if (date.isBefore(startDate) || date.isAfter(endDate)) continue;
 
                     DayAgentKey key = new DayAgentKey(date, agentId);
@@ -159,6 +163,7 @@ final class UsageStatisticsLoader {
         }
     }
 
+    @Nullable
     private static LocalDate extractDate(JsonObject obj, @Nullable String fallbackTimestamp) {
         String ts = null;
         if (obj.has("timestamp")) {
@@ -175,7 +180,7 @@ final class UsageStatisticsLoader {
                 // Unparseable timestamp — fall through
             }
         }
-        return LocalDate.now();
+        return null;
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
@@ -1,0 +1,179 @@
+package com.github.catatafishen.agentbridge.ui.statistics;
+
+import com.github.catatafishen.agentbridge.session.exporters.ExportUtils;
+import com.github.catatafishen.agentbridge.session.v2.EntryDataJsonAdapter;
+import com.github.catatafishen.agentbridge.session.v2.SessionStoreV2;
+import com.github.catatafishen.agentbridge.ui.EntryData;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.*;
+
+/**
+ * Loads session data from V2 JSONL files and aggregates into daily per-agent statistics.
+ * Scans only {@code TurnStats} entries for efficiency — all other entry types are skipped.
+ */
+final class UsageStatisticsLoader {
+
+    private static final Logger LOG = Logger.getInstance(UsageStatisticsLoader.class);
+
+    private UsageStatisticsLoader() {
+    }
+
+    /**
+     * Loads and aggregates usage statistics for the given project and time range.
+     */
+    static UsageStatisticsData.StatisticsSnapshot load(@NotNull Project project,
+                                                       @NotNull UsageStatisticsData.TimeRange range) {
+        LocalDate startDate = range.startDate();
+        LocalDate endDate = LocalDate.now();
+
+        String basePath = project.getBasePath();
+        List<SessionStoreV2.SessionRecord> sessions =
+                SessionStoreV2.getInstance(project).listSessions(basePath);
+        if (sessions.isEmpty()) {
+            return emptySnapshot(startDate, endDate);
+        }
+
+        Map<DayAgentKey, Accumulator> accumulators = new LinkedHashMap<>();
+        Set<String> agentIds = new LinkedHashSet<>();
+        Map<String, String> agentDisplayNames = new LinkedHashMap<>();
+
+        File sessionsDir = ExportUtils.sessionsDir(basePath);
+
+        for (SessionStoreV2.SessionRecord session : sessions) {
+            String agentDisplay = session.agent();
+            String agentId = toAgentId(agentDisplay);
+            agentIds.add(agentId);
+            agentDisplayNames.putIfAbsent(agentId, agentDisplay);
+
+            Path jsonlPath = sessionsDir.toPath().resolve(session.id() + ".jsonl");
+            if (!Files.exists(jsonlPath)) continue;
+
+            collectTurnStats(jsonlPath, agentId, startDate, endDate, accumulators);
+        }
+
+        List<UsageStatisticsData.DailyAgentStats> dailyStats = buildDailyStats(accumulators);
+
+        return new UsageStatisticsData.StatisticsSnapshot(
+                dailyStats, startDate, endDate, agentIds, agentDisplayNames);
+    }
+
+    private static List<UsageStatisticsData.DailyAgentStats> buildDailyStats(
+            Map<DayAgentKey, Accumulator> accumulators) {
+        List<UsageStatisticsData.DailyAgentStats> result = new ArrayList<>();
+        for (var entry : accumulators.entrySet()) {
+            DayAgentKey key = entry.getKey();
+            Accumulator acc = entry.getValue();
+            result.add(new UsageStatisticsData.DailyAgentStats(
+                    key.date, key.agentId,
+                    acc.turns, acc.inputTokens, acc.outputTokens,
+                    acc.toolCalls, acc.durationMs,
+                    acc.linesAdded, acc.linesRemoved, acc.premiumRequests
+            ));
+        }
+        result.sort(Comparator.comparing(UsageStatisticsData.DailyAgentStats::date)
+                .thenComparing(UsageStatisticsData.DailyAgentStats::agentId));
+        return result;
+    }
+
+    private static void collectTurnStats(Path jsonlPath, String agentId,
+                                         LocalDate startDate, LocalDate endDate,
+                                         Map<DayAgentKey, Accumulator> accumulators) {
+        try (BufferedReader reader = Files.newBufferedReader(jsonlPath)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (!line.contains("\"turnStats\"")) continue;
+
+                JsonObject obj = JsonParser.parseString(line).getAsJsonObject();
+                EntryData entry = EntryDataJsonAdapter.deserialize(obj);
+                if (!(entry instanceof EntryData.TurnStats stats)) continue;
+
+                LocalDate date = extractDate(obj);
+                if (date == null || date.isBefore(startDate) || date.isAfter(endDate)) continue;
+
+                DayAgentKey key = new DayAgentKey(date, agentId);
+                Accumulator acc = accumulators.computeIfAbsent(key, k -> new Accumulator());
+                acc.turns++;
+                acc.inputTokens += stats.getInputTokens();
+                acc.outputTokens += stats.getOutputTokens();
+                acc.toolCalls += stats.getToolCallCount();
+                acc.durationMs += stats.getDurationMs();
+                acc.linesAdded += stats.getLinesAdded();
+                acc.linesRemoved += stats.getLinesRemoved();
+                acc.premiumRequests += parsePremiumMultiplier(stats.getMultiplier());
+            }
+        } catch (IOException e) {
+            LOG.warn("Failed to read session file: " + jsonlPath, e);
+        }
+    }
+
+    private static LocalDate extractDate(JsonObject obj) {
+        if (obj.has("timestamp")) {
+            String ts = obj.get("timestamp").getAsString();
+            if (!ts.isEmpty()) {
+                try {
+                    return Instant.parse(ts).atZone(ZoneId.systemDefault()).toLocalDate();
+                } catch (Exception ignored) {
+                    // Fall through to default
+                }
+            }
+        }
+        return LocalDate.now();
+    }
+
+    /**
+     * Maps agent display names (e.g. "GitHub Copilot") to profile IDs (e.g. "copilot")
+     * for color lookup via {@code ChatTheme.agentColorIndex()}.
+     */
+    static String toAgentId(String agentDisplayName) {
+        if (agentDisplayName == null || agentDisplayName.isEmpty()) return "unknown";
+        String lower = agentDisplayName.toLowerCase();
+        if (lower.contains("copilot")) return "copilot";
+        if (lower.contains("claude")) return "claude-cli";
+        if (lower.contains("opencode")) return "opencode";
+        if (lower.contains("junie")) return "junie";
+        if (lower.contains("kiro")) return "kiro";
+        if (lower.contains("codex")) return "codex";
+        return lower.replaceAll("[^a-z0-9]", "-");
+    }
+
+    private static double parsePremiumMultiplier(String multiplier) {
+        if (multiplier == null || multiplier.isEmpty()) return 1.0;
+        try {
+            return Double.parseDouble(multiplier);
+        } catch (NumberFormatException e) {
+            return 1.0;
+        }
+    }
+
+    private static UsageStatisticsData.StatisticsSnapshot emptySnapshot(LocalDate start, LocalDate end) {
+        return new UsageStatisticsData.StatisticsSnapshot(
+                List.of(), start, end, Set.of(), Map.of());
+    }
+
+    private record DayAgentKey(LocalDate date, String agentId) {
+    }
+
+    private static final class Accumulator {
+        int turns;
+        long inputTokens;
+        long outputTokens;
+        int toolCalls;
+        long durationMs;
+        int linesAdded;
+        int linesRemoved;
+        double premiumRequests;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
@@ -47,7 +47,7 @@ final class UsageStatisticsLoader {
         List<SessionStoreV2.SessionRecord> sessions =
             SessionStoreV2.getInstance(project).listSessions(basePath);
         if (sessions.isEmpty()) {
-            LOG.debug("Statistics: no sessions found for basePath=" + basePath);
+            LOG.info("Statistics: no sessions found for basePath=" + basePath);
             return emptySnapshot(startDate, endDate);
         }
 
@@ -73,9 +73,18 @@ final class UsageStatisticsLoader {
         }
 
         List<UsageStatisticsData.DailyAgentStats> dailyStats = buildDailyStats(accumulators);
-        LOG.debug("Statistics: loaded " + sessions.size() + " sessions, "
+        LOG.info("Statistics: loaded " + sessions.size() + " sessions, "
             + accumulators.size() + " day/agent buckets, "
             + dailyStats.stream().mapToInt(UsageStatisticsData.DailyAgentStats::turns).sum() + " total turns");
+
+        // For "all time", start from the earliest data date instead of 2020-01-01
+        // to avoid creating thousands of zero-fill points in the chart
+        if (range == UsageStatisticsData.TimeRange.ALL && !accumulators.isEmpty()) {
+            startDate = accumulators.keySet().stream()
+                .map(DayAgentKey::date)
+                .min(Comparator.naturalOrder())
+                .orElse(startDate);
+        }
 
         return new UsageStatisticsData.StatisticsSnapshot(
             dailyStats, startDate, endDate, agentIds, agentDisplayNames);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsPanel.java
@@ -1,0 +1,148 @@
+package com.github.catatafishen.agentbridge.ui.statistics;
+
+import com.github.catatafishen.agentbridge.ui.ChatTheme;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.ComboBox;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBPanel;
+import com.intellij.util.ui.JBUI;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Main panel displaying usage statistics with a time-range selector, a legend,
+ * and six metric charts arranged in a 2×3 grid.
+ */
+class UsageStatisticsPanel extends JBPanel<UsageStatisticsPanel> {
+
+    private final Project project;
+    private final ComboBox<UsageStatisticsData.TimeRange> rangeCombo;
+    private final Map<UsageStatisticsData.Metric, UsageStatisticsChart> charts = new EnumMap<>(UsageStatisticsData.Metric.class);
+    private final JPanel legendContainer;
+
+    UsageStatisticsPanel(Project project) {
+        super(new BorderLayout());
+        this.project = project;
+        setBorder(JBUI.Borders.empty(12));
+
+        // --- NORTH: toolbar with time-range selector + legend ---
+        JPanel toolbar = new JPanel(new BorderLayout());
+
+        JPanel selectorPanel = new JPanel();
+        selectorPanel.setLayout(new BoxLayout(selectorPanel, BoxLayout.X_AXIS));
+        selectorPanel.add(new JBLabel("Period:"));
+        selectorPanel.add(Box.createHorizontalStrut(JBUI.scale(6)));
+
+        rangeCombo = new ComboBox<>(UsageStatisticsData.TimeRange.values());
+        rangeCombo.setSelectedItem(UsageStatisticsData.TimeRange.MONTH_30);
+        rangeCombo.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index,
+                                                          boolean isSelected, boolean cellHasFocus) {
+                super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+                if (value instanceof UsageStatisticsData.TimeRange timeRange) {
+                    setText(timeRange.label());
+                }
+                return this;
+            }
+        });
+        rangeCombo.addActionListener(e -> {
+            UsageStatisticsData.TimeRange selected = (UsageStatisticsData.TimeRange) rangeCombo.getSelectedItem();
+            if (selected != null) {
+                loadData(selected);
+            }
+        });
+        selectorPanel.add(rangeCombo);
+        toolbar.add(selectorPanel, BorderLayout.WEST);
+
+        legendContainer = new JPanel();
+        legendContainer.setLayout(new BoxLayout(legendContainer, BoxLayout.X_AXIS));
+        toolbar.add(legendContainer, BorderLayout.EAST);
+
+        add(toolbar, BorderLayout.NORTH);
+
+        // --- CENTER: 2×3 grid of charts ---
+        JPanel chartGrid = new JPanel(new GridLayout(2, 3, JBUI.scale(12), JBUI.scale(12)));
+        for (UsageStatisticsData.Metric metric : UsageStatisticsData.Metric.values()) {
+            UsageStatisticsChart chart = new UsageStatisticsChart(metric.displayName(), metric);
+            charts.put(metric, chart);
+            chartGrid.add(chart);
+        }
+        add(chartGrid, BorderLayout.CENTER);
+
+        // --- Initial load ---
+        loadData(UsageStatisticsData.TimeRange.MONTH_30);
+    }
+
+    private void loadData(UsageStatisticsData.TimeRange range) {
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            UsageStatisticsData.StatisticsSnapshot snapshot = UsageStatisticsLoader.load(project, range);
+            ApplicationManager.getApplication().invokeLater(() -> updateCharts(snapshot));
+        });
+    }
+
+    private void updateCharts(UsageStatisticsData.StatisticsSnapshot snapshot) {
+        for (UsageStatisticsChart chart : charts.values()) {
+            chart.update(snapshot);
+        }
+        legendContainer.removeAll();
+        JPanel legend = buildLegend(snapshot);
+        legendContainer.add(legend);
+        legendContainer.revalidate();
+        legendContainer.repaint();
+    }
+
+    private JPanel buildLegend(UsageStatisticsData.StatisticsSnapshot snapshot) {
+        JPanel legend = new JPanel();
+        legend.setLayout(new BoxLayout(legend, BoxLayout.X_AXIS));
+
+        for (String agentId : snapshot.agentIds()) {
+            int colorIndex = ChatTheme.INSTANCE.agentColorIndex(agentId);
+            JBColor color = ChatTheme.INSTANCE.getSA_COLORS()[colorIndex];
+            String displayName = snapshot.agentDisplayNames().get(agentId);
+
+            if (legend.getComponentCount() > 0) {
+                legend.add(Box.createHorizontalStrut(JBUI.scale(12)));
+            }
+
+            legend.add(new JLabel(new ColorDotIcon(color, JBUI.scale(8))));
+            legend.add(Box.createHorizontalStrut(JBUI.scale(4)));
+            legend.add(new JBLabel(displayName != null ? displayName : agentId));
+        }
+
+        return legend;
+    }
+
+    /**
+     * Small filled-circle icon used in the legend.
+     */
+    private record ColorDotIcon(Color color, int size) implements Icon {
+
+        @Override
+        public void paintIcon(Component c, Graphics g, int x, int y) {
+            Graphics2D g2 = (Graphics2D) g.create();
+            try {
+                g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+                g2.setColor(color);
+                g2.fillOval(x, y, size, size);
+            } finally {
+                g2.dispose();
+            }
+        }
+
+        @Override
+        public int getIconWidth() {
+            return size;
+        }
+
+        @Override
+        public int getIconHeight() {
+            return size;
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsPanel.java
@@ -91,7 +91,10 @@ class UsageStatisticsPanel extends JBPanel<UsageStatisticsPanel> {
                 UsageStatisticsData.StatisticsSnapshot snapshot = UsageStatisticsLoader.load(project, range);
                 LOG.info("Statistics panel: loaded " + snapshot.dailyStats().size()
                     + " daily stats, " + snapshot.agentIds().size() + " agents");
-                ApplicationManager.getApplication().invokeLater(() -> updateCharts(snapshot), modality);
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    if (project.isDisposed()) return;
+                    updateCharts(snapshot);
+                }, modality);
             } catch (Exception e) {
                 LOG.error("Statistics panel: failed to load data for range " + range, e);
             }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsPanel.java
@@ -2,6 +2,8 @@ package com.github.catatafishen.agentbridge.ui.statistics;
 
 import com.github.catatafishen.agentbridge.ui.ChatTheme;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.ui.JBColor;
@@ -19,6 +21,8 @@ import java.util.Map;
  * and six metric charts arranged in a 2×3 grid.
  */
 class UsageStatisticsPanel extends JBPanel<UsageStatisticsPanel> {
+
+    private static final Logger LOG = Logger.getInstance(UsageStatisticsPanel.class);
 
     private final Project project;
     private final ComboBox<UsageStatisticsData.TimeRange> rangeCombo;
@@ -80,9 +84,17 @@ class UsageStatisticsPanel extends JBPanel<UsageStatisticsPanel> {
     }
 
     private void loadData(UsageStatisticsData.TimeRange range) {
+        // Use ModalityState.any() so the callback runs even inside a modal dialog
+        ModalityState modality = ModalityState.any();
         ApplicationManager.getApplication().executeOnPooledThread(() -> {
-            UsageStatisticsData.StatisticsSnapshot snapshot = UsageStatisticsLoader.load(project, range);
-            ApplicationManager.getApplication().invokeLater(() -> updateCharts(snapshot));
+            try {
+                UsageStatisticsData.StatisticsSnapshot snapshot = UsageStatisticsLoader.load(project, range);
+                LOG.info("Statistics panel: loaded " + snapshot.dailyStats().size()
+                    + " daily stats, " + snapshot.agentIds().size() + " agents");
+                ApplicationManager.getApplication().invokeLater(() -> updateCharts(snapshot), modality);
+            } catch (Exception e) {
+                LOG.error("Statistics panel: failed to load data for range " + range, e);
+            }
         });
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/v2/EntryDataJsonAdapterTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/v2/EntryDataJsonAdapterTest.java
@@ -396,6 +396,7 @@ class EntryDataJsonAdapterTest {
             "t3", 45230, 1200, 3500, 0.015, 8, 42, 7,
             "claude-opus-4.6", "5x",
             120000, 5000, 15000, 0.065, 25, 150, 30,
+            "2026-04-10T09:00:00Z",
             "eid-stats-1"
         );
         JsonObject json = EntryDataJsonAdapter.serialize(stats);
@@ -417,6 +418,7 @@ class EntryDataJsonAdapterTest {
         assertEquals(25, json.get("totalToolCalls").getAsInt());
         assertEquals(150, json.get("totalLinesAdded").getAsInt());
         assertEquals(30, json.get("totalLinesRemoved").getAsInt());
+        assertEquals("2026-04-10T09:00:00Z", json.get("timestamp").getAsString());
         assertEquals("eid-stats-1", json.get("entryId").getAsString());
 
         EntryData deserialized = EntryDataJsonAdapter.deserialize(json);
@@ -439,6 +441,7 @@ class EntryDataJsonAdapterTest {
         assertEquals(25, rt.getTotalToolCalls());
         assertEquals(150, rt.getTotalLinesAdded());
         assertEquals(30, rt.getTotalLinesRemoved());
+        assertEquals("2026-04-10T09:00:00Z", rt.getTimestamp());
         assertEquals("eid-stats-1", rt.getEntryId());
     }
 
@@ -459,6 +462,7 @@ class EntryDataJsonAdapterTest {
         assertFalse(json.has("linesRemoved"), "zero linesRemoved should be omitted");
         assertFalse(json.has("model"), "empty model should be omitted");
         assertFalse(json.has("multiplier"), "empty multiplier should be omitted");
+        assertFalse(json.has("timestamp"), "empty timestamp should be omitted");
         assertTrue(json.has("entryId"), "entryId should always be present");
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2Test.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2Test.java
@@ -790,7 +790,7 @@ class SessionStoreV2Test {
             new EntryData.Status("✓", "Done", "st1"),
             new EntryData.SessionSeparator("2024-01-01T00:00:05Z", "copilot", "sep1"),
             new EntryData.TurnStats("turn-1", 5000L, 1000L, 500L, 0.05, 3, 10, 2,
-                "gpt-4", "1x", 10000L, 2000L, 1000L, 0.10, 6, 20, 4, "ts1")
+                "gpt-4", "1x", 10000L, 2000L, 1000L, 0.10, 6, 20, 4, "", "ts1")
         );
 
         String jsonl = toJsonl(originals);
@@ -962,6 +962,7 @@ class SessionStoreV2Test {
             25,        // totalToolCalls
             500,       // totalLinesAdded
             100,       // totalLinesRemoved
+            "",        // timestamp
             "ts-42"
         );
 
@@ -994,7 +995,7 @@ class SessionStoreV2Test {
     @Test
     void roundTrip_turnStatsWithZeroValues() {
         EntryData.TurnStats original = new EntryData.TurnStats(
-            "turn-empty", 0, 0, 0, 0.0, 0, 0, 0, "", "", 0, 0, 0, 0.0, 0, 0, 0, "ts-zero");
+            "turn-empty", 0, 0, 0, 0.0, 0, 0, 0, "", "", 0, 0, 0, 0.0, 0, 0, 0, "", "ts-zero");
 
         String jsonl = toJsonl(List.of(original));
         List<EntryData> loaded = SessionStoreV2.parseJsonlAutoDetect(jsonl);


### PR DESCRIPTION
## Summary

Adds a **Usage Statistics** button to the AgentBridge title bar that opens a dialog with six metric charts, aggregated from V2 JSONL session data.

### Charts
- **Premium Requests** — tracks premium/multiplied requests per agent
- **Turns** — conversation turn count over time
- **Tokens** — input + output token usage
- **Tool Calls** — MCP tool invocation count
- **Code Changes** — lines added + removed
- **Agent Time** — total agent processing time (seconds)

### Features
- Time range selector (7 days / 30 days / 90 days / All time)
- Per-agent color coding using existing SA_COLORS palette
- Stacked area charts with JetBrains native `XYLineChart`
- Legend with agent display names and colored dots
- Background data loading (no UI freeze)
- Dialog remembers window size/position via `DimensionServiceKey`

### Files
| File | Purpose |
|------|---------|
| `UsageStatisticsData.java` | Data model: records, enums (Metric, TimeRange) |
| `UsageStatisticsLoader.java` | Parses V2 JSONL sessions, aggregates by date+agent |
| `UsageStatisticsChart.java` | `XYLineChart` wrapper with per-agent coloring |
| `UsageStatisticsPanel.java` | Main panel: combo box, chart grid, legend |
| `UsageStatisticsDialog.java` | `DialogWrapper` host |
| `ChatToolWindowContent.kt` | Added `StatisticsAction` to title bar |

### Notes
- Uses `com.intellij.ui.charts` (marked `@ApiStatus.Experimental`) — the only native JetBrains charting API, stable since 2020.2. Suppression is documented and isolated to one class.
- V2 JSONL format only — no legacy V1 fallback needed.