### PR TITLE
fix: instant scroll during initial history restore, fix git_log chip …

### DIFF
--- a/plugin-core/chat-ui/src/ChatController.ts
+++ b/plugin-core/chat-ui/src/ChatController.ts
@@ -116,6 +116,8 @@ const ChatController = {
     _container(): HTMLElement & {
         scrollIfNeeded(): void;
         forceScroll(): void;
+        pauseAutoScrollForRestore(): void;
+        stopAutoScrollRestore(): void;
         compensateScroll(targetY: number): void;
         autoScroll: boolean;
         workingIndicator: HTMLElement & { show(): void; hide(): void; resetTimer(): void; stop(ms: number): void }
@@ -123,6 +125,8 @@ const ChatController = {
         return document.querySelector<HTMLElement & {
             scrollIfNeeded(): void;
             forceScroll(): void;
+            pauseAutoScrollForRestore(): void;
+            stopAutoScrollRestore(): void;
             compensateScroll(targetY: number): void;
             autoScroll: boolean;
             workingIndicator: HTMLElement & { show(): void; hide(): void; resetTimer(): void; stop(ms: number): void }
@@ -706,6 +710,36 @@ const ChatController = {
                 container.compensateScroll(targetScroll);
             }
         }
+    },
+
+    restoreBatchFinal(encodedJson: string, smoothAfter: boolean): void {
+        const container = this._container();
+        if (container) {
+            container.style.scrollBehavior = 'auto';
+            container.pauseAutoScrollForRestore();
+        }
+
+        const fragment = renderBatchFragment(encodedJson);
+        const msgs = this._msgs();
+        msgs.appendChild(fragment);
+        this._moveQueuedToBottom();
+
+        if (!container) return;
+
+        // Two rAFs: first for initial layout, second for code-block setup (_copyObs fires in rAF).
+        // After both, instantly jump to bottom, then restore smooth scroll for subsequent use.
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                container.stopAutoScrollRestore();
+                container.style.scrollBehavior = 'auto';
+                container.forceScroll();
+                if (smoothAfter) {
+                    requestAnimationFrame(() => {
+                        container.style.scrollBehavior = 'smooth';
+                    });
+                }
+            });
+        });
     },
 
     showLoadMore(count: number): void {

--- a/plugin-core/chat-ui/src/components/ChatContainer.ts
+++ b/plugin-core/chat-ui/src/components/ChatContainer.ts
@@ -2,6 +2,7 @@ export default class ChatContainer extends HTMLElement {
     private _init = false;
     private _autoScroll = true;
     private _autoScrollLocked = false; // true when user explicitly disabled via toggle
+    private _restoring = false; // true while initial history batch is being inserted
     private _messages!: HTMLDivElement;
     private _workingIndicator!: HTMLElement;
     private _scrollRAF: number | null = null;
@@ -51,7 +52,7 @@ export default class ChatContainer extends HTMLElement {
 
         // When the container or its content resizes, re-anchor to bottom if auto-scrolling
         this._resizeObs = new ResizeObserver(() => {
-            if (this._autoScroll) {
+            if (this._autoScroll && !this._restoring) {
                 this._programmaticScroll = true;
                 this.scrollTop = this.scrollHeight;
             }
@@ -169,7 +170,7 @@ export default class ChatContainer extends HTMLElement {
     }
 
     scrollIfNeeded(): void {
-        if (this._autoScroll) {
+        if (this._autoScroll && !this._restoring) {
             this._programmaticScroll = true;
             this.scrollTop = this.scrollHeight;
         }
@@ -178,6 +179,16 @@ export default class ChatContainer extends HTMLElement {
     forceScroll(): void {
         this._programmaticScroll = true;
         this.scrollTop = this.scrollHeight;
+    }
+
+    /** Suppress auto-scroll while initial history batch is being inserted. */
+    pauseAutoScrollForRestore(): void {
+        this._restoring = true;
+    }
+
+    /** Re-enable auto-scroll after initial history batch has been rendered. */
+    stopAutoScrollRestore(): void {
+        this._restoring = false;
     }
 
     compensateScroll(targetY: number): void {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -115,7 +115,6 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
 
         /** Active panels keyed by project — used by MCP tool to retrieve page HTML. */
         private val instances = java.util.concurrent.ConcurrentHashMap<Project, ChatConsolePanel>()
-
         fun getInstance(project: Project): ChatConsolePanel? = instances[project]
 
         private const val FAILED_SPAN = "<span style='color:var(--error)'>✖ Failed</span>"
@@ -131,6 +130,7 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
         private val BUILD_TOOLS = setOf(
             "read_build_output", "build_project"
         )
+        private val GIT_HISTORY_TOOLS = setOf("git_log", "git_show")
     }
 
     // ── Init ───────────────────────────────────────────────────────
@@ -797,7 +797,8 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
         if (count > 0) turnCounter += count
         val json = serializeBatchTurns(entries)
         if (json != "[]") {
-            executeJs("ChatController.restoreBatch('${encodeBase64(json)}')")
+            val smooth = McpServerSettings.getInstance(project).isSmoothScrollEnabled
+            executeJs("ChatController.restoreBatchFinal('${encodeBase64(json)}', $smooth)")
         }
     }
 
@@ -1401,6 +1402,9 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
         if (baseName?.trim('\'', '"') == "git_commit" && tryNavigateToCommit(entry?.result)) {
             return
         }
+        if (baseName?.trim('\'', '"') in GIT_HISTORY_TOOLS && tryNavigateToGitLog(entry?.result)) {
+            return
+        }
         // If the tool arguments contain old_str/new_str, open IntelliJ's diff viewer directly.
         val diff = extractDiffFromArgs(entry?.arguments)
         if (diff != null) {
@@ -1545,6 +1549,21 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
             } catch (_: Exception) {
                 // best-effort navigation
             }
+        }
+        return true
+    }
+
+    /**
+     * Extracts a full 40-char commit hash from the first `commit <hash>` line of git_log/git_show
+     * output and navigates to it in the VCS Log. Returns true if a hash was found (async nav),
+     * false if the result doesn't contain a valid commit line (falls through to popup).
+     */
+    private fun tryNavigateToGitLog(result: String?): Boolean {
+        if (result.isNullOrBlank()) return false
+        val hash = Regex("""^commit ([0-9a-f]{40})$""", RegexOption.MULTILINE)
+            .find(result)?.groupValues?.get(1) ?: return false
+        ApplicationManager.getApplication().invokeLater {
+            PlatformApiCompat.showRevisionInLogAfterRefresh(project, hash)
         }
         return true
     }


### PR DESCRIPTION
…navigation

- `restoreBatchFinal()` in ChatController.ts: sets scrollBehavior='auto', calls `pauseAutoScrollForRestore()` on ChatContainer before inserting the history batch, then after 2 rAFs calls `stopAutoScrollRestore()`, `forceScroll()` (instant jump to bottom), and finally restores smooth scroll in a 3rd rAF if smooth is enabled.
- `ChatContainer.ts`: adds `_restoring` flag; ResizeObserver and `scrollIfNeeded()` both skip scroll while `_restoring=true`, preventing the animated scroll-to-bottom that occurred as each bubble was rendered.
- `ChatConsolePanel.kt`: `appendEntries()` now calls `restoreBatchFinal` instead of `restoreBatch`, passing `isSmoothScrollEnabled` as the `smoothAfter` flag.
- `GIT_HISTORY_TOOLS` set (git_log, git_show): clicking these chips now extracts the `commit <hash>` from the result and navigates directly to that revision in the VCS Log via `PlatformApiCompat.showRevisionInLogAfterRefresh`, instead of falling through to the popup.