### PR TITLE
fix: HTTP request tool Run panel tabs empty and stuck running

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/HttpRequestTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/HttpRequestTool.java
@@ -293,12 +293,18 @@ public final class HttpRequestTool extends InfrastructureTool {
             try {
                 var factory = com.intellij.execution.filters.TextConsoleBuilderFactory.getInstance();
                 var view = factory.createBuilder(project).getConsole();
-                view.print(text, com.intellij.execution.ui.ConsoleViewContentType.SYSTEM_OUTPUT);
 
-                new RunContentExecutor(project, new NopProcessHandler())
+                NopProcessHandler processHandler = new NopProcessHandler();
+                processHandler.startNotify();
+
+                new RunContentExecutor(project, processHandler)
                     .withTitle(tabTitle)
+                    .withConsole(view)
                     .withActivateToolWindow(false)
                     .run();
+
+                view.print(text, com.intellij.execution.ui.ConsoleViewContentType.SYSTEM_OUTPUT);
+                processHandler.destroyProcess();
             } catch (Exception e) {
                 LOG.warn("Failed to show HTTP request in Run panel", e);
             }


### PR DESCRIPTION
Three bugs in showRequestInRunPanel:

1. ConsoleView was created and printed to, but never attached to the RunContentExecutor via withConsole(). The executor created its own empty console, so users saw blank tabs.

2. NopProcessHandler was never started (startNotify) or terminated (destroyProcess), so tabs stayed in "running" state indefinitely.

3. Text was printed to the console before run() attached it to the UI, so the output was lost even if withConsole had been used.