### PR TITLE
fix: serialize release workflow to prevent version tag race condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,14 @@ on:
 
 permissions: read-all
 
+concurrency:
+  # Only one release job runs at a time. cancel-in-progress: false means a second
+  # push queues rather than being dropped. GitHub keeps at most one pending run per
+  # group, so a burst of merges still collapses correctly: the queued run will see
+  # all commits accumulated since the tag the running job is about to create.
+  group: release
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
When multiple PRs are merged in quick succession every push to master triggers an independent release job. Without a concurrency guard two jobs can both read the same LATEST_TAG, compute the same next version, and race to push the tag — one succeeds and the other fails, dropping a release or corrupting the version sequence.

Add `concurrency: { group: release, cancel-in-progress: false }` so only one release job runs at a time. A second push while a release is in flight queues rather than running concurrently. GitHub retains at most one pending run per group, so a burst of merges collapses safely: the queued run re-reads git history after the running job has pushed its tag and picks up all accumulated commits in one go.