### PR TITLE
fix: guard database tool loading against NoClassDefFoundError in Rider

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/database/DatabaseToolFactory.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/database/DatabaseToolFactory.java
@@ -2,13 +2,14 @@ package com.github.catatafishen.agentbridge.psi.tools.database;
 
 import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
 import com.github.catatafishen.agentbridge.psi.tools.Tool;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
 /**
- * Creates database tools when the Database plugin is installed.
+ * Creates database tools when the Database plugin is installed and its classes are accessible.
  * <p>
  * Only read-only tools (list sources, list tables, get schema) are registered here
  * because they use the public DAS model API ({@code database-plugin-frontend.jar}).
@@ -19,6 +20,7 @@ import java.util.List;
  */
 public final class DatabaseToolFactory {
 
+    private static final Logger LOG = Logger.getInstance(DatabaseToolFactory.class);
     private static final String DATABASE_PLUGIN_ID = "com.intellij.database";
 
     private DatabaseToolFactory() {
@@ -28,10 +30,20 @@ public final class DatabaseToolFactory {
         if (!PlatformApiCompat.isPluginInstalled(DATABASE_PLUGIN_ID)) {
             return List.of();
         }
-        return List.of(
-            new ListDataSourcesTool(project),
-            new ListTablesTool(project),
-            new GetSchemaTool(project)
-        );
+        // The database plugin may be registered but its classes unreachable from this classloader
+        // (e.g. in Rider where DasDataSource lives in a module not visible to AgentBridge).
+        // Catching NoClassDefFoundError here is the correct fix: the plugin-installed check
+        // confirms the plugin exists, but class accessibility requires a runtime probe.
+        try {
+            return List.of(
+                new ListDataSourcesTool(project),
+                new ListTablesTool(project),
+                new GetSchemaTool(project)
+            );
+        } catch (NoClassDefFoundError e) {
+            LOG.warn("Database plugin is installed but its classes are not accessible from AgentBridge's classloader; " +
+                "database tools will be unavailable. Cause: " + e.getMessage());
+            return List.of();
+        }
     }
 }


### PR DESCRIPTION
Add defensive handling when creating database tools: introduce a Logger and wrap tool construction in a try/catch for NoClassDefFoundError. If the Database plugin is installed but its classes are not accessible (e.g. in Rider due to classloader/module visibility), log a warning and return an empty list of tools. Also update the class javadoc to clarify the accessibility requirement.


---

com.intellij.diagnostic.PluginException: com/intellij/database/model/DasDataSource [Plugin: com.github.catatafishen.agentbridge]
	at com.intellij.serviceContainer.ServiceInstanceInitializer.createInstance$suspendImpl(ServiceInstanceInitializer.kt:64)
	at com.intellij.serviceContainer.ServiceInstanceInitializer.createInstance(ServiceInstanceInitializer.kt)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1$1.invokeSuspend(LazyInstanceHolder.kt:181)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1$1.invoke(LazyInstanceHolder.kt)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1$1.invoke(LazyInstanceHolder.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndspatched(Undispatched.kt:67)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:43)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:165)
	at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1.invokeSuspend(LazyInstanceHolder.kt:179)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1.invoke(LazyInstanceHolder.kt)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1.invoke(LazyInstanceHolder.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startCoroutineUndispatched(Undispatched.kt:20)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:360)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:134)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:53)
	at kotlinx.coroutines.BuildersKt.launch(Unknown Source)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.initialize(LazyInstanceHolder.kt:164)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.access$initialize(LazyInstanceHolder.kt:29)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.tryInitialize(LazyInstanceHolder.kt:154)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.getInstance(LazyInstanceHolder.kt:112)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.getInstanceInCallerContext$suspendImpl(LazyInstanceHolder.kt:104)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.getInstanceInCallerContext(LazyInstanceHolder.kt)
	at com.intellij.serviceContainer.ComponentManagerImplKt$doGetOrCreateInstanceBlocking$1.invokeSuspend(ComponentManagerImpl.kt:1698)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:263)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:112)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$BuildersKt__BuildersKt(Builders.kt:87)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlockingWithParallelismCompensation(Builders.kt:63)
	at kotlinx.coroutines.BuildersKt.runBlockingWithParallelismCompensation(Unknown Source)
	at kotlinx.coroutines.internal.intellij.IntellijCoroutines.runBlockingWithParallelismCompensation(intellij.kt:48)
	at com.intellij.util.IntelliJCoroutinesFacade.runBlockingWithParallelismCompensation(IntelliJCoroutinesFacade.kt:35)
	at com.intellij.serviceContainer.ComponentManagerImplKt.runBlockingInitialization$lambda$0(ComponentManagerImpl.kt:1829)
	at com.intellij.openapi.progress.ContextKt.prepareThreadContext$lambda$0(context.kt:93)
	at com.intellij.concurrency.ThreadContext.resetThreadContext(threadContext.kt:294)
	at com.intellij.openapi.progress.ContextKt.prepareThreadContext(context.kt:92)
	at com.intellij.serviceContainer.ComponentManagerImplKt.runBlockingInitialization(ComponentManagerImpl.kt:1814)
	at com.intellij.serviceContainer.ComponentManagerImplKt.doGetOrCreateInstanceBlocking(ComponentManagerImpl.kt:1697)
	at com.intellij.serviceContainer.ComponentManagerImplKt.getOrCreateInstanceBlocking(ComponentManagerImpl.kt:1686)
	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:803)
	at com.intellij.serviceContainer.ComponentManagerImpl.getService(ComponentManagerImpl.kt:741)
	at com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(PsiBridgeService.java:121)
	at com.github.catatafishen.agentbridge.psi.PsiBridgeStartup.execute(PsiBridgeStartup.kt:22)
	at com.intellij.ide.startup.impl.StartupManagerImplKt$launchActivity$1.invokeSuspend(StartupManagerImpl.kt:534)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:610)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runDefaultDispatcherTask(CoroutineScheduler.kt:1194)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:906)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:775)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:762)
Caused by: java.lang.NoClassDefFoundError: com/intellij/database/model/DasDataSource
	at com.github.catatafishen.agentbridge.psi.tools.database.DatabaseToolFactory.create(DatabaseToolFactory.java:31)
	at com.github.catatafishen.agentbridge.psi.PsiBridgeService.<init>(PsiBridgeService.java:114)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:735)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate$lambda$0(instantiate.kt:52)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate$lambda$3$0(instantiate.kt:294)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.withStoredTemporaryContext(instantiate.kt:310)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate(instantiate.kt:293)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate(instantiate.kt:45)
	at com.intellij.serviceContainer.ServiceInstanceInitializer.createInstance$suspendImpl(ServiceInstanceInitializer.kt:39)
	... 51 more
Caused by: java.lang.ClassNotFoundException: com.intellij.database.model.DasDataSource PluginClassLoader(plugin=PluginMainDescriptor(name=AgentBridge, id=com.github.catatafishen.agentbridge, version=1.41.4, isBundled=false, path=~\AppData\Roaming\JetBrains\Rider2026.1\plugins\agentbridge), packagePrefix=null, state=active, parents=ContentModuleDescriptor(id=intellij.terminal.sh, package=org.jetbrains.plugins.terminal.sh) <- PluginMainDescriptor(name=Terminal, id=org.jetbrains.plugins.terminal, version=261.22158.335, package=org.jetbrains.plugins.terminal, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\terminal), ContentModuleDescriptor(id=intellij.terminal.backend, package=com.intellij.terminal.backend) <- PluginMainDescriptor(name=Terminal, id=org.jetbrains.plugins.terminal, version=261.22158.335, package=org.jetbrains.plugins.terminal, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\terminal), ContentModuleDescriptor(id=intellij.database.java, package=com.intellij.database.java) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.impl.frontend, package=com.intellij.database.impl.frontend) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.grazie, package=com.intellij.database.grazie) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.flameGraphs, package=com.intellij.database.flameGraph) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.docker, package=com.intellij.database.docker) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.diagrams, package=com.intellij.database.diagram) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.util, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.terminal.cloud) <- PluginMainDescriptor(name=Terminal, id=org.jetbrains.plugins.terminal, version=261.22158.335, package=org.jetbrains.plugins.terminal, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\terminal), ContentModuleDescriptor(id=intellij.platform.vcs.log.graph) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.database.jdbcConsole.shim, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.jdbcConsole, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database, loadingRule=EMBEDDED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.sql, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.vcs.git.shared, loadingRule=EMBEDDED) <- PluginMainDescriptor(name=Git, id=Git4Idea, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\vcs-git), ContentModuleDescriptor(id=intellij.database.core.impl, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.sql.core.impl, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.sql.common.core, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.sql.common.impl, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.mssql.impl, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.mysqlbase.impl, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.connectivity, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.terminal.frontend) <- PluginMainDescriptor(name=Terminal, id=org.jetbrains.plugins.terminal, version=261.22158.335, package=org.jetbrains.plugins.terminal, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\terminal), ContentModuleDescriptor(id=intellij.terminal.frontend.split) <- PluginMainDescriptor(name=Terminal, id=org.jetbrains.plugins.terminal, version=261.22158.335, package=org.jetbrains.plugins.terminal, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\terminal), ContentModuleDescriptor(id=intellij.database.sql.backend.core, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.platform.vcs.log) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.platform.vcs.dvcs) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.database.connectivity.ex, loadingRule=EMBEDDED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.platform.structuralSearch) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.relaxng) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.platform.vcs.impl) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.platform.vcs.log.impl) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.platform.vcs.dvcs.impl) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.spellchecker) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.spellchecker.xml) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.platform.scriptDebugger.protocolReaderRuntime) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.platform.scriptDebugger.backend) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.platform.scriptDebugger.ui) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.platform.tasks) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.platform.tasks.impl) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.platform.collaborationTools.auth.base) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.platform.collaborationTools.auth) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.platform.collaborationTools) <- PluginMainDescriptor(name=IDEA CORE, id=com.intellij, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\lib), ContentModuleDescriptor(id=intellij.vcs.git.frontend) <- PluginMainDescriptor(name=Git, id=Git4Idea, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\vcs-git), ContentModuleDescriptor(id=intellij.vcs.git.coverage) <- PluginMainDescriptor(name=Git, id=Git4Idea, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\vcs-git), ContentModuleDescriptor(id=intellij.vcs.git.terminal) <- PluginMainDescriptor(name=Git, id=Git4Idea, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\vcs-git), ContentModuleDescriptor(id=intellij.vcs.git.localHistory) <- PluginMainDescriptor(name=Git, id=Git4Idea, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\vcs-git), ContentModuleDescriptor(id=intellij.database.dialects.base, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.mongo, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.mongo.sql, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.redis, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.redis.backend, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.mysqlbase, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.sqlite, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.postgresbase, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.postgresgreenplumbase, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.sql92, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.generic, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.oracle, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.mssql, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.sybase, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.maria, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.mysql, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.postgres, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.impl, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.base.ex, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.sybase.ex, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.oracle.ex, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.sqlite.ex, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.mssql.ex, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.mysqlbase.ex, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.postgresbase.ex, loadingRule=EMBEDDED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.postgresgreenplumbase.ex, loadingRule=EMBEDDED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.postgres.ex, loadingRule=EMBEDDED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.sql.impl, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.mongo.ex, loadingRule=REQUIRED) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.oracle.ex.coverage) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.pro) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.trialPromotion.idesWithFreeTier) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.backend.split) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.sql.frontend.core) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.sql.frontend.impl) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.frontend.split) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.sql.intelliLang) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.sql.copyright) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.completionMlRanking) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.cloudExplorer.jba) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.mcp) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), ContentModuleDescriptor(id=intellij.database.dialects.mongo.js.external) <- PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), PluginMainDescriptor(name=Terminal, id=org.jetbrains.plugins.terminal, version=261.22158.335, package=org.jetbrains.plugins.terminal, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\terminal), PluginMainDescriptor(name=Git, id=Git4Idea, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\vcs-git), PluginMainDescriptor(name=Database Tools and SQL, id=com.intellij.database, version=261.22158.335, isBundled=true, path=C:\Program Files\JetBrains\JetBrains Rider 2023.3.3\plugins\DatabaseTools), )
	at com.intellij.ide.plugins.cl.PluginClassLoader.loadClass(PluginClassLoader.kt:154)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
	... 60 more
