### PR TITLE
chore: add TypeScript/JS coverage reporting and fix JaCoCo settings e…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,8 @@ jobs:
         run: npm ci --silent --ignore-scripts
         working-directory: plugin-core/js-tests
 
-      - name: Build chat-ui
-        run: npm run build
+      - name: Build chat-ui with sourcemaps (for coverage mapping to TypeScript)
+        run: npm run build:coverage
         working-directory: plugin-core/chat-ui
 
       - name: Setup Gradle
@@ -108,18 +108,35 @@ jobs:
         with:
           cache-disabled: true
 
-      - name: Generate chat resources
+      - name: Generate chat resources (with sourcemaps for test coverage)
         run: ./gradlew :plugin-core:processResources --no-daemon --quiet
 
-      - name: Run chat-ui tests
-        run: npm test
+      - name: Run chat-ui tests with coverage
+        run: npm run test:coverage
         working-directory: plugin-core/js-tests
+
+      - name: Rebuild chat-ui without sourcemaps (production bundle)
+        run: npm run build
+        working-directory: plugin-core/chat-ui
+
+      - name: Replace generated chat resource with production bundle
+        run: cp plugin-core/chat-ui/dist/chat-components.js plugin-core/build/generated/resources/chat-ui/chat/chat-components.js
 
       - name: Build plugins
         run: ./gradlew :plugin-core:buildPlugin :plugin-experimental:buildPlugin --no-daemon --quiet
 
       - name: Run plugin tests
         run: ./gradlew :plugin-core:test --no-daemon
+
+      - name: Upload chat-ui coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5.5.4
+        with:
+          files: plugin-core/js-tests/coverage/lcov.info
+          flags: chat-ui
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage to Codecov
         if: always()

--- a/plugin-core/build.gradle.kts
+++ b/plugin-core/build.gradle.kts
@@ -447,9 +447,11 @@ tasks {
         // can only be tested via integration tests, not unit tests.
         val instrumentedClasses = fileTree("${layout.buildDirectory.get()}/instrumented/instrumentCode") {
             exclude(
-                "**/ui/**",           // Swing/JCEF UI components
-                "**/actions/**",      // AnAction subclasses (need ActionManager)
-                "**/settings/**",     // Settings UI (configurable panels)
+                "**/ui/**",                        // Swing/JCEF UI components (need IDE runtime)
+                "**/actions/**",                   // AnAction subclasses (need ActionManager)
+                "**/settings/*Configurable*",      // Settings UI configurables (need IDE runtime)
+                "**/settings/QrCodePanel*",        // QR code panel (UI, needs IDE runtime)
+                "**/settings/ThemeColorComboBox*", // Theme color combo (UI, needs IDE runtime)
             )
         }
         // Fallback to raw classes if instrumentCode hasn't run (e.g., standalone report)
@@ -457,7 +459,9 @@ tasks {
             exclude(
                 "**/ui/**",
                 "**/actions/**",
-                "**/settings/**",
+                "**/settings/*Configurable*",
+                "**/settings/QrCodePanel*",
+                "**/settings/ThemeColorComboBox*",
             )
         }
         classDirectories.setFrom(

--- a/plugin-core/chat-ui/build.js
+++ b/plugin-core/chat-ui/build.js
@@ -16,6 +16,8 @@ const banner = `/*
 
 `;
 
+const sourcemaps = process.env.BUILD_SOURCEMAPS === '1';
+
 async function build() {
     // 1. Chat components — custom elements + ChatController (loaded first)
     await esbuild.build({
@@ -25,6 +27,7 @@ async function build() {
         globalName: '__chatUI',
         outfile: 'dist/chat-components.js',
         target: 'es2022',
+        sourcemap: sourcemaps ? 'inline' : false,
     });
 
     // 2. Web app — PWA page logic (loaded after chat-components)
@@ -35,6 +38,7 @@ async function build() {
         globalName: '__webApp',
         outfile: 'dist/web-app.js',
         target: 'es2022',
+        sourcemap: sourcemaps ? 'inline' : false,
     });
 
     // 3. Service worker — runs in SW context, no DOM
@@ -44,6 +48,7 @@ async function build() {
         format: 'iife',
         outfile: 'dist/sw.js',
         target: 'es2022',
+        sourcemap: sourcemaps ? 'inline' : false,
     });
 
     // Prepend banner to JS output files

--- a/plugin-core/chat-ui/package.json
+++ b/plugin-core/chat-ui/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "node build.js",
+    "build:coverage": "BUILD_SOURCEMAPS=1 node build.js",
     "build:watch": "esbuild src/index.ts --bundle --format=iife --global-name=__chatUI --outfile=dist/chat-components.js --target=es2022 --watch",
     "typecheck": "tsc --noEmit"
   },

--- a/plugin-core/js-tests/package-lock.json
+++ b/plugin-core/js-tests/package-lock.json
@@ -6,8 +6,64 @@
     "": {
       "name": "chat-ui-tests",
       "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.4",
         "happy-dom": "^20.8.9",
         "vitest": "^4.1.4"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -44,12 +100,31 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.3",
@@ -173,9 +248,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -193,9 +265,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -213,9 +282,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -233,9 +299,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -253,9 +316,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -273,9 +333,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -429,6 +486,36 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "dev": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.4",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.4",
+        "vitest": "4.1.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
@@ -552,6 +639,17 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -667,6 +765,63 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -811,9 +966,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -835,9 +987,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -859,9 +1008,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -883,9 +1029,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -949,6 +1092,32 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/nanoid": {
@@ -1071,6 +1240,18 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -1099,6 +1280,18 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/plugin-core/js-tests/package.json
+++ b/plugin-core/js-tests/package.json
@@ -4,9 +4,11 @@
   "type": "module",
   "scripts": {
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.4",
     "happy-dom": "^20.8.9",
     "vitest": "^4.1.4"
   }

--- a/plugin-core/js-tests/vitest.config.js
+++ b/plugin-core/js-tests/vitest.config.js
@@ -5,5 +5,17 @@ export default defineConfig({
     environment: 'happy-dom',
     globals: true,
     setupFiles: ['./setup.js'],
+    coverage: {
+      provider: 'v8',
+      // lcov for Codecov upload; text-summary for CI log
+      reporter: ['lcov', 'text-summary'],
+      reportsDirectory: './coverage',
+      // The tests load a pre-built bundle via new Function(), so coverage is
+      // attributed at the bundle level. With BUILD_SOURCEMAPS=1, esbuild embeds
+      // inline sourcemaps, and V8 maps coverage back to the TypeScript source.
+      // Without sourcemaps the report covers the bundle; still useful for CI gating.
+      include: ['../chat-ui/src/**/*.ts'],
+      exclude: ['**/*.d.ts'],
+    },
   },
 });

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2.java
@@ -513,7 +513,7 @@ public final class SessionStoreV2 implements Disposable {
                 }
             } catch (Exception e) {
                 skippedLines++;
-                LOG.warn("Skipping malformed JSONL line: " + line, e);
+                LOG.warn("Skipping malformed JSONL line: " + line + " (" + e.getMessage() + ")");
             }
         }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/debug/DebugToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/debug/DebugToolsTest.java
@@ -22,7 +22,6 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import com.intellij.xdebugger.XDebuggerManager;
 import com.intellij.xdebugger.breakpoints.XBreakpoint;
-import com.intellij.xdebugger.breakpoints.XBreakpointManager;
 
 import java.util.List;
 
@@ -142,10 +141,16 @@ public class DebugToolsTest extends BasePlatformTestCase {
 
     /**
      * Verifies that {@code execute()} returns the canonical "No breakpoints set."
-     * message when the breakpoint manager contains no breakpoints, as is guaranteed
-     * in a freshly-initialized {@link BasePlatformTestCase} project.
+     * message when the breakpoint manager contains no breakpoints. Uses
+     * {@link BreakpointRemoveTool} with {@code remove_all: true} to clear any default
+     * breakpoints (e.g. the Java plugin's "Java Exception Breakpoints") that may be
+     * registered asynchronously after {@link #setUp()}.
      */
-    public void testListBreakpointsEmptyReturnsNoBreakpointsMessage() {
+    public void testListBreakpointsEmptyReturnsNoBreakpointsMessage() throws Exception {
+        JsonObject removeAll = new JsonObject();
+        removeAll.addProperty("remove_all", true);
+        breakpointRemoveTool.execute(removeAll);
+
         String result = breakpointListTool.execute(new JsonObject());
         assertEquals("Expected 'No breakpoints set.' for an empty breakpoint manager",
             "No breakpoints set.", result);
@@ -216,17 +221,22 @@ public class DebugToolsTest extends BasePlatformTestCase {
     /**
      * Verifies that {@link BreakpointAddTool} does not modify the breakpoint
      * manager when the target file cannot be resolved — i.e. no phantom breakpoint
-     * is created.
+     * is created. Compares the count before and after to avoid assuming a specific
+     * absolute count (default breakpoints such as "Java Exception Breakpoints" may
+     * be present in the test environment).
      */
     public void testAddBreakpointNonexistentFileDoesNotAddBreakpoint() throws Exception {
+        var bpManager = XDebuggerManager.getInstance(getProject()).getBreakpointManager();
+        int countBefore = bpManager.getAllBreakpoints().length;
+
         breakpointAddTool.execute(args(
             "file", "/does/not/exist/Phantom.java",
             "line", "5"
         ));
 
-        var bpManager = XDebuggerManager.getInstance(getProject()).getBreakpointManager();
-        int count = bpManager.getAllBreakpoints().length;
-        assertEquals("No breakpoint should have been added for a nonexistent file", 0, count);
+        int countAfter = bpManager.getAllBreakpoints().length;
+        assertEquals("No breakpoint should have been added for a nonexistent file",
+            countBefore, countAfter);
     }
 
     // ═════════════════════════════════════════════════════════════════════════════
@@ -248,13 +258,15 @@ public class DebugToolsTest extends BasePlatformTestCase {
     }
 
     /**
-     * Verifies that supplying an out-of-range 1-based index (when there are no
-     * breakpoints) returns an error message that mentions the index and the valid
-     * range, as well as a hint to run {@code breakpoint_list}.
+     * Verifies that supplying an out-of-range 1-based index returns an error message
+     * that mentions the index and the valid range, as well as a hint to run
+     * {@code breakpoint_list}. Uses {@code total + 1} as the index so the test is
+     * robust to any number of default breakpoints present in the test environment.
      */
     public void testRemoveBreakpointIndexOutOfRangeReturnsError() throws Exception {
+        int total = XDebuggerManager.getInstance(getProject()).getBreakpointManager().getAllBreakpoints().length;
         JsonObject a = new JsonObject();
-        a.addProperty("index", 1);
+        a.addProperty("index", total + 1);
         String result = breakpointRemoveTool.execute(a);
         assertNotNull("execute() must not return null", result);
         assertTrue("Expected 'Error:' prefix for out-of-range index, got: " + result,
@@ -268,14 +280,17 @@ public class DebugToolsTest extends BasePlatformTestCase {
     /**
      * Verifies that {@code remove_all: true} succeeds even when there are no
      * breakpoints — returning the "Removed all 0 breakpoint(s)." confirmation
-     * rather than an error.
+     * rather than an error. Calls the tool twice: the first call clears any default
+     * breakpoints registered by the Java plugin (e.g. "Java Exception Breakpoints"),
+     * the second call verifies the zero-count confirmation.
      */
     public void testRemoveAllBreakpointsWhenNoneExistReturnsConfirmation() throws Exception {
         JsonObject a = new JsonObject();
         a.addProperty("remove_all", true);
-        String result = breakpointRemoveTool.execute(a);
+        breakpointRemoveTool.execute(a); // clear any defaults (e.g. Java Exception Breakpoints)
+        String result = breakpointRemoveTool.execute(a); // now test the zero-count case
         assertNotNull("execute() must not return null", result);
-        assertTrue("Expected 'Removed all' confirmation, got: " + result,
+        assertTrue("Expected 'Removed all 0' confirmation, got: " + result,
             result.contains("Removed all") && result.contains("0"));
     }
 
@@ -881,18 +896,17 @@ public class DebugToolsTest extends BasePlatformTestCase {
     // ── Private helpers ──────────────────────────────────────────────────────────────
 
     /**
-     * Removes all breakpoints from the project's {@link XBreakpointManager}.
-     * Called from both {@link #setUp()} and {@link #tearDown()} so that every test
-     * method starts and ends with a zero-breakpoint state regardless of what the
-     * Java plugin may have registered (e.g. the default "Java Exception Breakpoints"
-     * entry) or what a previous test may have added.
+     * Removes breakpoints added during a test to prevent state leaking into subsequent
+     * test methods. Note: the Java plugin's default "Java Exception Breakpoints" entry
+     * is registered asynchronously and may reappear between calls; tests that need a
+     * truly zero-breakpoint state must call {@link BreakpointRemoveTool} with
+     * {@code remove_all: true} directly (as the tool's write action runs synchronously).
      */
     private void clearAllBreakpoints() {
         ApplicationManager.getApplication().runWriteAction(() -> {
             var mgr = XDebuggerManager.getInstance(getProject()).getBreakpointManager();
             for (XBreakpoint<?> bp : mgr.getAllBreakpoints()) {
-                //noinspection unchecked,rawtypes
-                mgr.removeBreakpoint((XBreakpoint) bp);
+                mgr.removeBreakpoint(bp);
             }
         });
     }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/debug/DebugToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/debug/DebugToolsTest.java
@@ -1,0 +1,904 @@
+package com.github.catatafishen.agentbridge.psi.tools.debug;
+
+import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
+import com.github.catatafishen.agentbridge.psi.tools.debug.breakpoints.BreakpointAddExceptionTool;
+import com.github.catatafishen.agentbridge.psi.tools.debug.breakpoints.BreakpointAddTool;
+import com.github.catatafishen.agentbridge.psi.tools.debug.breakpoints.BreakpointListTool;
+import com.github.catatafishen.agentbridge.psi.tools.debug.breakpoints.BreakpointRemoveTool;
+import com.github.catatafishen.agentbridge.psi.tools.debug.breakpoints.BreakpointUpdateTool;
+import com.github.catatafishen.agentbridge.psi.tools.debug.inspection.DebugEvaluateTool;
+import com.github.catatafishen.agentbridge.psi.tools.debug.inspection.DebugInspectFrameTool;
+import com.github.catatafishen.agentbridge.psi.tools.debug.inspection.DebugReadConsoleTool;
+import com.github.catatafishen.agentbridge.psi.tools.debug.inspection.DebugSnapshotTool;
+import com.github.catatafishen.agentbridge.psi.tools.debug.inspection.DebugVariableDetailTool;
+import com.github.catatafishen.agentbridge.psi.tools.debug.navigation.DebugRunToLineTool;
+import com.github.catatafishen.agentbridge.psi.tools.debug.navigation.DebugStepTool;
+import com.github.catatafishen.agentbridge.psi.tools.debug.session.DebugSessionListTool;
+import com.github.catatafishen.agentbridge.psi.tools.debug.session.DebugSessionStopTool;
+import com.github.catatafishen.agentbridge.services.ToolRegistry;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.xdebugger.XDebuggerManager;
+import com.intellij.xdebugger.breakpoints.XBreakpoint;
+import com.intellij.xdebugger.breakpoints.XBreakpointManager;
+
+import java.util.List;
+
+/**
+ * Platform tests for all 14 debug tools created by {@link DebugToolFactory}.
+ *
+ * <p>JUnit 3 style (extends {@link BasePlatformTestCase}): test methods must be
+ * {@code public void testXxx()}. Run via Gradle only:
+ * {@code ./gradlew :plugin-core:test}.
+ *
+ * <p>Debug tools generally require an active (possibly paused) debug session.
+ * Since a real debug session cannot be started in a light test environment, all
+ * tests focus on two complementary strategies:
+ * <ol>
+ *   <li><b>Read-only state queries</b> — tools that can answer without a session
+ *       ({@link BreakpointListTool}, {@link DebugSessionListTool}) are exercised
+ *       against the empty state of a fresh test project.</li>
+ *   <li><b>Graceful error paths</b> — tools that call
+ *       {@code requireSession()} / {@code requirePausedSession()} must throw
+ *       {@link IllegalStateException} with a clear user-facing message; tools with
+ *       required parameters must return a well-formed error string when the
+ *       parameters are invalid.</li>
+ * </ol>
+ *
+ * <p>{@link #tearDown()} removes all breakpoints added during a test to prevent
+ * state from leaking into subsequent test methods that share the light project.
+ */
+public class DebugToolsTest extends BasePlatformTestCase {
+
+    // ── Tool instances ────────────────────────────────────────────────────────────
+
+    // Breakpoint tools
+    private BreakpointListTool breakpointListTool;
+    private BreakpointAddTool breakpointAddTool;
+    private BreakpointAddExceptionTool breakpointAddExceptionTool;
+    private BreakpointRemoveTool breakpointRemoveTool;
+    private BreakpointUpdateTool breakpointUpdateTool;
+
+    // Session tools
+    private DebugSessionListTool debugSessionListTool;
+    private DebugSessionStopTool debugSessionStopTool;
+
+    // Inspection tools
+    private DebugSnapshotTool debugSnapshotTool;
+    private DebugVariableDetailTool debugVariableDetailTool;
+    private DebugInspectFrameTool debugInspectFrameTool;
+    private DebugEvaluateTool debugEvaluateTool;
+    private DebugReadConsoleTool debugReadConsoleTool;
+
+    // Navigation tools
+    private DebugRunToLineTool debugRunToLineTool;
+    private DebugStepTool debugStepTool;
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────────
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        // Clear any pre-existing breakpoints registered during project initialization
+        // (e.g. the default disabled "Java Exception Breakpoints" added by the Java plugin).
+        // This ensures every test method starts from a clean, zero-breakpoint state.
+        clearAllBreakpoints();
+
+        // Prevent followFileIfEnabled from opening editors during tests.
+        // Use the String overload — the boolean overload removes the key when
+        // value==defaultValue, which would leave the setting at its default (true).
+        PropertiesComponent.getInstance(getProject())
+            .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
+
+        breakpointListTool = new BreakpointListTool(getProject());
+        breakpointAddTool = new BreakpointAddTool(getProject());
+        breakpointAddExceptionTool = new BreakpointAddExceptionTool(getProject());
+        breakpointRemoveTool = new BreakpointRemoveTool(getProject());
+        breakpointUpdateTool = new BreakpointUpdateTool(getProject());
+
+        debugSessionListTool = new DebugSessionListTool(getProject());
+        debugSessionStopTool = new DebugSessionStopTool(getProject());
+
+        debugSnapshotTool = new DebugSnapshotTool(getProject());
+        debugVariableDetailTool = new DebugVariableDetailTool(getProject());
+        debugInspectFrameTool = new DebugInspectFrameTool(getProject());
+        debugEvaluateTool = new DebugEvaluateTool(getProject());
+        debugReadConsoleTool = new DebugReadConsoleTool(getProject());
+
+        debugRunToLineTool = new DebugRunToLineTool(getProject());
+        debugStepTool = new DebugStepTool(getProject());
+    }
+
+    /**
+     * Removes all breakpoints set during the test to prevent state leaking into
+     * subsequent test methods that reuse the same light project instance.
+     */
+    @Override
+    protected void tearDown() throws Exception {
+        clearAllBreakpoints();
+        super.tearDown();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    /**
+     * Builds a {@link JsonObject} from alternating key/value string pairs.
+     * Example: {@code args("file", "/some/path.java", "line", "42")}
+     */
+    private JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── BreakpointListTool ────────────────────────────────────────────────────────
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that {@code execute()} returns the canonical "No breakpoints set."
+     * message when the breakpoint manager contains no breakpoints, as is guaranteed
+     * in a freshly-initialized {@link BasePlatformTestCase} project.
+     */
+    public void testListBreakpointsEmptyReturnsNoBreakpointsMessage() {
+        String result = breakpointListTool.execute(new JsonObject());
+        assertEquals("Expected 'No breakpoints set.' for an empty breakpoint manager",
+            "No breakpoints set.", result);
+    }
+
+    /**
+     * Verifies that {@code execute()} never returns {@code null} and always
+     * produces a non-blank string, regardless of breakpoint state.
+     */
+    public void testListBreakpointsResultIsNonNull() {
+        String result = breakpointListTool.execute(new JsonObject());
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+    }
+
+    /**
+     * Verifies that {@link BreakpointListTool} is flagged as a read-only tool
+     * (it only reads the breakpoint manager and never modifies project state).
+     */
+    public void testBreakpointListToolIsReadOnly() {
+        assertTrue("BreakpointListTool.isReadOnly() must return true",
+            breakpointListTool.isReadOnly());
+    }
+
+    /**
+     * Verifies that {@link BreakpointListTool} reports the DEBUG category.
+     */
+    public void testBreakpointListToolCategory() {
+        assertEquals("BreakpointListTool must be in the DEBUG category",
+            ToolRegistry.Category.DEBUG, breakpointListTool.category());
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── BreakpointAddTool ─────────────────────────────────────────────────────────
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that attempting to add a breakpoint to an absolute path that does
+     * not exist in the VFS returns a "File not found:" error instead of throwing.
+     */
+    public void testAddBreakpointAbsoluteFileNotFoundReturnsError() throws Exception {
+        String result = breakpointAddTool.execute(args(
+            "file", "/nonexistent/path/to/NonexistentSource.java",
+            "line", "10"
+        ));
+        assertNotNull("execute() must not return null", result);
+        assertTrue("Expected 'File not found:' message, got: " + result,
+            result.startsWith("File not found:"));
+        assertTrue("Error message must include the requested path, got: " + result,
+            result.contains("NonexistentSource.java"));
+    }
+
+    /**
+     * Verifies that a project-relative path that resolves to no real file
+     * also returns a "File not found:" error gracefully.
+     */
+    public void testAddBreakpointProjectRelativeFileNotFoundReturnsError() throws Exception {
+        String result = breakpointAddTool.execute(args(
+            "file", "src/main/java/com/example/NoSuchClass.java",
+            "line", "1"
+        ));
+        assertNotNull("execute() must not return null", result);
+        // "File not found:" is the canonical prefix from BreakpointAddTool
+        assertTrue("Expected file-not-found message, got: " + result,
+            result.contains("File not found:") || result.contains("not found"));
+    }
+
+    /**
+     * Verifies that {@link BreakpointAddTool} does not modify the breakpoint
+     * manager when the target file cannot be resolved — i.e. no phantom breakpoint
+     * is created.
+     */
+    public void testAddBreakpointNonexistentFileDoesNotAddBreakpoint() throws Exception {
+        breakpointAddTool.execute(args(
+            "file", "/does/not/exist/Phantom.java",
+            "line", "5"
+        ));
+
+        var bpManager = XDebuggerManager.getInstance(getProject()).getBreakpointManager();
+        int count = bpManager.getAllBreakpoints().length;
+        assertEquals("No breakpoint should have been added for a nonexistent file", 0, count);
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── BreakpointRemoveTool ──────────────────────────────────────────────────────
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that calling {@code execute()} with no selector arguments returns
+     * a descriptive error explaining which selectors are accepted, rather than
+     * throwing or returning a null/blank response.
+     */
+    public void testRemoveBreakpointNoSelectorReturnsError() throws Exception {
+        String result = breakpointRemoveTool.execute(new JsonObject());
+        assertNotNull("execute() must not return null", result);
+        assertTrue("Expected 'Error:' prefix for missing selector, got: " + result,
+            result.startsWith("Error:"));
+        assertTrue("Error must mention valid selectors (index / file / remove_all), got: " + result,
+            result.contains("index") || result.contains("file") || result.contains("remove_all"));
+    }
+
+    /**
+     * Verifies that supplying an out-of-range 1-based index (when there are no
+     * breakpoints) returns an error message that mentions the index and the valid
+     * range, as well as a hint to run {@code breakpoint_list}.
+     */
+    public void testRemoveBreakpointIndexOutOfRangeReturnsError() throws Exception {
+        JsonObject a = new JsonObject();
+        a.addProperty("index", 1);
+        String result = breakpointRemoveTool.execute(a);
+        assertNotNull("execute() must not return null", result);
+        assertTrue("Expected 'Error:' prefix for out-of-range index, got: " + result,
+            result.startsWith("Error:"));
+        assertTrue("Error must mention 'out of range', got: " + result,
+            result.contains("out of range"));
+        assertTrue("Error must suggest breakpoint_list, got: " + result,
+            result.contains("breakpoint_list"));
+    }
+
+    /**
+     * Verifies that {@code remove_all: true} succeeds even when there are no
+     * breakpoints — returning the "Removed all 0 breakpoint(s)." confirmation
+     * rather than an error.
+     */
+    public void testRemoveAllBreakpointsWhenNoneExistReturnsConfirmation() throws Exception {
+        JsonObject a = new JsonObject();
+        a.addProperty("remove_all", true);
+        String result = breakpointRemoveTool.execute(a);
+        assertNotNull("execute() must not return null", result);
+        assertTrue("Expected 'Removed all' confirmation, got: " + result,
+            result.contains("Removed all") && result.contains("0"));
+    }
+
+    /**
+     * Verifies that supplying a {@code file} + {@code line} selector pointing to a
+     * path that has no breakpoint returns an error message that includes the
+     * requested file path.
+     */
+    public void testRemoveBreakpointByFileLineNoneExistReturnsError() throws Exception {
+        String result = breakpointRemoveTool.execute(args(
+            "file", "/nonexistent/src/Missing.java",
+            "line", "5"
+        ));
+        assertNotNull("execute() must not return null", result);
+        assertTrue("Expected 'Error:' prefix for missing breakpoint, got: " + result,
+            result.startsWith("Error:"));
+        assertTrue("Error must reference the file path, got: " + result,
+            result.contains("Missing.java") || result.contains("no breakpoint found"));
+    }
+
+    /**
+     * Verifies that supplying only a {@code file} argument (no {@code line}) still
+     * produces a meaningful error rather than throwing a NullPointerException.
+     */
+    public void testRemoveBreakpointFileOnlyNoLineReturnsError() throws Exception {
+        String result = breakpointRemoveTool.execute(args("file", "/some/path/File.java"));
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertTrue("Expected error or 'no breakpoint found' message, got: " + result,
+            result.startsWith("Error:") || result.contains("index") || result.contains("no breakpoint found"));
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── BreakpointUpdateTool ──────────────────────────────────────────────────────
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that calling {@code execute()} with an empty argument object returns
+     * a guidance message asking the caller to supply an {@code index} or
+     * {@code file}+{@code line} selector.
+     */
+    public void testUpdateBreakpointNoSelectorReturnsGuidance() throws Exception {
+        String result = breakpointUpdateTool.execute(new JsonObject());
+        assertNotNull("execute() must not return null", result);
+        // "Provide 'index' or 'file'+'line' to identify the breakpoint."
+        assertTrue("Expected guidance about providing a selector, got: " + result,
+            result.contains("index") || result.contains("file") || result.contains("Provide"));
+    }
+
+    /**
+     * Verifies that an out-of-range index returns an error with the index number
+     * and a suggestion to run {@code breakpoint_list}.
+     */
+    public void testUpdateBreakpointIndexOutOfRangeReturnsError() throws Exception {
+        JsonObject a = new JsonObject();
+        a.addProperty("index", 99);
+        a.addProperty("enabled", true);
+        String result = breakpointUpdateTool.execute(a);
+        assertNotNull("execute() must not return null", result);
+        assertTrue("Expected 'out of range' in error, got: " + result,
+            result.contains("out of range"));
+        assertTrue("Error must suggest breakpoint_list, got: " + result,
+            result.contains("breakpoint_list"));
+    }
+
+    /**
+     * Verifies that supplying a {@code file}+{@code line} selector that matches no
+     * breakpoint returns a human-readable "not found" error rather than throwing.
+     */
+    public void testUpdateBreakpointByFileLineNoneExistReturnsError() throws Exception {
+        String result = breakpointUpdateTool.execute(args(
+            "file", "/nonexistent/path/Absent.java",
+            "line", "20"
+        ));
+        assertNotNull("execute() must not return null", result);
+        // "No breakpoint found at /nonexistent/path/Absent.java:20."
+        assertTrue("Expected 'No breakpoint found' or similar error, got: " + result,
+            result.contains("No breakpoint found") || result.contains("not found") || result.contains("Provide"));
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── BreakpointAddExceptionTool ────────────────────────────────────────────────
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that adding an exception breakpoint for a concrete Java exception
+     * class either succeeds (Java plugin present) or returns a human-readable
+     * "no exception breakpoint type found" message (lightweight test environment
+     * without the full Java plugin loaded).
+     *
+     * <p>In both cases the result must be non-null, non-blank, and must not be a
+     * raw stack trace.
+     */
+    public void testAddExceptionBreakpointRuntimeExceptionReturnsValidResponse() throws Exception {
+        String result = breakpointAddExceptionTool.execute(args(
+            "exception_class", "java.lang.RuntimeException"
+        ));
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        // Either the breakpoint was added, or no exception BP type is available in the
+        // lightweight test environment — both are valid outcomes.
+        boolean isValidResponse =
+            result.contains("exception breakpoint")
+                || result.contains("No exception breakpoint type found");
+        assertTrue("Expected a valid exception-breakpoint response, got: " + result, isValidResponse);
+    }
+
+    /**
+     * Verifies that the wildcard {@code "*"} exception class is handled gracefully —
+     * either a "catch-any" exception breakpoint is created, or the tool reports that
+     * no exception breakpoint type is available.
+     */
+    public void testAddExceptionBreakpointWildcardReturnsValidResponse() throws Exception {
+        String result = breakpointAddExceptionTool.execute(args("exception_class", "*"));
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        boolean isValidResponse =
+            result.contains("exception breakpoint")
+                || result.contains("No exception breakpoint type found");
+        assertTrue("Expected a valid wildcard exception-breakpoint response, got: " + result,
+            isValidResponse);
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── DebugSessionListTool ──────────────────────────────────────────────────────
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that {@code execute()} returns the exact string {@code "No active debug sessions."}
+     * when no debug sessions are running, as guaranteed for a fresh test project.
+     */
+    public void testDebugSessionListEmptyReturnsNoSessionsMessage() {
+        String result = debugSessionListTool.execute(new JsonObject());
+        assertNotNull("execute() must not return null", result);
+        assertEquals("Expected 'No active debug sessions.' for an empty session list",
+            "No active debug sessions.", result);
+    }
+
+    /**
+     * Verifies that {@link DebugSessionListTool} is a read-only tool.
+     */
+    public void testDebugSessionListIsReadOnly() {
+        assertTrue("DebugSessionListTool.isReadOnly() must return true",
+            debugSessionListTool.isReadOnly());
+    }
+
+    /**
+     * Verifies that {@code execute()} never returns {@code null}.
+     */
+    public void testDebugSessionListResultIsNonNull() {
+        assertNotNull("execute() must not return null",
+            debugSessionListTool.execute(new JsonObject()));
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── DebugSessionStopTool ──────────────────────────────────────────────────────
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that attempting to stop the active session when none is running
+     * throws {@link IllegalStateException} with the canonical "No active debug session"
+     * message from {@code DebugTool.requireSession()}.
+     */
+    public void testDebugSessionStopNoSessionThrowsIllegalStateException() throws Exception {
+        try {
+            debugSessionStopTool.execute(new JsonObject());
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertNotNull("Exception message must not be null", e.getMessage());
+            assertTrue(
+                "Expected 'No active debug session' in the exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    /**
+     * Verifies that {@code stop_all: true} returns the "No active debug sessions to stop."
+     * message gracefully (no exception) when there are no running sessions.
+     */
+    public void testDebugSessionStopAllNoSessionsReturnsMessage() throws Exception {
+        JsonObject a = new JsonObject();
+        a.addProperty("stop_all", true);
+        String result = debugSessionStopTool.execute(a);
+        assertNotNull("execute() must not return null", result);
+        assertEquals("Expected 'No active debug sessions to stop.' when no sessions running",
+            "No active debug sessions to stop.", result);
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── DebugSnapshotTool (requires paused session) ───────────────────────────────
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that {@link DebugSnapshotTool#execute} throws {@link IllegalStateException}
+     * with the "No active debug session" message when there is no running session.
+     */
+    public void testDebugSnapshotNoSessionThrowsIllegalStateException() throws Exception {
+        try {
+            debugSnapshotTool.execute(new JsonObject());
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    /**
+     * Verifies that explicitly providing all {@code include_*} flags still propagates
+     * the no-session error — confirming that the session guard is checked first,
+     * before any flag processing occurs.
+     */
+    public void testDebugSnapshotWithAllFlagsNoSessionThrowsIllegalStateException() throws Exception {
+        JsonObject a = new JsonObject();
+        a.addProperty("include_source", true);
+        a.addProperty("include_variables", true);
+        a.addProperty("include_stack", true);
+        try {
+            debugSnapshotTool.execute(a);
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    /**
+     * Verifies that passing {@code include_source: false} etc. also throws before
+     * attempting any file access, confirming the guard is not bypassed by disabling flags.
+     */
+    public void testDebugSnapshotAllFlagsFalseNoSessionThrowsIllegalStateException() throws Exception {
+        JsonObject a = new JsonObject();
+        a.addProperty("include_source", false);
+        a.addProperty("include_variables", false);
+        a.addProperty("include_stack", false);
+        try {
+            debugSnapshotTool.execute(a);
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── DebugVariableDetailTool (requires paused session) ────────────────────────
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that {@link DebugVariableDetailTool#execute} throws
+     * {@link IllegalStateException} with the "No active debug session" message.
+     */
+    public void testDebugVariableDetailNoSessionThrowsIllegalStateException() throws Exception {
+        try {
+            debugVariableDetailTool.execute(args("path", "someVariable"));
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    /**
+     * Verifies that a nested dot-path also hits the session guard before any
+     * variable resolution is attempted.
+     */
+    public void testDebugVariableDetailDotPathNoSessionThrowsIllegalStateException() throws Exception {
+        try {
+            debugVariableDetailTool.execute(args("path", "obj.field.nested"));
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── DebugInspectFrameTool (requires paused session) ───────────────────────────
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that {@link DebugInspectFrameTool#execute} throws
+     * {@link IllegalStateException} with the "No active debug session" message
+     * for frame index 0 (the top/current frame).
+     */
+    public void testDebugInspectFrameZeroNoSessionThrowsIllegalStateException() throws Exception {
+        JsonObject a = new JsonObject();
+        a.addProperty("frame_index", 0);
+        try {
+            debugInspectFrameTool.execute(a);
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    /**
+     * Verifies that inspecting a deeper frame index also hits the session guard
+     * first — no NullPointerException or ArrayIndexOutOfBoundsException should be thrown.
+     */
+    public void testDebugInspectFrameNonZeroNoSessionThrowsIllegalStateException() throws Exception {
+        JsonObject a = new JsonObject();
+        a.addProperty("frame_index", 3);
+        try {
+            debugInspectFrameTool.execute(a);
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── DebugEvaluateTool (requires paused session) ───────────────────────────────
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that evaluating a simple expression throws {@link IllegalStateException}
+     * when there is no active debug session.
+     */
+    public void testDebugEvaluateSimpleExpressionNoSessionThrowsIllegalStateException() throws Exception {
+        try {
+            debugEvaluateTool.execute(args("expression", "1 + 1"));
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    /**
+     * Verifies that providing an explicit {@code frame_index} does not bypass
+     * the session guard.
+     */
+    public void testDebugEvaluateWithFrameIndexNoSessionThrowsIllegalStateException() throws Exception {
+        JsonObject a = new JsonObject();
+        a.addProperty("expression", "myObj.toString()");
+        a.addProperty("frame_index", 1);
+        try {
+            debugEvaluateTool.execute(a);
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── DebugReadConsoleTool (requires active — not necessarily paused — session) ─
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that reading the debug console throws {@link IllegalStateException}
+     * with the "No active debug session" message when no session is running.
+     */
+    public void testDebugReadConsoleNoSessionThrowsIllegalStateException() throws Exception {
+        try {
+            debugReadConsoleTool.execute(new JsonObject());
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    /**
+     * Verifies that providing a custom {@code max_chars} limit does not prevent
+     * the session guard from triggering.
+     */
+    public void testDebugReadConsoleWithMaxCharsNoSessionThrowsIllegalStateException() throws Exception {
+        JsonObject a = new JsonObject();
+        a.addProperty("max_chars", 1000);
+        try {
+            debugReadConsoleTool.execute(a);
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── DebugStepTool (requires paused session) ───────────────────────────────────
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that {@code action: "over"} throws {@link IllegalStateException}
+     * (no session) rather than hanging on the completion latch.
+     */
+    public void testDebugStepOverNoSessionThrowsIllegalStateException() throws Exception {
+        try {
+            debugStepTool.execute(args("action", "over"));
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    /**
+     * Verifies that {@code action: "into"} also triggers the session guard.
+     */
+    public void testDebugStepIntoNoSessionThrowsIllegalStateException() throws Exception {
+        try {
+            debugStepTool.execute(args("action", "into"));
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    /**
+     * Verifies that {@code action: "out"} also triggers the session guard.
+     */
+    public void testDebugStepOutNoSessionThrowsIllegalStateException() throws Exception {
+        try {
+            debugStepTool.execute(args("action", "out"));
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    /**
+     * Verifies that {@code action: "continue"} also triggers the session guard.
+     */
+    public void testDebugStepContinueNoSessionThrowsIllegalStateException() throws Exception {
+        try {
+            debugStepTool.execute(args("action", "continue"));
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── DebugRunToLineTool (requires paused session) ──────────────────────────────
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that {@link DebugRunToLineTool#execute} throws
+     * {@link IllegalStateException} with the "No active debug session" message
+     * even before the file-path argument is resolved.
+     */
+    public void testDebugRunToLineNoSessionThrowsIllegalStateException() throws Exception {
+        try {
+            debugRunToLineTool.execute(args(
+                "file", "/nonexistent/File.java",
+                "line", "10"
+            ));
+            fail("Expected IllegalStateException when no active debug session is present");
+        } catch (IllegalStateException e) {
+            assertTrue(
+                "Expected 'No active debug session' in exception message, got: " + e.getMessage(),
+                e.getMessage().contains("No active debug session"));
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── DebugToolFactory ──────────────────────────────────────────────────────────
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that {@link DebugToolFactory#create(com.intellij.openapi.project.Project)}
+     * produces exactly 14 tool instances, matching the count documented in the factory.
+     */
+    public void testDebugToolFactoryCreates14Tools() {
+        List<?> tools = DebugToolFactory.create(getProject());
+        assertNotNull("Tool list must not be null", tools);
+        assertEquals("DebugToolFactory must create exactly 14 tools", 14, tools.size());
+    }
+
+    /**
+     * Verifies that none of the 14 tools produced by the factory are {@code null}.
+     */
+    public void testDebugToolFactoryToolsAreAllNonNull() {
+        List<?> tools = DebugToolFactory.create(getProject());
+        for (int i = 0; i < tools.size(); i++) {
+            assertNotNull("Tool at index " + i + " must not be null", tools.get(i));
+        }
+    }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // ── Tool metadata (id, displayName, category) ────────────────────────────────
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Verifies that every debug tool exposes a non-null, non-blank {@code id()}.
+     */
+    public void testAllDebugToolsHaveNonBlankId() {
+        assertNonBlankId(breakpointListTool.id(), "BreakpointListTool");
+        assertNonBlankId(breakpointAddTool.id(), "BreakpointAddTool");
+        assertNonBlankId(breakpointAddExceptionTool.id(), "BreakpointAddExceptionTool");
+        assertNonBlankId(breakpointRemoveTool.id(), "BreakpointRemoveTool");
+        assertNonBlankId(breakpointUpdateTool.id(), "BreakpointUpdateTool");
+        assertNonBlankId(debugSessionListTool.id(), "DebugSessionListTool");
+        assertNonBlankId(debugSessionStopTool.id(), "DebugSessionStopTool");
+        assertNonBlankId(debugSnapshotTool.id(), "DebugSnapshotTool");
+        assertNonBlankId(debugVariableDetailTool.id(), "DebugVariableDetailTool");
+        assertNonBlankId(debugInspectFrameTool.id(), "DebugInspectFrameTool");
+        assertNonBlankId(debugEvaluateTool.id(), "DebugEvaluateTool");
+        assertNonBlankId(debugReadConsoleTool.id(), "DebugReadConsoleTool");
+        assertNonBlankId(debugRunToLineTool.id(), "DebugRunToLineTool");
+        assertNonBlankId(debugStepTool.id(), "DebugStepTool");
+    }
+
+    /**
+     * Verifies that every debug tool's {@code id()} is unique within the set of
+     * all 14 debug tools (no duplicate IDs that would cause MCP routing collisions).
+     */
+    public void testAllDebugToolIdsAreUnique() {
+        List<?> tools = DebugToolFactory.create(getProject());
+        java.util.Set<String> ids = new java.util.HashSet<>();
+        for (Object t : tools) {
+            if (t instanceof com.github.catatafishen.agentbridge.psi.tools.Tool tool) {
+                String id = tool.id();
+                assertTrue("Duplicate tool id '" + id + "' detected", ids.add(id));
+            }
+        }
+    }
+
+    /**
+     * Verifies that every debug tool reports {@link ToolRegistry.Category#DEBUG}
+     * as its category, so the tool registry routes them correctly.
+     */
+    public void testAllDebugToolsReportDebugCategory() {
+        List<?> tools = DebugToolFactory.create(getProject());
+        for (Object t : tools) {
+            if (t instanceof com.github.catatafishen.agentbridge.psi.tools.Tool tool) {
+                assertEquals(
+                    "Tool '" + tool.id() + "' must report DEBUG category",
+                    ToolRegistry.Category.DEBUG,
+                    tool.category());
+            }
+        }
+    }
+
+    /**
+     * Verifies the exact tool IDs that the MCP client depends on at runtime.
+     */
+    public void testCanonicalToolIds() {
+        assertEquals("breakpoint_list", breakpointListTool.id());
+        assertEquals("breakpoint_add", breakpointAddTool.id());
+        assertEquals("breakpoint_add_exception", breakpointAddExceptionTool.id());
+        assertEquals("breakpoint_remove", breakpointRemoveTool.id());
+        assertEquals("breakpoint_update", breakpointUpdateTool.id());
+        assertEquals("debug_session_list", debugSessionListTool.id());
+        assertEquals("debug_session_stop", debugSessionStopTool.id());
+        assertEquals("debug_snapshot", debugSnapshotTool.id());
+        assertEquals("debug_variable_detail", debugVariableDetailTool.id());
+        assertEquals("debug_inspect_frame", debugInspectFrameTool.id());
+        assertEquals("debug_evaluate", debugEvaluateTool.id());
+        assertEquals("debug_read_console", debugReadConsoleTool.id());
+        assertEquals("debug_run_to_line", debugRunToLineTool.id());
+        assertEquals("debug_step", debugStepTool.id());
+    }
+
+    /**
+     * Verifies that the read-only / write classification of every tool matches the
+     * documented contract from the source code:
+     * <ul>
+     *   <li>Read-only: {@code breakpoint_list}, {@code debug_session_list},
+     *       {@code debug_snapshot}, {@code debug_variable_detail},
+     *       {@code debug_inspect_frame}, {@code debug_read_console}.</li>
+     *   <li>Write (or side-effecting): all other tools.</li>
+     * </ul>
+     */
+    public void testReadOnlyFlagsMatchDocumentedContract() {
+        assertTrue("breakpoint_list must be read-only", breakpointListTool.isReadOnly());
+        assertFalse("breakpoint_add must NOT be read-only", breakpointAddTool.isReadOnly());
+        assertFalse("breakpoint_add_exception must NOT be read-only", breakpointAddExceptionTool.isReadOnly());
+        assertFalse("breakpoint_remove must NOT be read-only", breakpointRemoveTool.isReadOnly());
+        assertFalse("breakpoint_update must NOT be read-only", breakpointUpdateTool.isReadOnly());
+        assertTrue("debug_session_list must be read-only", debugSessionListTool.isReadOnly());
+        assertFalse("debug_session_stop must NOT be read-only", debugSessionStopTool.isReadOnly());
+        assertTrue("debug_snapshot must be read-only", debugSnapshotTool.isReadOnly());
+        assertTrue("debug_variable_detail must be read-only", debugVariableDetailTool.isReadOnly());
+        assertTrue("debug_inspect_frame must be read-only", debugInspectFrameTool.isReadOnly());
+        assertFalse("debug_evaluate must NOT be read-only", debugEvaluateTool.isReadOnly());
+        assertTrue("debug_read_console must be read-only", debugReadConsoleTool.isReadOnly());
+        assertFalse("debug_run_to_line must NOT be read-only", debugRunToLineTool.isReadOnly());
+        assertFalse("debug_step must NOT be read-only", debugStepTool.isReadOnly());
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * Removes all breakpoints from the project's {@link XBreakpointManager}.
+     * Called from both {@link #setUp()} and {@link #tearDown()} so that every test
+     * method starts and ends with a zero-breakpoint state regardless of what the
+     * Java plugin may have registered (e.g. the default "Java Exception Breakpoints"
+     * entry) or what a previous test may have added.
+     */
+    private void clearAllBreakpoints() {
+        ApplicationManager.getApplication().runWriteAction(() -> {
+            var mgr = XDebuggerManager.getInstance(getProject()).getBreakpointManager();
+            for (XBreakpoint<?> bp : mgr.getAllBreakpoints()) {
+                //noinspection unchecked,rawtypes
+                mgr.removeBreakpoint((XBreakpoint) bp);
+            }
+        });
+    }
+
+    private static void assertNonBlankId(String id, String toolName) {
+        assertNotNull(toolName + ".id() must not be null", id);
+        assertFalse(toolName + ".id() must not be blank, got: '" + id + "'", id.isBlank());
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/editing/EditingToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/editing/EditingToolsTest.java
@@ -1,0 +1,324 @@
+package com.github.catatafishen.agentbridge.psi.tools.editing;
+
+import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
+import com.github.catatafishen.agentbridge.psi.ToolUtils;
+import com.github.catatafishen.agentbridge.psi.tools.Tool;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.util.ui.UIUtil;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Platform tests for {@link ReplaceSymbolBodyTool}, {@link InsertAfterSymbolTool},
+ * and {@link InsertBeforeSymbolTool}.
+ *
+ * <p>JUnit 3 style (extends BasePlatformTestCase): test methods must be
+ * {@code public void testXxx()}. Run via Gradle only:
+ * {@code ./gradlew :plugin-core:test}.
+ *
+ * <p><b>Threading:</b> all three editing tools use {@code EdtUtil.invokeLater}
+ * internally and complete a {@code CompletableFuture} on the EDT. Because
+ * {@code BasePlatformTestCase} methods already run on the EDT, calling
+ * {@code execute()} directly would deadlock. {@link #executeSync} runs the tool
+ * on a pooled thread while pumping the EDT event queue, mirroring the pattern
+ * from {@code WriteFileToolTest}.
+ *
+ * <p><b>File creation:</b> {@code myFixture.addFileToProject()} creates in-memory
+ * (TempFS) files that are invisible to {@code LocalFileSystem#findFileByPath}. The
+ * editing tools call {@code resolveVirtualFile} which uses that API. Tests therefore
+ * create real disk files under a temp directory and register them in the VFS via
+ * {@code LocalFileSystem#refreshAndFindFileByPath}, following the same pattern as
+ * {@code EditTextToolTest}.
+ *
+ * <p><b>File names:</b> each test method uses a unique temp file name to avoid any
+ * caching collisions.
+ */
+public class EditingToolsTest extends BasePlatformTestCase {
+
+    private ReplaceSymbolBodyTool replaceSymbolBodyTool;
+    private InsertAfterSymbolTool insertAfterSymbolTool;
+    private InsertBeforeSymbolTool insertBeforeSymbolTool;
+    private Path tempDir;
+
+    /**
+     * Java source with a single {@code hello()} method — no package needed for temp files.
+     */
+    private static final String SIMPLE_CLASS_TEMPLATE = """
+        public class %s {
+            public String hello() {
+                return "world";
+            }
+        }
+        """;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Disable follow-agent UI (editor navigation, status-bar feedback)
+        // to avoid spurious editor-lifecycle failures in headless tests.
+        PropertiesComponent.getInstance(getProject())
+            .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
+        replaceSymbolBodyTool = new ReplaceSymbolBodyTool(getProject());
+        insertAfterSymbolTool = new InsertAfterSymbolTool(getProject());
+        insertBeforeSymbolTool = new InsertBeforeSymbolTool(getProject());
+        tempDir = Files.createTempDirectory("editing-tools-test");
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            // Close any editors opened by the tool to prevent DisposalException.
+            FileEditorManager fem = FileEditorManager.getInstance(getProject());
+            for (VirtualFile openFile : fem.getOpenFiles()) {
+                fem.closeFile(openFile);
+            }
+            // Remove temp files created during this test.
+            try (var paths = Files.walk(tempDir)) {
+                paths.sorted(java.util.Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(java.io.File::delete);
+            }
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * Creates a real file on disk and registers it in the VFS so that
+     * {@code LocalFileSystem#findFileByPath} can find it during {@code execute()}.
+     *
+     * <p>This is required because the editing tools call {@code resolveVirtualFile},
+     * which uses {@code LocalFileSystem#findFileByPath} and cannot see TempFS files
+     * created by {@code myFixture.addFileToProject()}.
+     */
+    private String createTestFile(String name, String content) throws IOException {
+        Path file = tempDir.resolve(name);
+        Files.writeString(file, content);
+        VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByPath(file.toString());
+        assertNotNull("Failed to register test file in VFS: " + file, vf);
+        return file.toString();
+    }
+
+    /**
+     * Builds a {@link JsonObject} from alternating key/value String pairs.
+     */
+    private static JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    /**
+     * Runs {@code tool.execute(argsObj)} on a pooled background thread while
+     * pumping the EDT event queue. Required because the editing tools dispatch
+     * write-actions back to the EDT via {@code EdtUtil.invokeLater}. Blocking
+     * the EDT directly would deadlock; this pattern avoids that cycle.
+     */
+    private String executeSync(Tool tool, JsonObject argsObj) throws Exception {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                future.complete(tool.execute(argsObj));
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (!future.isDone()) {
+            UIUtil.dispatchAllInvocationEvents();
+            if (System.currentTimeMillis() > deadline) {
+                fail("tool.execute() timed out after 15 seconds");
+            }
+        }
+        return future.get();
+    }
+
+    // ── ReplaceSymbolBodyTool ─────────────────────────────────────────────────
+
+    /**
+     * Replacing the body of an existing {@code hello()} method must succeed and
+     * return a response that starts with {@code "Replaced lines"}, contains the
+     * file path, and ends with the formatted-imports suffix.
+     */
+    public void testReplaceSymbolBodySuccess() throws Exception {
+        String path = createTestFile("ReplaceSuccess.java",
+            String.format(SIMPLE_CLASS_TEMPLATE, "ReplaceSuccess"));
+
+        String result = executeSync(replaceSymbolBodyTool, args(
+            "file", path,
+            "symbol", "hello",
+            "new_body", """
+                    public String hello() {
+                        return "updated";
+                    }
+                """
+        ));
+
+        assertFalse("Expected success (no error prefix), got: " + result,
+            result.startsWith(ToolUtils.ERROR_PREFIX));
+        assertFalse("Expected success (not symbol-not-found), got: " + result,
+            result.startsWith(EditingTool.SYMBOL_PREFIX));
+        assertTrue("Expected 'Replaced lines' prefix, got: " + result,
+            result.startsWith("Replaced lines"));
+        assertTrue("Expected file path in result, got: " + result,
+            result.contains(path));
+        assertTrue("Expected formatted-imports suffix, got: " + result,
+            result.contains("formatted & imports queued"));
+    }
+
+    /**
+     * When the named symbol does not exist in the file, the tool must return a
+     * message beginning with {@code "Symbol '"} that names the missing symbol.
+     * The file IS present on disk so this exercises the actual symbol-search
+     * code path (not the file-not-found fallback).
+     */
+    public void testReplaceSymbolBodySymbolNotFound() throws Exception {
+        String path = createTestFile("ReplaceNotFound.java",
+            String.format(SIMPLE_CLASS_TEMPLATE, "ReplaceNotFound"));
+
+        String result = executeSync(replaceSymbolBodyTool, args(
+            "file", path,
+            "symbol", "nonExistentMethod_XYZ_Replace",
+            "new_body", "public void nonExistentMethod_XYZ_Replace() {}\n"
+        ));
+
+        assertTrue("Expected symbol-not-found message, got: " + result,
+            result.startsWith(EditingTool.SYMBOL_PREFIX));
+        assertTrue("Expected missing symbol name in message, got: " + result,
+            result.contains("nonExistentMethod_XYZ_Replace"));
+    }
+
+    /**
+     * When the required {@code symbol} argument is omitted, the tool must
+     * return the standard {@code "Missing required parameter: symbol"} error
+     * immediately (before any async dispatch).
+     */
+    public void testReplaceSymbolBodyMissingSymbol() throws Exception {
+        String path = createTestFile("ReplaceMissingSymbol.java",
+            String.format(SIMPLE_CLASS_TEMPLATE, "ReplaceMissingSymbol"));
+
+        JsonObject a = new JsonObject();
+        a.addProperty("file", path);
+        a.addProperty("new_body", "public void foo() {}\n");
+        // "symbol" intentionally omitted
+
+        String result = executeSync(replaceSymbolBodyTool, a);
+
+        assertEquals("Missing required parameter: symbol", result);
+    }
+
+    // ── InsertAfterSymbolTool ─────────────────────────────────────────────────
+
+    /**
+     * Inserting content after an existing method must succeed and return a
+     * response that starts with {@code "Inserted"}, contains {@code "after"},
+     * and contains the file path.
+     */
+    public void testInsertAfterSymbolSuccess() throws Exception {
+        String path = createTestFile("InsertAfterSuccess.java",
+            String.format(SIMPLE_CLASS_TEMPLATE, "InsertAfterSuccess"));
+
+        String result = executeSync(insertAfterSymbolTool, args(
+            "file", path,
+            "symbol", "hello",
+            "content", """
+                    public String goodbye() {
+                        return "bye";
+                    }
+                """
+        ));
+
+        assertFalse("Expected success (no error prefix), got: " + result,
+            result.startsWith(ToolUtils.ERROR_PREFIX));
+        assertFalse("Expected success (not symbol-not-found), got: " + result,
+            result.startsWith(EditingTool.SYMBOL_PREFIX));
+        assertTrue("Expected 'Inserted' prefix, got: " + result,
+            result.startsWith("Inserted"));
+        assertTrue("Expected 'after' in result, got: " + result,
+            result.contains("after"));
+        assertTrue("Expected file path in result, got: " + result,
+            result.contains(path));
+    }
+
+    /**
+     * When the named symbol does not exist in the file, the tool must return a
+     * message beginning with {@code "Symbol '"} that names the missing symbol.
+     */
+    public void testInsertAfterSymbolNotFound() throws Exception {
+        String path = createTestFile("InsertAfterNotFound.java",
+            String.format(SIMPLE_CLASS_TEMPLATE, "InsertAfterNotFound"));
+
+        String result = executeSync(insertAfterSymbolTool, args(
+            "file", path,
+            "symbol", "nonExistentSymbol_ABC_After",
+            "content", "    public void extra() {}\n"
+        ));
+
+        assertTrue("Expected symbol-not-found message, got: " + result,
+            result.startsWith(EditingTool.SYMBOL_PREFIX));
+        assertTrue("Expected missing symbol name in message, got: " + result,
+            result.contains("nonExistentSymbol_ABC_After"));
+    }
+
+    // ── InsertBeforeSymbolTool ────────────────────────────────────────────────
+
+    /**
+     * Inserting content before an existing method must succeed and return a
+     * response that starts with {@code "Inserted"}, contains {@code "before"},
+     * and contains the file path.
+     */
+    public void testInsertBeforeSymbolSuccess() throws Exception {
+        String path = createTestFile("InsertBeforeSuccess.java",
+            String.format(SIMPLE_CLASS_TEMPLATE, "InsertBeforeSuccess"));
+
+        String result = executeSync(insertBeforeSymbolTool, args(
+            "file", path,
+            "symbol", "hello",
+            "content", "    // inserted comment\n"
+        ));
+
+        assertFalse("Expected success (no error prefix), got: " + result,
+            result.startsWith(ToolUtils.ERROR_PREFIX));
+        assertFalse("Expected success (not symbol-not-found), got: " + result,
+            result.startsWith(EditingTool.SYMBOL_PREFIX));
+        assertTrue("Expected 'Inserted' prefix, got: " + result,
+            result.startsWith("Inserted"));
+        assertTrue("Expected 'before' in result, got: " + result,
+            result.contains("before"));
+        assertTrue("Expected file path in result, got: " + result,
+            result.contains(path));
+    }
+
+    /**
+     * When the named symbol does not exist in the file, the tool must return a
+     * message beginning with {@code "Symbol '"} that names the missing symbol.
+     */
+    public void testInsertBeforeSymbolNotFound() throws Exception {
+        String path = createTestFile("InsertBeforeNotFound.java",
+            String.format(SIMPLE_CLASS_TEMPLATE, "InsertBeforeNotFound"));
+
+        String result = executeSync(insertBeforeSymbolTool, args(
+            "file", path,
+            "symbol", "nonExistentSymbol_DEF_Before",
+            "content", "    // comment\n"
+        ));
+
+        assertTrue("Expected symbol-not-found message, got: " + result,
+            result.startsWith(EditingTool.SYMBOL_PREFIX));
+        assertTrue("Expected missing symbol name in message, got: " + result,
+            result.contains("nonExistentSymbol_DEF_Before"));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/editor/EditorToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/editor/EditorToolsTest.java
@@ -1,0 +1,395 @@
+package com.github.catatafishen.agentbridge.psi.tools.editor;
+
+import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
+import com.github.catatafishen.agentbridge.psi.ToolUtils;
+import com.github.catatafishen.agentbridge.psi.tools.Tool;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.util.ui.UIUtil;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Platform tests for editor tools: {@link GetActiveFileTool}, {@link GetOpenEditorsTool},
+ * {@link OpenInEditorTool}, {@link ListScratchFilesTool}, {@link CreateScratchFileTool},
+ * and {@link ListThemesTool}.
+ *
+ * <p>JUnit 3 style (extends {@link BasePlatformTestCase}): test methods must be
+ * {@code public void testXxx()}. Run via Gradle only:
+ * {@code ./gradlew :plugin-core:test}.
+ *
+ * <p><b>Threading:</b> tools that use {@code EdtUtil.invokeLater} ({@link GetActiveFileTool},
+ * {@link GetOpenEditorsTool}, {@link OpenInEditorTool}) dispatch their result to the EDT via a
+ * {@code CompletableFuture}. Because {@code BasePlatformTestCase} methods already run on the EDT,
+ * calling {@code execute()} directly would deadlock. {@link #executeSync} runs those tools on a
+ * pooled thread while pumping the EDT event queue, mirroring the pattern from
+ * {@code EditingToolsTest}.
+ *
+ * <p>Tools that use {@code EdtUtil.invokeAndWait} ({@link ListScratchFilesTool},
+ * {@link CreateScratchFileTool}) check {@code isDispatchThread()} internally and run their
+ * runnable inline when called from the EDT, so they can be called directly in tests.
+ * {@link ListThemesTool} is synchronous and needs no special handling.
+ */
+public class EditorToolsTest extends BasePlatformTestCase {
+
+    private GetActiveFileTool getActiveFileTool;
+    private GetOpenEditorsTool getOpenEditorsTool;
+    private OpenInEditorTool openInEditorTool;
+    private ListScratchFilesTool listScratchFilesTool;
+    private CreateScratchFileTool createScratchFileTool;
+    private ListThemesTool listThemesTool;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Disable "follow agent files" UI navigation to prevent editor lifecycle
+        // failures (DisposalException, focus stealing) in the headless test environment.
+        // Use the String overload — the boolean overload silently removes the key when
+        // value == defaultValue (true), which would leave the setting at true.
+        PropertiesComponent.getInstance(getProject())
+            .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
+
+        getActiveFileTool = new GetActiveFileTool(getProject());
+        getOpenEditorsTool = new GetOpenEditorsTool(getProject());
+        openInEditorTool = new OpenInEditorTool(getProject());
+        listScratchFilesTool = new ListScratchFilesTool(getProject());
+        createScratchFileTool = new CreateScratchFileTool(getProject());
+        listThemesTool = new ListThemesTool(getProject());
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            // Close any editors opened during this test to prevent DisposalException
+            // in the next test or when the fixture is torn down.
+            FileEditorManager fem = FileEditorManager.getInstance(getProject());
+            for (VirtualFile f : fem.getOpenFiles()) {
+                fem.closeFile(f);
+            }
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * Builds a {@link JsonObject} from alternating key/value String pairs.
+     * Example: {@code args("file", "/tmp/foo.java", "line", "10")}.
+     */
+    private static JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    /**
+     * Runs {@code tool.execute(argsObj)} on a pooled background thread while
+     * pumping the EDT event queue. Required because tools using
+     * {@code EdtUtil.invokeLater} schedule their result callback on the EDT via a
+     * {@code CompletableFuture}: calling {@code execute()} directly from the EDT
+     * would block, preventing the scheduled callback from ever running.
+     * Running the tool off the EDT and pumping events with
+     * {@code UIUtil.dispatchAllInvocationEvents()} breaks this deadlock.
+     */
+    private String executeSync(Tool tool, JsonObject argsObj) throws Exception {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                future.complete(tool.execute(argsObj));
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (!future.isDone()) {
+            UIUtil.dispatchAllInvocationEvents();
+            if (System.currentTimeMillis() > deadline) {
+                fail("tool.execute() timed out after 15 seconds");
+            }
+        }
+        return future.get();
+    }
+
+    // ── GetActiveFileTool ─────────────────────────────────────────────────────
+
+    /**
+     * When no file is open in the editor, {@code get_active_file} must return
+     * exactly "No active editor" — the standard response when
+     * {@code FileEditorManager.getSelectedTextEditor()} returns {@code null}.
+     */
+    public void testGetActiveFileNoOpenEditors() throws Exception {
+        // No configureByText call — no editor should be open in a freshly initialised test.
+        String result = executeSync(getActiveFileTool, new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        assertEquals("Expected 'No active editor' when no file is open, got: " + result,
+            "No active editor", result);
+    }
+
+    /**
+     * Verifies the tool returns a non-blank, non-null string even when the
+     * editor is empty — it should never throw or produce a null/blank result.
+     */
+    public void testGetActiveFileReturnType() throws Exception {
+        String result = executeSync(getActiveFileTool, new JsonObject());
+
+        assertNotNull(result);
+        assertFalse("Result must not be blank", result.isBlank());
+    }
+
+    // ── GetOpenEditorsTool ────────────────────────────────────────────────────
+
+    /**
+     * When no file is open, {@code get_open_editors} must return exactly
+     * "No open editors" — the standard empty-panel response from
+     * {@link GetOpenEditorsTool}.
+     */
+    public void testGetOpenEditorsNoFiles() throws Exception {
+        String result = executeSync(getOpenEditorsTool, new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        assertEquals("Expected 'No open editors' when no file is open, got: " + result,
+            "No open editors", result);
+    }
+
+    /**
+     * After opening a file via the fixture, {@code get_open_editors} must return
+     * the "Open editors (N):" summary header and include the opened filename.
+     *
+     * <p>{@code myFixture.configureByText()} creates a light in-memory VFS file and
+     * registers it with {@code FileEditorManager}, so {@code getOpenFiles()} returns it.
+     */
+    public void testGetOpenEditorsWithFile() throws Exception {
+        // Open an in-memory file — FileEditorManager tracks it in the light test fixture.
+        myFixture.configureByText("OpenEditorsSubject.java", "class OpenEditorsSubject {}");
+
+        String result = executeSync(getOpenEditorsTool, new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        assertTrue("Expected 'Open editors' count header, got: " + result,
+            result.contains("Open editors ("));
+        assertTrue("Expected 'OpenEditorsSubject.java' in result, got: " + result,
+            result.contains("OpenEditorsSubject.java"));
+    }
+
+    /**
+     * The active file (most recently configured) is marked with "* " in the listing.
+     * After calling {@code configureByText}, that file is the selected editor.
+     */
+    public void testGetOpenEditorsActiveFileMarked() throws Exception {
+        myFixture.configureByText("ActiveMarker.java", "class ActiveMarker {}");
+
+        String result = executeSync(getOpenEditorsTool, new JsonObject());
+
+        assertNotNull(result);
+        // Active file should be prefixed with "* " in the listing.
+        assertTrue("Expected '* ' active-file marker in result, got: " + result,
+            result.contains("* "));
+    }
+
+    // ── OpenInEditorTool ──────────────────────────────────────────────────────
+
+    /**
+     * When the required {@code file} argument is omitted entirely, the tool must
+     * return the standard error message "Error: 'file' parameter is required"
+     * without dispatching any EDT work.
+     */
+    public void testOpenInEditorMissingPath() throws Exception {
+        String result = executeSync(openInEditorTool, new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        assertEquals("Expected 'file' param error, got: " + result,
+            "Error: 'file' parameter is required", result);
+    }
+
+    /**
+     * When the {@code file} argument points to a path that does not exist on disk,
+     * the tool must return an error message that starts with {@code "Error: "},
+     * contains {@code "File not found:"}, and includes the requested path —
+     * matching the constants from {@link ToolUtils}.
+     */
+    public void testOpenInEditorNonExistentPath() throws Exception {
+        String nonExistentPath = "/nonexistent/totally/fake/path/XyzMissingFile.java";
+
+        String result = executeSync(openInEditorTool, args("file", nonExistentPath));
+
+        assertNotNull("Result must not be null", result);
+        assertTrue("Expected error prefix 'Error: ', got: " + result,
+            result.startsWith(ToolUtils.ERROR_PREFIX));
+        assertTrue("Expected 'File not found:' in result, got: " + result,
+            result.contains(ToolUtils.ERROR_FILE_NOT_FOUND));
+        assertTrue("Expected the non-existent path in result, got: " + result,
+            result.contains(nonExistentPath));
+    }
+
+    /**
+     * Verifies that when {@code file} is missing, the tool returns its error
+     * message immediately — the result must never be blank, null, or a raw
+     * Java exception string.
+     */
+    public void testOpenInEditorMissingPathIsNotBlank() throws Exception {
+        String result = executeSync(openInEditorTool, new JsonObject());
+
+        assertNotNull(result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertFalse("Result must not be a raw Java exception", result.startsWith("java."));
+    }
+
+    // ── ListScratchFilesTool ──────────────────────────────────────────────────
+
+    /**
+     * {@code list_scratch_files} with empty args must return a non-error, non-blank
+     * response. In a fresh test environment the scratch directory may not exist, in which
+     * case the tool returns "0 scratch files\nUse create_scratch_file to create one.";
+     * if it does exist the tool lists whatever files are present.
+     *
+     * <p>{@link ListScratchFilesTool} uses {@code EdtUtil.invokeAndWait} which detects
+     * {@code isDispatchThread() == true} and runs the runnable inline — so calling
+     * {@code execute()} directly from the EDT is safe.
+     */
+    public void testListScratchFiles() throws Exception {
+        String result = listScratchFilesTool.execute(new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        // The tool never silently errors — it always returns either a count line or a listing.
+        assertFalse("Result must not start with 'Error listing scratch files:'",
+            result.startsWith("Error listing scratch files:"));
+        assertTrue("Expected 'scratch' in result (count or listing), got: " + result,
+            result.contains("scratch"));
+    }
+
+    /**
+     * The empty-scratch-directory response has the form:
+     * {@code "0 scratch files\nUse create_scratch_file to create one."}.
+     * If the scratch dir exists but is empty, this exact message is returned.
+     */
+    public void testListScratchFilesEmptyDirMessage() throws Exception {
+        String result = listScratchFilesTool.execute(new JsonObject());
+
+        assertNotNull(result);
+        // Two valid outcomes depending on whether scratch files exist in this environment.
+        boolean isCountResponse = result.startsWith("0 scratch files")
+            || result.matches("\\d+ scratch files:.*");
+        boolean isListingResponse = result.contains("scratch files:");
+        assertTrue("Expected a count or listing response, got: " + result,
+            isCountResponse || isListingResponse);
+    }
+
+    // ── CreateScratchFileTool ─────────────────────────────────────────────────
+
+    /**
+     * {@code create_scratch_file} with no {@code name} argument falls back to
+     * {@code "scratch.txt"} rather than throwing or returning an error, because the
+     * implementation treats {@code name} as optional (defaults to "scratch.txt") despite
+     * the input schema marking it as required.
+     *
+     * <p>This test verifies graceful handling of the missing parameter: the tool must
+     * return a non-blank, non-null string — either a success message
+     * {@code "Created scratch file: ...scratch.txt..."} or a descriptive error string.
+     * It must never throw an unhandled exception.
+     *
+     * <p>{@link CreateScratchFileTool} uses {@code EdtUtil.invokeAndWait} (EDT-check inline)
+     * so it can be called directly from the test method.
+     */
+    public void testCreateScratchFileMissingName() throws Exception {
+        // Provide only "content"; omit the "name" parameter.
+        // The tool defaults name to "scratch.txt" when absent.
+        JsonObject argsObj = new JsonObject();
+        argsObj.addProperty("content", "// test content without explicit name");
+
+        String result = createScratchFileTool.execute(argsObj);
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        // Either the file was created ("Created scratch file: ...") or an error was reported.
+        boolean isValidResponse = result.startsWith("Created scratch file:")
+            || result.startsWith("Error");
+        assertTrue("Expected a 'Created' or 'Error' response, got: " + result, isValidResponse);
+    }
+
+    /**
+     * {@code create_scratch_file} with both {@code name} and {@code content} must
+     * succeed and return a "Created scratch file:" message that contains the filename.
+     */
+    public void testCreateScratchFileWithNameAndContent() throws Exception {
+        JsonObject argsObj = new JsonObject();
+        argsObj.addProperty("name", "test-editor-tools.md");
+        argsObj.addProperty("content", "# Editor Tools Test\n\nContent here.");
+
+        String result = createScratchFileTool.execute(argsObj);
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        // Success path: "Created scratch file: .../test-editor-tools.md (N chars)"
+        // Failure path (e.g. IO error in test env): must still be a descriptive error.
+        assertTrue("Expected success or error response, got: " + result,
+            result.startsWith("Created scratch file:") || result.startsWith("Error"));
+    }
+
+    // ── ListThemesTool ────────────────────────────────────────────────────────
+
+    /**
+     * {@code list_themes} must return a non-blank response that starts with the
+     * "Available themes:" header. IntelliJ always ships with built-in themes
+     * (at minimum Darcula and IntelliJ Light), so the listing is never empty.
+     */
+    public void testListThemes() {
+        // ListThemesTool is synchronous (no EDT dispatch) — safe to call directly.
+        String result = listThemesTool.execute(new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertTrue("Expected 'Available themes:' header, got: " + result,
+            result.contains("Available themes:"));
+    }
+
+    /**
+     * Verifies the theme-entry format contract when entries are present: bullet/active
+     * markers, dark/light labels, and the {@code "← current"} active-theme marker.
+     *
+     * <p>In the headless Gradle test sandbox, {@code LafManager.getInstalledThemes()}
+     * may return an empty sequence, in which case the response contains only the
+     * "Available themes:" header. Both cases are valid — the important invariant is
+     * that the tool never throws and always includes the header. Theme-specific
+     * assertions are guarded by an entry-presence check.
+     */
+    public void testListThemesFormatWhenEntriesPresent() {
+        String result = listThemesTool.execute(new JsonObject());
+
+        assertNotNull(result);
+        assertTrue("Expected 'Available themes:' header, got: " + result,
+            result.contains("Available themes:"));
+
+        boolean hasEntries = result.contains("•") || result.contains("▸");
+        if (hasEntries) {
+            // When theme entries ARE present, each must carry a dark/light label.
+            assertTrue("Entries present but no '(dark)' or '(light)' label, got: " + result,
+                result.contains("(dark)") || result.contains("(light)"));
+            // And the active theme must be identified.
+            assertTrue("Entries present but no '← current' active marker, got: " + result,
+                result.contains("← current"));
+        }
+        // No entries: headless Gradle sandbox has no registered themes — header alone is fine.
+    }
+
+    /**
+     * Verifies the result is never an error message regardless of theme availability.
+     * The tool must always return a response that starts with "Available themes:".
+     */
+    public void testListThemesNeverErrors() {
+        String result = listThemesTool.execute(new JsonObject());
+
+        assertNotNull(result);
+        assertFalse("Result must not start with 'Error'", result.startsWith("Error"));
+        assertTrue("Result must always start with 'Available themes:', got: " + result,
+            result.startsWith("Available themes:"));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/EditTextToolTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/EditTextToolTest.java
@@ -1,0 +1,241 @@
+package com.github.catatafishen.agentbridge.psi.tools.file;
+
+import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
+import com.github.catatafishen.agentbridge.psi.ToolUtils;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.util.ui.UIUtil;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+/**
+ * Platform tests for {@link EditTextTool}.
+ *
+ * <p>JUnit 3 style (extends BasePlatformTestCase): test methods must be {@code public void testXxx()}.
+ * Run via Gradle only: {@code ./gradlew :plugin-core:test}.
+ *
+ * <p><b>File creation note:</b> {@code myFixture.addFileToProject()} creates in-memory VFS files
+ * that are invisible to {@code LocalFileSystem#findFileByPath}. Tests use real disk files
+ * created under a temp directory, registered in the VFS via
+ * {@code LocalFileSystem#refreshAndFindFileByPath}.
+ *
+ * <p><b>Editor lifecycle note:</b> EditTextTool (a subclass of WriteFileTool) may open editors
+ * when {@code followFileIfEnabled} is active. We disable that setting in setUp and close all
+ * editors in tearDown to prevent "Editor hasn't been released" errors.
+ */
+public class EditTextToolTest extends BasePlatformTestCase {
+
+    private EditTextTool tool;
+    private Path tempDir;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Prevent followFileIfEnabled from opening Editors during tests.
+        // Use the String overload — the boolean overload removes the key when value==defaultValue,
+        // which would leave the setting at its default (true) instead of setting it to false.
+        PropertiesComponent.getInstance(getProject())
+            .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
+        tool = new EditTextTool(getProject());
+        tempDir = Files.createTempDirectory("edit-text-tool-test");
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            // Close any editors the tool may have opened to prevent DisposalException.
+            FileEditorManager fem = FileEditorManager.getInstance(getProject());
+            for (VirtualFile openFile : fem.getOpenFiles()) {
+                fem.closeFile(openFile);
+            }
+            deleteDir(tempDir);
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    /**
+     * Creates a real file on disk and registers it in the VFS so that
+     * {@code LocalFileSystem#findFileByPath} can find it during {@code execute()}.
+     */
+    private VirtualFile createTestFile(String name, String content) {
+        try {
+            Path file = tempDir.resolve(name);
+            Files.writeString(file, content);
+            VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByPath(file.toString());
+            assertNotNull("Failed to register test file in VFS: " + file, vf);
+            return vf;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create test file: " + name, e);
+        }
+    }
+
+    private static void deleteDir(Path dir) {
+        if (dir == null || !Files.exists(dir)) return;
+        try (Stream<Path> walk = Files.walk(dir)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException ignored) {
+                    // best-effort cleanup
+                }
+            });
+        } catch (IOException ignored) {
+            // best-effort cleanup
+        }
+    }
+
+    /**
+     * Builds a JsonObject from alternating String key/value pairs.
+     * Example: {@code args("path", "/tmp/f.txt", "old_str", "foo", "new_str", "bar")}
+     */
+    private JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    /**
+     * Runs {@code tool.execute(argsObj)} on a pooled background thread while pumping
+     * the EDT event queue on the calling thread. This is required because
+     * {@code BasePlatformTestCase} methods run on the EDT, and EditTextTool (a subclass
+     * of WriteFileTool) uses {@code EdtUtil.invokeLater} to schedule write-actions back
+     * onto the EDT. Blocking the EDT directly would deadlock; running execute() off-EDT
+     * and pumping the queue resolves that cycle.
+     */
+    private String executeSync(JsonObject argsObj) throws Exception {
+        java.util.concurrent.CompletableFuture<String> future = new java.util.concurrent.CompletableFuture<>();
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                future.complete(tool.execute(argsObj));
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (!future.isDone()) {
+            UIUtil.dispatchAllInvocationEvents();
+            if (System.currentTimeMillis() > deadline) {
+                fail("tool.execute() timed out after 15 seconds");
+            }
+        }
+        return future.get();
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────────
+
+    /**
+     * Passing an explicit JSON null for "path" should return the standard error constant.
+     */
+    public void testNullPathReturnsError() throws Exception {
+        JsonObject a = new JsonObject();
+        a.add("path", null);
+        String result = executeSync(a);
+        assertEquals(ToolUtils.ERROR_PATH_REQUIRED, result);
+    }
+
+    /**
+     * When {@code old_str} is not present in the file the response must contain
+     * "old_str not found in".
+     */
+    public void testOldStrNotFoundReturnsError() throws Exception {
+        VirtualFile vf = createTestFile("notfound.txt", "hello world");
+
+        String result = executeSync(
+            args("path", vf.getPath(), "old_str", "nonexistent text", "new_str", "replacement"));
+
+        assertTrue("Expected 'old_str not found in' error, got: " + result,
+            result.contains("old_str not found in"));
+    }
+
+    /**
+     * A successful find-and-replace must return a response starting with "Edited:".
+     */
+    public void testSuccessfulEditReturnsEditedMessage() throws Exception {
+        VirtualFile vf = createTestFile("edit.txt", "hello world");
+
+        String result = executeSync(
+            args("path", vf.getPath(), "old_str", "hello", "new_str", "goodbye"));
+
+        assertTrue("Expected 'Edited:' prefix, got: " + result, result.startsWith("Edited:"));
+    }
+
+    /**
+     * After a successful edit the file on disk must reflect the replacement.
+     */
+    public void testSuccessfulEditUpdatesFileContent() throws Exception {
+        VirtualFile vf = createTestFile("update.txt", "The quick brown fox");
+
+        executeSync(args("path", vf.getPath(), "old_str", "quick brown", "new_str", "slow red"));
+
+        // Read from disk directly — bypasses any stale VFS cache
+        String actual = Files.readString(Path.of(vf.getPath()));
+        assertEquals("The slow red fox", actual);
+    }
+
+    /**
+     * When {@code old_str} appears more than once without {@code replace_all: true}
+     * the response must contain "old_str matches multiple locations in".
+     */
+    public void testMultipleMatchesReturnsError() throws Exception {
+        VirtualFile vf = createTestFile("multi.txt", "foo bar foo bar");
+
+        String result = executeSync(
+            args("path", vf.getPath(), "old_str", "foo", "new_str", "baz"));
+
+        assertTrue("Expected multiple-matches error, got: " + result,
+            result.contains("old_str matches multiple locations in"));
+    }
+
+    /**
+     * With {@code replace_all: true} every occurrence of {@code old_str} must be replaced
+     * and the response must start with "Edited:".
+     */
+    public void testReplaceAllReplacesAllOccurrences() throws Exception {
+        VirtualFile vf = createTestFile("replaceall.txt", "cat and cat and cat");
+
+        JsonObject a = new JsonObject();
+        a.addProperty("path", vf.getPath());
+        a.addProperty("old_str", "cat");
+        a.addProperty("new_str", "dog");
+        a.addProperty("replace_all", true);
+        String result = executeSync(a);
+
+        assertTrue("Expected 'Edited:' prefix, got: " + result, result.startsWith("Edited:"));
+        String actual = Files.readString(Path.of(vf.getPath()));
+        assertEquals("dog and dog and dog", actual);
+    }
+
+    /**
+     * With {@code case_sensitive: false} the match must be case-insensitive while the
+     * replacement is inserted exactly as supplied. The response must start with "Edited:".
+     */
+    public void testCaseInsensitiveMatch() throws Exception {
+        VirtualFile vf = createTestFile("case.txt", "Hello World");
+
+        JsonObject a = new JsonObject();
+        a.addProperty("path", vf.getPath());
+        a.addProperty("old_str", "hello world");
+        a.addProperty("new_str", "Goodbye");
+        a.addProperty("case_sensitive", false);
+        String result = executeSync(a);
+
+        assertTrue("Expected 'Edited:' prefix for case-insensitive match, got: " + result,
+            result.startsWith("Edited:"));
+        String actual = Files.readString(Path.of(vf.getPath()));
+        assertEquals("Goodbye", actual);
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/WriteFileToolTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/WriteFileToolTest.java
@@ -1,0 +1,245 @@
+package com.github.catatafishen.agentbridge.psi.tools.file;
+
+import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
+import com.github.catatafishen.agentbridge.psi.ToolUtils;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.util.ui.UIUtil;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+/**
+ * Platform tests for {@link WriteFileTool}.
+ *
+ * <p>JUnit 3 style (extends BasePlatformTestCase): test methods must be {@code public void testXxx()}.
+ * Run via Gradle only: {@code ./gradlew :plugin-core:test}.
+ *
+ * <p><b>File creation note:</b> {@code myFixture.addFileToProject()} creates in-memory VFS files
+ * that are invisible to {@code LocalFileSystem#findFileByPath}. Tests use real disk files
+ * created under a temp directory, registered in the VFS via
+ * {@code LocalFileSystem#refreshAndFindFileByPath}.
+ *
+ * <p><b>Editor lifecycle note:</b> WriteFileTool may open editors when
+ * {@code followFileIfEnabled} is active. We disable that setting in setUp and
+ * close all editors in tearDown to prevent "Editor hasn't been released" errors.
+ */
+public class WriteFileToolTest extends BasePlatformTestCase {
+
+    private WriteFileTool tool;
+    private Path tempDir;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Prevent followFileIfEnabled from opening Editors during tests.
+        // Use the String overload — the boolean overload removes the key when value==defaultValue,
+        // which would leave the setting at its default (true) instead of setting it to false.
+        PropertiesComponent.getInstance(getProject())
+            .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
+        tool = new WriteFileTool(getProject());
+        tempDir = Files.createTempDirectory("write-file-tool-test");
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            // Close any editors the tool may have opened to prevent DisposalException.
+            FileEditorManager fem = FileEditorManager.getInstance(getProject());
+            for (VirtualFile openFile : fem.getOpenFiles()) {
+                fem.closeFile(openFile);
+            }
+            deleteDir(tempDir);
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    /**
+     * Creates a real file on disk and registers it in the VFS so that
+     * {@code LocalFileSystem#findFileByPath} can find it during {@code execute()}.
+     */
+    private VirtualFile createTestFile(String name, String content) {
+        try {
+            Path file = tempDir.resolve(name);
+            Files.writeString(file, content);
+            VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByPath(file.toString());
+            assertNotNull("Failed to register test file in VFS: " + file, vf);
+            return vf;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create test file: " + name, e);
+        }
+    }
+
+    private static void deleteDir(Path dir) {
+        if (dir == null || !Files.exists(dir)) return;
+        try (Stream<Path> walk = Files.walk(dir)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException ignored) {
+                    // best-effort cleanup
+                }
+            });
+        } catch (IOException ignored) {
+            // best-effort cleanup
+        }
+    }
+
+    /**
+     * Builds a JsonObject from alternating key/value pairs.
+     * Example: {@code args("path", "/tmp/f.txt", "content", "hello")}
+     */
+    private JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    /**
+     * Runs {@code tool.execute(argsObj)} on a pooled background thread while pumping
+     * the EDT event queue on the calling thread. This is required because
+     * {@code BasePlatformTestCase} methods run on the EDT, and WriteFileTool uses
+     * {@code EdtUtil.invokeLater} to schedule write-actions back onto the EDT.
+     * Blocking the EDT directly would deadlock; running execute() off-EDT and pumping
+     * the queue resolves that cycle.
+     */
+    private String executeSync(JsonObject argsObj) throws Exception {
+        java.util.concurrent.CompletableFuture<String> future = new java.util.concurrent.CompletableFuture<>();
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                future.complete(tool.execute(argsObj));
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (!future.isDone()) {
+            UIUtil.dispatchAllInvocationEvents();
+            if (System.currentTimeMillis() > deadline) {
+                fail("tool.execute() timed out after 15 seconds");
+            }
+        }
+        return future.get();
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────────
+
+    /**
+     * Passing an explicit JSON null for "path" should return the standard error.
+     */
+    public void testNullPathReturnsError() throws Exception {
+        JsonObject a = new JsonObject();
+        a.add("path", null);
+        String result = executeSync(a);
+        assertEquals(ToolUtils.ERROR_PATH_REQUIRED, result);
+    }
+
+    /**
+     * Omitting the "path" key entirely should return the standard error.
+     */
+    public void testMissingPathReturnsError() throws Exception {
+        String result = executeSync(new JsonObject());
+        assertEquals(ToolUtils.ERROR_PATH_REQUIRED, result);
+    }
+
+    /**
+     * Writing to a path that does not yet exist should create the file
+     * and return a response that starts with "Created:".
+     * <p>
+     * New-file creation uses direct disk I/O + {@code WriteAction.run()} (no
+     * {@code EdtUtil.invokeLater}), so it is safe to call {@code execute()} directly
+     * from the EDT test thread.
+     */
+    public void testWriteNewFile() throws Exception {
+        Path newFile = tempDir.resolve("newfile.txt");
+        assertFalse("File must not exist before the test", Files.exists(newFile));
+
+        String result = tool.execute(args("path", newFile.toString(), "content", "hello world"));
+
+        assertTrue("Expected 'Created:' prefix, got: " + result, result.startsWith("Created:"));
+    }
+
+    /**
+     * After creating a new file the content on disk must match what was passed.
+     * <p>
+     * New-file creation uses direct disk I/O + {@code WriteAction.run()} (no
+     * {@code EdtUtil.invokeLater}), so it is safe to call {@code execute()} directly
+     * from the EDT test thread.
+     */
+    public void testWriteNewFileCreatesContent() throws Exception {
+        Path newFile = tempDir.resolve("created.txt");
+        String expected = "line1\nline2\nline3";
+
+        tool.execute(args("path", newFile.toString(), "content", expected));
+
+        assertTrue("File should exist on disk after creation", Files.exists(newFile));
+        assertEquals(expected, Files.readString(newFile));
+    }
+
+    /**
+     * Writing to an already-existing file should return a response that starts with "Written:".
+     */
+    public void testWriteExistingFile() throws Exception {
+        VirtualFile vf = createTestFile("existing.txt", "original content");
+
+        String result = executeSync(args("path", vf.getPath(), "content", "updated content"));
+
+        assertTrue("Expected 'Written:' prefix, got: " + result, result.startsWith("Written:"));
+    }
+
+    /**
+     * After writing to an existing file, the content on disk must match the new content.
+     */
+    public void testWriteExistingFileUpdatesContent() throws Exception {
+        VirtualFile vf = createTestFile("update.txt", "old content");
+        String newContent = "brand new content";
+
+        executeSync(args("path", vf.getPath(), "content", newContent));
+
+        // Read from disk directly — bypasses any stale VFS cache
+        String actual = Files.readString(Path.of(vf.getPath()));
+        assertEquals(newContent, actual);
+    }
+
+    /**
+     * Writing an empty string to an existing file should succeed and the response
+     * should start with "Written:".
+     */
+    public void testWriteEmptyContent() throws Exception {
+        VirtualFile vf = createTestFile("empty.txt", "some content");
+
+        String result = executeSync(args("path", vf.getPath(), "content", ""));
+
+        assertTrue("Expected 'Written:' prefix for empty content, got: " + result,
+            result.startsWith("Written:"));
+        String actual = Files.readString(Path.of(vf.getPath()));
+        assertEquals("", actual);
+    }
+
+    /**
+     * Writing multi-line content should succeed and produce the correct file on disk.
+     */
+    public void testWriteMultilineContent() throws Exception {
+        VirtualFile vf = createTestFile("multiline.txt", "initial");
+        String multiline = "line one\nline two\nline three\nline four";
+
+        String result = executeSync(args("path", vf.getPath(), "content", multiline));
+
+        assertTrue("Expected 'Written:' prefix, got: " + result, result.startsWith("Written:"));
+        String actual = Files.readString(Path.of(vf.getPath()));
+        assertEquals(multiline, actual);
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitToolsTest.java
@@ -1,0 +1,521 @@
+package com.github.catatafishen.agentbridge.psi.tools.git;
+
+import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Platform tests for all git tools: {@link GitStatusTool}, {@link GitLogTool},
+ * {@link GitBranchTool}, {@link GitDiffTool}, {@link GitStageTool}, and
+ * {@link GitCommitTool}.
+ *
+ * <p>A real git repository is initialised inside {@code getProject().getBasePath()}
+ * during {@link #setUp()} so that every process-based git command has a valid working
+ * tree and at least one commit to operate on.
+ *
+ * <p>JUnit 3 style (extends {@link BasePlatformTestCase}): test methods must be
+ * {@code public void testXxx()}. Run via Gradle only:
+ * {@code ./gradlew :plugin-core:test}.
+ *
+ * <p><b>Safety:</b> Stage/commit tests only exercise error paths (missing arguments,
+ * nothing staged) — no commits are ever made to the real repository.
+ */
+public class GitToolsTest extends BasePlatformTestCase {
+
+    private String basePath;
+    /**
+     * Absolute path to the git executable (resolved once in setUp).
+     */
+    private String gitExec;
+
+    // ── Test lifecycle ────────────────────────────────────────────────────────────
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        // Disable follow-along UI behaviour (opens tool windows, navigates editors).
+        // Use the String overload -- the boolean overload removes the key when value==default,
+        // which would leave the setting at its default (true) rather than forcing it false.
+        PropertiesComponent.getInstance(getProject())
+            .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
+
+        basePath = getProject().getBasePath();
+        assertNotNull("BasePlatformTestCase must provide a non-null project base path", basePath);
+
+        // Light test projects may use virtual (in-memory) VFS paths that don't exist
+        // on the real filesystem. ProcessBuilder.start() requires a real directory as
+        // working directory, so we ensure it exists before running any git commands.
+        Files.createDirectories(Path.of(basePath));
+
+        // Resolve the git executable. The Gradle test runner may not have 'git' in PATH
+        // (it inherits a restricted environment), so we probe common fixed locations first
+        // and fall back to the bare 'git' command only as a last resort.
+        gitExec = resolveGitExecutable();
+
+        // Initialise a git repository so that runGitProcess() has a valid working tree.
+        // Git4Idea's GitRepositoryManager won't know about this repo (it was just created),
+        // so PlatformApiCompat.runIdeGitCommand returns null and the fallback process-based
+        // path is used -- which reads getProject().getBasePath() as its working directory.
+        git("init");
+        git("config", "user.email", "test@example.com");
+        git("config", "user.name", "Test User");
+
+        // Create and commit a single file so that git-log, branch listing, and the
+        // "nothing staged" pre-flight check all have a meaningful state to operate on.
+        Path readme = Path.of(basePath, "README.md");
+        Files.writeString(readme, "# Test Repository\n");
+        git("add", "README.md");
+        git("commit", "-m", "chore: initial test commit");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────────
+
+    /**
+     * Runs a git command in {@link #basePath}, discarding output.
+     * Used only during test set-up, never during SUT execution.
+     */
+    private void git(String... args) throws Exception {
+        List<String> cmd = new ArrayList<>();
+        cmd.add(gitExec);
+        cmd.addAll(List.of(args));
+        Process p = new ProcessBuilder(cmd)
+            .directory(new File(basePath))
+            .redirectErrorStream(true)
+            .start();
+        // Drain stdout/stderr to prevent the subprocess from blocking on a full pipe buffer.
+        p.getInputStream().readAllBytes();
+        p.waitFor();
+    }
+
+    /**
+     * Resolves the git executable to an absolute path.
+     *
+     * <p>The Gradle test runner inherits a restricted environment that may omit '/usr/bin'
+     * from PATH. Rather than relying on PATH resolution, we probe well-known locations
+     * for git and only fall back to the bare {@code "git"} command as a last resort.
+     *
+     * <p>On Linux git is almost always at {@code /usr/bin/git}; on macOS Homebrew installs
+     * to {@code /usr/local/bin/git} or {@code /opt/homebrew/bin/git}.
+     */
+    private static String resolveGitExecutable() {
+        for (String candidate : List.of(
+            "/usr/bin/git",
+            "/usr/local/bin/git",
+            "/opt/homebrew/bin/git",
+            "/opt/local/bin/git"   // MacPorts
+        )) {
+            if (new File(candidate).canExecute()) {
+                return candidate;
+            }
+        }
+        return "git"; // last resort: rely on PATH
+    }
+
+    /**
+     * Builds a {@link JsonObject} from alternating key/value {@link String} pairs.
+     * Example: {@code args("action", "list", "format", "oneline")}
+     */
+    private static JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i + 1 < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    // ── GitStatusTool ─────────────────────────────────────────────────────────────
+
+    /**
+     * Calling GitStatusTool on a valid git repository must return a non-empty,
+     * non-error response.
+     */
+    public void testGitStatusReturnsValidResponse() throws Exception {
+        GitStatusTool tool = new GitStatusTool(getProject());
+        String result = tool.execute(new JsonObject());
+
+        assertNotNull("git status must return a result", result);
+        assertFalse("Result should not be blank", result.isBlank());
+        assertFalse("Result should not start with 'Error', got: " + result,
+            result.startsWith("Error"));
+    }
+
+    /**
+     * The short-format output of {@code git status --short --branch} always includes
+     * a {@code ##} branch indicator on the first line.
+     */
+    public void testGitStatusShortFormatContainsBranchIndicator() throws Exception {
+        GitStatusTool tool = new GitStatusTool(getProject());
+        String result = tool.execute(new JsonObject());
+
+        assertTrue("Expected '##' branch indicator in short-format output, got: " + result,
+            result.contains("##"));
+    }
+
+    /**
+     * Verbose mode executes {@code git status} (no flags), whose output always starts
+     * with "On branch" — distinct from short mode's {@code ##} prefix.
+     */
+    public void testGitStatusVerboseContainsOnBranchLine() throws Exception {
+        GitStatusTool tool = new GitStatusTool(getProject());
+        JsonObject argsObj = new JsonObject();
+        argsObj.addProperty("verbose", true);
+        String result = tool.execute(argsObj);
+
+        assertNotNull(result);
+        assertFalse("Verbose result should not start with 'Error', got: " + result,
+            result.startsWith("Error"));
+        assertTrue("Verbose output should contain 'On branch', got: " + result,
+            result.contains("On branch"));
+    }
+
+    /**
+     * Short-format output does NOT contain the "On branch" phrase (that is verbose-only).
+     */
+    public void testGitStatusShortFormatDoesNotContainOnBranch() throws Exception {
+        GitStatusTool tool = new GitStatusTool(getProject());
+        String result = tool.execute(new JsonObject()); // default = short format
+
+        assertFalse("Short-format output should not contain 'On branch', got: " + result,
+            result.contains("On branch"));
+    }
+
+    // ── GitLogTool ────────────────────────────────────────────────────────────────
+
+    /**
+     * Git log with default arguments must return the initial commit created in
+     * {@link #setUp()} without error.
+     */
+    public void testGitLogReturnsCommits() throws Exception {
+        GitLogTool tool = new GitLogTool(getProject());
+        String result = tool.execute(new JsonObject());
+
+        assertNotNull("git log must return a result", result);
+        assertFalse("Result should not be blank", result.isBlank());
+        assertFalse("Result should not start with 'Error', got: " + result,
+            result.startsWith("Error"));
+        // The medium format (default) emits "commit <hash>\nAuthor: …" for every entry.
+        assertTrue("Expected 'commit' keyword in git log medium output, got: " + result,
+            result.contains("commit"));
+    }
+
+    /**
+     * Passing {@code max_count}=3 limits the number of returned commits.
+     * With only one commit in the repo the output still contains that commit.
+     */
+    public void testGitLogWithMaxCount() throws Exception {
+        GitLogTool tool = new GitLogTool(getProject());
+        JsonObject argsObj = new JsonObject();
+        argsObj.addProperty("max_count", 3);
+        String result = tool.execute(argsObj);
+
+        assertNotNull(result);
+        assertFalse("Result should not start with 'Error', got: " + result,
+            result.startsWith("Error"));
+        assertTrue("Expected 'commit' keyword in limited git log output, got: " + result,
+            result.contains("commit"));
+    }
+
+    /**
+     * The {@code oneline} format emits one abbreviated line per commit.
+     * The output must include the commit message from setUp.
+     */
+    public void testGitLogOnelineFormatContainsMessage() throws Exception {
+        GitLogTool tool = new GitLogTool(getProject());
+        String result = tool.execute(args("format", "oneline"));
+
+        assertNotNull(result);
+        assertFalse("Result should not start with 'Error', got: " + result,
+            result.startsWith("Error"));
+        assertTrue("Expected commit message in oneline output, got: " + result,
+            result.contains("initial test commit"));
+    }
+
+    /**
+     * The {@code short} format includes an "Author:" line per commit.
+     */
+    public void testGitLogShortFormatContainsAuthor() throws Exception {
+        GitLogTool tool = new GitLogTool(getProject());
+        String result = tool.execute(args("format", "short"));
+
+        assertNotNull(result);
+        assertFalse("Result should not start with 'Error', got: " + result,
+            result.startsWith("Error"));
+        assertTrue("Expected 'Author:' in short git log output, got: " + result,
+            result.contains("Author:"));
+    }
+
+    // ── GitBranchTool ─────────────────────────────────────────────────────────────
+
+    /**
+     * The {@code list} action must return available branches without error.
+     * {@code git branch --list -v} marks the current branch with {@code *}.
+     */
+    public void testGitBranchListAction() throws Exception {
+        GitBranchTool tool = new GitBranchTool(getProject());
+        String result = tool.execute(args("action", "list"));
+
+        assertNotNull("git branch list must return a result", result);
+        assertFalse("Result should not be blank", result.isBlank());
+        assertFalse("Result should not start with 'Error', got: " + result,
+            result.startsWith("Error"));
+        // git branch --list -v marks the current branch with '*'
+        assertTrue("Expected '*' to mark the current branch, got: " + result,
+            result.contains("*"));
+    }
+
+    /**
+     * Omitting the {@code action} parameter defaults to "list" — same behaviour as explicit list.
+     */
+    public void testGitBranchDefaultActionIsList() throws Exception {
+        GitBranchTool tool = new GitBranchTool(getProject());
+        String resultDefault = tool.execute(new JsonObject());
+        String resultExplicit = tool.execute(args("action", "list"));
+
+        assertFalse("Default branch result should not start with 'Error', got: " + resultDefault,
+            resultDefault.startsWith("Error"));
+        assertFalse("Explicit list should not start with 'Error', got: " + resultExplicit,
+            resultExplicit.startsWith("Error"));
+        // Both outputs must mark the current branch
+        assertTrue("Default result must contain '*'", resultDefault.contains("*"));
+        assertTrue("Explicit list result must contain '*'", resultExplicit.contains("*"));
+    }
+
+    /**
+     * Requesting an unrecognised action must return a clear error that names the
+     * invalid action and lists the valid ones.
+     */
+    public void testGitBranchInvalidActionReturnsError() throws Exception {
+        GitBranchTool tool = new GitBranchTool(getProject());
+        String result = tool.execute(args("action", "bogus_action"));
+
+        assertNotNull(result);
+        // Exact message from GitBranchTool source:
+        // "Error: unknown action 'bogus_action'. Use: list, create, switch, delete"
+        assertTrue("Expected unknown-action error, got: " + result,
+            result.startsWith("Error: unknown action 'bogus_action'"));
+        assertTrue("Error must list valid actions, got: " + result,
+            result.contains("list"));
+        assertTrue("Error must list valid actions, got: " + result,
+            result.contains("create"));
+    }
+
+    /**
+     * The {@code create} action without a {@code name} parameter must return a validation error.
+     */
+    public void testGitBranchCreateWithoutNameReturnsError() throws Exception {
+        GitBranchTool tool = new GitBranchTool(getProject());
+        String result = tool.execute(args("action", "create"));
+
+        assertNotNull(result);
+        // Exact message: "Error: 'name' parameter is required for 'create'"
+        assertEquals("Error: 'name' parameter is required for 'create'", result);
+    }
+
+    /**
+     * The {@code switch} action without a {@code name} parameter must return a validation error.
+     */
+    public void testGitBranchSwitchWithoutNameReturnsError() throws Exception {
+        GitBranchTool tool = new GitBranchTool(getProject());
+        String result = tool.execute(args("action", "switch"));
+
+        assertNotNull(result);
+        // Exact message: "Error: 'name' parameter is required for 'switch'"
+        assertEquals("Error: 'name' parameter is required for 'switch'", result);
+    }
+
+    /**
+     * The {@code delete} action without a {@code name} parameter must return a validation error.
+     */
+    public void testGitBranchDeleteWithoutNameReturnsError() throws Exception {
+        GitBranchTool tool = new GitBranchTool(getProject());
+        String result = tool.execute(args("action", "delete"));
+
+        assertNotNull(result);
+        // Exact message: "Error: 'name' parameter is required for 'delete'"
+        assertEquals("Error: 'name' parameter is required for 'delete'", result);
+    }
+
+    // ── GitDiffTool ───────────────────────────────────────────────────────────────
+
+    /**
+     * With a clean working tree, {@code git diff} produces empty output (no unstaged changes).
+     * The tool must not return an error string.
+     */
+    public void testGitDiffEmptyArgsCleanTree() throws Exception {
+        GitDiffTool tool = new GitDiffTool(getProject());
+        String result = tool.execute(new JsonObject());
+
+        assertNotNull("git diff must return a result (even empty)", result);
+        assertFalse("Clean-tree diff should not start with 'Error', got: " + result,
+            result.startsWith("Error"));
+    }
+
+    /**
+     * With nothing staged, {@code git diff --cached} (staged diff) must return
+     * empty output without error.
+     */
+    public void testGitDiffStagedOnCleanIndexIsEmpty() throws Exception {
+        GitDiffTool tool = new GitDiffTool(getProject());
+        JsonObject argsObj = new JsonObject();
+        argsObj.addProperty("staged", true);
+        String result = tool.execute(argsObj);
+
+        assertNotNull(result);
+        assertFalse("Staged diff should not start with 'Error', got: " + result,
+            result.startsWith("Error"));
+        // Clean index → staged diff is empty
+        assertTrue("Staged diff on a clean index must be empty, got: " + result,
+            result.isBlank());
+    }
+
+    /**
+     * Stat-only mode ({@code --stat}) on a clean tree must not produce an error.
+     */
+    public void testGitDiffStatOnlyNoChangesReturnsNoError() throws Exception {
+        GitDiffTool tool = new GitDiffTool(getProject());
+        JsonObject argsObj = new JsonObject();
+        argsObj.addProperty("stat_only", true);
+        String result = tool.execute(argsObj);
+
+        assertNotNull(result);
+        assertFalse("Stat-only diff should not start with 'Error', got: " + result,
+            result.startsWith("Error"));
+    }
+
+    /**
+     * Comparing against HEAD (a valid ref) must not produce an error.
+     */
+    public void testGitDiffAgainstHeadReturnsNoError() throws Exception {
+        GitDiffTool tool = new GitDiffTool(getProject());
+        String result = tool.execute(args("commit", "HEAD"));
+
+        assertNotNull(result);
+        assertFalse("Diff against HEAD should not start with 'Error', got: " + result,
+            result.startsWith("Error"));
+    }
+
+    // ── GitStageTool ──────────────────────────────────────────────────────────────
+
+    /**
+     * Omitting all path parameters ({@code path}, {@code paths}, {@code all}) must
+     * return the exact validation error defined in {@code GitStageTool.execute()}.
+     */
+    public void testGitStageWithoutPathReturnsError() throws Exception {
+        GitStageTool tool = new GitStageTool(getProject());
+        String result = tool.execute(new JsonObject());
+
+        assertNotNull(result);
+        assertEquals(
+            "Error: provide 'path', 'paths', or 'all' parameter",
+            result
+        );
+    }
+
+    /**
+     * Staging a path that does not exist on disk must return a git error (not a raw exception).
+     * Git exits non-zero with "pathspec '...' did not match any files".
+     */
+    public void testGitStageNonExistentFileReturnsError() throws Exception {
+        GitStageTool tool = new GitStageTool(getProject());
+        String result = tool.execute(args("path", "/nonexistent/file-that-does-not-exist-xyz99.txt"));
+
+        assertNotNull(result);
+        assertTrue("Expected 'Error' for staging non-existent file, got: " + result,
+            result.startsWith("Error"));
+        // Must not be a raw Java exception dump
+        assertFalse("Result must not contain a Java exception class, got: " + result,
+            result.contains("Exception"));
+    }
+
+    /**
+     * Providing an empty {@code paths} JSON array should still produce a graceful error
+     * or at most a no-op — never a raw Java exception.
+     */
+    public void testGitStageEmptyPathsArrayIsGraceful() throws Exception {
+        GitStageTool tool = new GitStageTool(getProject());
+        JsonObject argsObj = new JsonObject();
+        argsObj.add("paths", new JsonArray()); // empty array
+        String result = tool.execute(argsObj);
+
+        assertNotNull(result);
+        // Must not expose a raw exception dump regardless of the outcome
+        assertFalse("Result must not contain a Java exception class, got: " + result,
+            result.contains("Exception"));
+    }
+
+    // ── GitCommitTool ─────────────────────────────────────────────────────────────
+
+    /**
+     * Omitting the required {@code message} parameter must return the exact
+     * validation error defined in {@code GitCommitTool.execute()}.
+     */
+    public void testGitCommitWithoutMessageReturnsError() throws Exception {
+        GitCommitTool tool = new GitCommitTool(getProject());
+        String result = tool.execute(new JsonObject());
+
+        assertNotNull(result);
+        assertEquals("Error: 'message' parameter is required", result);
+    }
+
+    /**
+     * Passing an empty string for {@code message} is treated identically to a missing
+     * parameter — the tool returns the same validation error.
+     */
+    public void testGitCommitWithEmptyMessageReturnsError() throws Exception {
+        GitCommitTool tool = new GitCommitTool(getProject());
+        String result = tool.execute(args("message", ""));
+
+        assertNotNull(result);
+        assertEquals("Error: 'message' parameter is required", result);
+    }
+
+    /**
+     * Attempting a commit with a valid message but nothing staged must return
+     * the "nothing staged" error from the pre-flight check — not a raw git error
+     * and not a Java exception. The working tree is clean after the setUp commit,
+     * so the pre-flight branch that detects "nothing to commit" is exercised.
+     */
+    public void testGitCommitNothingStagedReturnsError() throws Exception {
+        GitCommitTool tool = new GitCommitTool(getProject());
+        String result = tool.execute(args("message", "test: must not be committed"));
+
+        assertNotNull(result);
+        // All three "nothing staged" variants begin with this prefix:
+        // • "...The working tree is clean — there is nothing to commit."
+        // • "...There are unstaged changes — use git_stage first, …"
+        // • "...There are untracked files — use git_stage to add them first."
+        assertTrue("Expected 'nothing staged' error, got: " + result,
+            result.startsWith("Error: nothing staged for commit."));
+        // Must not surface a raw Java exception
+        assertFalse("Result must not contain a Java exception, got: " + result,
+            result.contains("Exception"));
+    }
+
+    /**
+     * The error message for "nothing staged" must provide actionable guidance —
+     * it must not be a bare "nothing to commit" with no hint.
+     */
+    public void testGitCommitNothingStagedErrorContainsHint() throws Exception {
+        GitCommitTool tool = new GitCommitTool(getProject());
+        String result = tool.execute(args("message", "test: must not be committed"));
+
+        assertNotNull(result);
+        assertTrue("Expected 'nothing staged' error", result.startsWith("Error: nothing staged for commit."));
+        // The hint appended after the base message must contain some guidance keyword.
+        // The three variants contain: "working tree", "unstaged changes", or "untracked files".
+        boolean containsHint =
+            result.contains("working tree")
+                || result.contains("unstaged")
+                || result.contains("untracked");
+        assertTrue("Error must include actionable guidance, got: " + result, containsHint);
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/InfrastructureToolsExtendedTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/InfrastructureToolsExtendedTest.java
@@ -1,0 +1,282 @@
+package com.github.catatafishen.agentbridge.psi.tools.infrastructure;
+
+import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+/**
+ * Platform tests for infrastructure tools: {@link ListRunTabsTool},
+ * {@link GetNotificationsTool}, {@link ReadBuildOutputTool}, and {@link ReadRunOutputTool}.
+ *
+ * <p>JUnit 3 style (extends {@link BasePlatformTestCase}): test methods must be
+ * {@code public void testXxx()}. Run via Gradle only:
+ * {@code ./gradlew :plugin-core:test}.
+ *
+ * <p>All tools in this group use {@code EdtUtil.invokeAndWait} or synchronous execution
+ * only. {@code EdtUtil.invokeAndWait} contains an {@code isDispatchThread()} check that
+ * runs the runnable inline when called from the EDT, so all tools can be called directly
+ * from the test method without a {@code executeSync} wrapper.
+ *
+ * <p>A fresh {@link BasePlatformTestCase} project has no run/build activity and no
+ * notifications, so all "empty state" assertions are deterministic.
+ */
+public class InfrastructureToolsExtendedTest extends BasePlatformTestCase {
+
+    private ListRunTabsTool listRunTabsTool;
+    private GetNotificationsTool getNotificationsTool;
+    private ReadBuildOutputTool readBuildOutputTool;
+    private ReadRunOutputTool readRunOutputTool;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Disable "follow agent files" UI navigation so tools do not open extra editors
+        // or steal focus in the headless test environment.
+        PropertiesComponent.getInstance(getProject())
+            .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
+
+        listRunTabsTool = new ListRunTabsTool(getProject());
+        getNotificationsTool = new GetNotificationsTool(getProject());
+        readBuildOutputTool = new ReadBuildOutputTool(getProject());
+        readRunOutputTool = new ReadRunOutputTool(getProject());
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            FileEditorManager fem = FileEditorManager.getInstance(getProject());
+            for (VirtualFile f : fem.getOpenFiles()) {
+                fem.closeFile(f);
+            }
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * Builds a {@link JsonObject} from alternating key/value String pairs.
+     */
+    private static JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    // ── ListRunTabsTool ───────────────────────────────────────────────────────
+
+    /**
+     * In a fresh test project with no run/build activity, {@code list_run_tabs}
+     * must return a non-blank response that includes the "Run panel tabs" section
+     * header and "(none)" for the empty run panel.
+     *
+     * <p>{@link ListRunTabsTool} uses {@code EdtUtil.invokeAndWait} which runs
+     * inline on the EDT — safe to call directly from the test.
+     */
+    public void testListRunTabsEmpty() {
+        String result = listRunTabsTool.execute(new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertTrue("Expected 'Run panel tabs' section header, got: " + result,
+            result.contains("Run panel tabs"));
+        // No run/debug configurations have been launched — run panel must report empty.
+        assertTrue("Expected '(none)' for empty run panel, got: " + result,
+            result.contains("(none)"));
+    }
+
+    /**
+     * Verifies that the result also includes the "Build panel tabs" section header.
+     * Even when no build has run (Build tool window may be unavailable in a light
+     * test project), the section header must appear in the output.
+     */
+    public void testListRunTabsIncludesBuildSection() {
+        String result = listRunTabsTool.execute(new JsonObject());
+
+        assertNotNull(result);
+        assertTrue("Expected 'Build panel tabs' section header, got: " + result,
+            result.contains("Build panel tabs"));
+    }
+
+    /**
+     * The result must be a non-null, non-blank, non-exception string regardless
+     * of IDE state — the tool must never throw or return null.
+     */
+    public void testListRunTabsReturnsNonBlank() {
+        String result = listRunTabsTool.execute(new JsonObject());
+
+        assertNotNull(result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertFalse("Result must not be a raw Java exception", result.startsWith("java."));
+    }
+
+    // ── GetNotificationsTool ──────────────────────────────────────────────────
+
+    /**
+     * In a fresh test project with no notifications, {@code get_notifications} must
+     * return exactly "No recent notifications." — the standard empty-list response
+     * from {@link GetNotificationsTool#execute(JsonObject)}.
+     *
+     * <p>{@link GetNotificationsTool} is synchronous (no EDT dispatch) and can be
+     * called directly from the test.
+     */
+    public void testGetNotificationsEmpty() {
+        String result = getNotificationsTool.execute(new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        assertEquals("Expected 'No recent notifications.' in fresh test project, got: " + result,
+            "No recent notifications.", result);
+    }
+
+    /**
+     * Verifies the tool never throws even when no notifications have been issued.
+     * The response must be a non-blank string.
+     */
+    public void testGetNotificationsReturnsNonBlank() {
+        String result = getNotificationsTool.execute(new JsonObject());
+
+        assertNotNull(result);
+        assertFalse("Result must not be blank", result.isBlank());
+    }
+
+    /**
+     * Verifies the tool returns a human-readable response rather than a raw
+     * Java exception string or null literal.
+     */
+    public void testGetNotificationsNoRawException() {
+        String result = getNotificationsTool.execute(new JsonObject());
+
+        assertNotNull(result);
+        assertFalse("Result must not be a raw Java exception", result.startsWith("java."));
+        assertFalse("Result must not be the 'null' string", "null".equals(result));
+    }
+
+    // ── ReadBuildOutputTool ───────────────────────────────────────────────────
+
+    /**
+     * When no build has been run, {@code read_build_output} must return a
+     * human-readable message describing why no output is available.
+     *
+     * <p>Two valid outcomes exist depending on the test IDE environment:
+     * <ul>
+     *   <li>"Build tool window is not available" — Build tool window absent
+     *       (light test project without Java plugin active)</li>
+     *   <li>"Build tool window is empty" — tool window present but no content yet</li>
+     * </ul>
+     * The tool must never throw an unhandled exception.
+     *
+     * <p>{@link ReadBuildOutputTool} uses {@code EdtUtil.invokeAndWait} which
+     * runs inline on the EDT — safe to call directly.
+     */
+    public void testReadBuildOutputNoTabs() {
+        String result = readBuildOutputTool.execute(new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        // Either the Build tool window is absent or present-but-empty.
+        boolean isExpectedResponse =
+            result.contains("Build tool window is not available")
+                || result.contains("Build tool window is empty")
+                || result.contains("not available");
+        assertTrue("Expected no-build description, got: " + result, isExpectedResponse);
+    }
+
+    /**
+     * Specifying a {@code tab_name} when no build tabs exist must still return
+     * a graceful message — never an unhandled exception or blank string.
+     *
+     * <p>The Build tool window is absent in a light test project, so the tool
+     * returns its "not available" message before it can attempt tab matching.
+     */
+    public void testReadBuildOutputSpecificTabNoBuilds() {
+        String result = readBuildOutputTool.execute(args("tab_name", "nonexistent_build_tab_xyz"));
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertFalse("Result must not start with 'Error reading Build output:'",
+            result.startsWith("Error reading Build output:"));
+    }
+
+    /**
+     * Verifies the result is never a raw Java exception stack trace or null literal,
+     * regardless of the build state.
+     */
+    public void testReadBuildOutputNoRawException() {
+        String result = readBuildOutputTool.execute(new JsonObject());
+
+        assertNotNull(result);
+        assertFalse("Result must not be a raw Java exception", result.startsWith("java."));
+        assertFalse("Result must not be the 'null' string", "null".equals(result));
+    }
+
+    // ── ReadRunOutputTool ─────────────────────────────────────────────────────
+
+    /**
+     * When no run configurations have been launched, {@code read_run_output} must
+     * return exactly "No Run or Debug panel tabs available." — the standard
+     * empty-panel response from {@link ReadRunOutputTool#execute(JsonObject)}.
+     *
+     * <p>{@link ReadRunOutputTool} uses {@code runReadAction} + {@code invokeAndWait},
+     * both of which handle being called from the EDT correctly.
+     */
+    public void testReadRunOutputNoTabs() {
+        String result = readRunOutputTool.execute(new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        assertEquals(
+            "Expected 'No Run or Debug panel tabs available.' in fresh project, got: " + result,
+            "No Run or Debug panel tabs available.", result);
+    }
+
+    /**
+     * When a specific tab name is requested but no run tabs exist at all, the tool must
+     * return the same "No Run or Debug panel tabs available." message, because the
+     * empty-descriptors check occurs before any name-matching logic.
+     */
+    public void testReadRunOutputMissingTab() {
+        String result = readRunOutputTool.execute(args("tab_name", "nonexistent_tab_xyz_abc"));
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        // With no run tabs at all, the empty-panel guard fires before name matching.
+        assertEquals(
+            "Expected 'No Run or Debug panel tabs available.' when no tabs exist, got: " + result,
+            "No Run or Debug panel tabs available.", result);
+    }
+
+    /**
+     * Verifies that when no run panel is available, the result is always a user-readable
+     * message — never a Java exception stack trace, null string, or blank response.
+     */
+    public void testReadRunOutputNoTabsReturnsReadableMessage() {
+        String result = readRunOutputTool.execute(new JsonObject());
+
+        assertNotNull(result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertFalse("Result must not be the 'null' string", "null".equals(result));
+        assertFalse("Result must not be a raw Java exception", result.startsWith("java."));
+    }
+
+    /**
+     * Verifies that omitting the optional {@code tab_name} and {@code max_chars}
+     * parameters is handled gracefully — the tool must use its defaults and return
+     * the same result as calling it with explicit defaults.
+     */
+    public void testReadRunOutputDefaultParameters() {
+        String withoutParams = readRunOutputTool.execute(new JsonObject());
+
+        JsonObject explicitDefaults = new JsonObject();
+        explicitDefaults.addProperty("max_chars", 8000);
+        String withExplicitDefaults = readRunOutputTool.execute(explicitDefaults);
+
+        // Both calls with no tabs return the same empty-panel message.
+        assertEquals("Default and explicit-default calls must return the same result",
+            withoutParams, withExplicitDefaults);
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/ListProjectFilesToolTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/ListProjectFilesToolTest.java
@@ -1,0 +1,279 @@
+package com.github.catatafishen.agentbridge.psi.tools.navigation;
+
+import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+/**
+ * Platform tests for {@link ListProjectFilesTool}.
+ *
+ * <p>JUnit 3 style (extends BasePlatformTestCase): test methods must be
+ * {@code public void testXxx()}.  Run via Gradle only:
+ * {@code ./gradlew :plugin-core:test}.
+ *
+ * <p>{@link ListProjectFilesTool#execute} runs entirely inside
+ * {@code ApplicationManager.getApplication().runReadAction()} so it is
+ * synchronous when called from the EDT test thread — no extra threading is
+ * needed.
+ *
+ * <p>Files added via {@code myFixture.addFileToProject()} land in the
+ * project's in-memory VFS, are indexed by {@code ProjectFileIndex}, and are
+ * therefore returned by the tool's {@code iterateContent} pass.
+ *
+ * <p>The tool's output format per entry is:
+ * {@code <relpath> [<tag><typeName>, <size>, <timestamp>]}
+ * where {@code tag} is one of {@code "source "}, {@code "test "}, or empty,
+ * and the whole listing is prefixed by {@code "N files:\n"}.
+ * An empty result set returns {@code "No files found"}.
+ */
+public class ListProjectFilesToolTest extends BasePlatformTestCase {
+
+    private ListProjectFilesTool tool;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Disable follow-agent UI features that would be no-ops in a headless test.
+        PropertiesComponent.getInstance(getProject())
+            .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
+        tool = new ListProjectFilesTool(getProject());
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    // ---- Helpers -------------------------------------------------------------
+
+    /**
+     * Builds a {@link JsonObject} from alternating String key/value pairs.
+     * For integer or boolean parameters use {@link JsonObject#addProperty}
+     * directly on the returned object.
+     */
+    private static JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    // ---- Tests ---------------------------------------------------------------
+
+    /**
+     * After adding three files via {@code addFileToProject}, listing all project
+     * files (no filters) must include each file's name in the result.
+     */
+    public void testListAllFiles() {
+        myFixture.addFileToProject("FileA.java", "public class FileA {}");
+        myFixture.addFileToProject("FileB.java", "public class FileB {}");
+        myFixture.addFileToProject("FileC.java", "public class FileC {}");
+
+        String result = tool.execute(new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertTrue("Expected file listing or 'No files found', got: " + result,
+            result.contains("files:") || result.equals("No files found"));
+        if (result.contains("files:")) {
+            assertTrue("Expected FileA.java, got: " + result, result.contains("FileA.java"));
+            assertTrue("Expected FileB.java, got: " + result, result.contains("FileB.java"));
+            assertTrue("Expected FileC.java, got: " + result, result.contains("FileC.java"));
+        }
+    }
+
+    /**
+     * The {@code pattern} parameter restricts output to files matching a glob.
+     * Adding {@code .java}, {@code .txt}, and {@code .xml} files then filtering
+     * by {@code *.java} must include only the Java file.
+     */
+    public void testListWithPattern() {
+        myFixture.addFileToProject("Pattern.java", "public class Pattern {}");
+        myFixture.addFileToProject("Pattern.txt", "some text");
+        myFixture.addFileToProject("Pattern.xml", "<root/>");
+
+        String result = tool.execute(args("pattern", "*.java"));
+
+        assertTrue("Expected Pattern.java in result, got: " + result,
+            result.contains("Pattern.java"));
+        assertFalse("Should not include Pattern.txt, got: " + result,
+            result.contains("Pattern.txt"));
+        assertFalse("Should not include Pattern.xml, got: " + result,
+            result.contains("Pattern.xml"));
+    }
+
+    /**
+     * The {@code min_size} filter must exclude files smaller than the threshold.
+     * A large file (well over 100 bytes) must appear; a tiny 1-byte file must not.
+     */
+    public void testListWithMinSizeFilter() {
+        myFixture.addFileToProject("TinyMin.java", "x"); // 1 byte
+
+        StringBuilder big = new StringBuilder("public class LargeMin {\n");
+        for (int i = 0; i < 5; i++) {
+            big.append("    private String field").append(i)
+                .append(" = \"padding_value_that_makes_file_larger\";\n");
+        }
+        big.append("}");
+        // big is ~270 bytes — well over the 100-byte threshold
+        myFixture.addFileToProject("LargeMin.java", big.toString());
+
+        JsonObject a = new JsonObject();
+        a.addProperty("min_size", 100);
+        a.addProperty("pattern", "*.java");
+        String result = tool.execute(a);
+
+        if (result.contains("files:")) {
+            assertTrue("LargeMin.java must pass the min_size filter, got: " + result,
+                result.contains("LargeMin.java"));
+            assertFalse("TinyMin.java must be excluded by min_size filter, got: " + result,
+                result.contains("TinyMin.java"));
+        }
+    }
+
+    /**
+     * The {@code max_size} filter must exclude files larger than the threshold.
+     * A 1-byte file must appear; a file over 1 000 bytes must not.
+     */
+    public void testListWithMaxSizeFilter() {
+        myFixture.addFileToProject("TinyMax.txt", "x"); // 1 byte
+
+        StringBuilder big = new StringBuilder();
+        // 20 bytes x 60 = 1200 bytes
+        big.repeat("aaaaaaaaaaaaaaaaaaa\n", 60);
+        myFixture.addFileToProject("BigMax.txt", big.toString());
+
+        JsonObject a = new JsonObject();
+        a.addProperty("max_size", 10);
+        a.addProperty("pattern", "*.txt");
+        String result = tool.execute(a);
+
+        if (result.contains("files:")) {
+            assertTrue("TinyMax.txt must pass max_size filter, got: " + result,
+                result.contains("TinyMax.txt"));
+            assertFalse("BigMax.txt must be excluded by max_size filter, got: " + result,
+                result.contains("BigMax.txt"));
+        }
+    }
+
+    /**
+     * With {@code sort=name} (the default) the output must list files in
+     * ascending alphabetical order: "Apple" before "Mango" before "Zebra".
+     */
+    public void testListSortByName() {
+        myFixture.addFileToProject("Zebra.java", "class Zebra {}");
+        myFixture.addFileToProject("Apple.java", "class Apple {}");
+        myFixture.addFileToProject("Mango.java", "class Mango {}");
+
+        String result = tool.execute(args("sort", "name", "pattern", "*.java"));
+
+        assertTrue("Expected Apple.java in result, got: " + result, result.contains("Apple.java"));
+        assertTrue("Expected Mango.java in result, got: " + result, result.contains("Mango.java"));
+        assertTrue("Expected Zebra.java in result, got: " + result, result.contains("Zebra.java"));
+
+        if (result.contains("files:")) {
+            int appleIdx = result.indexOf("Apple.java");
+            int mangoIdx = result.indexOf("Mango.java");
+            int zebraIdx = result.indexOf("Zebra.java");
+            assertTrue("Apple should appear before Mango in name-sorted output",
+                appleIdx < mangoIdx);
+            assertTrue("Mango should appear before Zebra in name-sorted output",
+                mangoIdx < zebraIdx);
+        }
+    }
+
+    /**
+     * A glob pattern that matches no indexed files must return exactly
+     * {@code "No files found"}.
+     */
+    public void testListWithNoMatchingPattern() {
+        myFixture.addFileToProject("SomeFile.java", "class SomeFile {}");
+
+        String result = tool.execute(args("pattern", "*.frobnicator"));
+
+        assertEquals("Expected 'No files found' for non-matching pattern, got: " + result,
+            "No files found", result);
+    }
+
+    /**
+     * The {@code directory} parameter filters to files whose relative path
+     * starts with the given prefix.  Files in the subdirectory must appear;
+     * root-level files must not.
+     */
+    public void testListWithDirectory() {
+        myFixture.addFileToProject("subdir/InSubdir.java", "class InSubdir {}");
+        myFixture.addFileToProject("subdir/AlsoInSubdir.java", "class AlsoInSubdir {}");
+        myFixture.addFileToProject("Root.java", "class Root {}");
+
+        String result = tool.execute(args("directory", "subdir"));
+
+        if (result.contains("files:")) {
+            assertTrue("Expected InSubdir.java in subdir result, got: " + result,
+                result.contains("InSubdir.java"));
+            assertTrue("Expected AlsoInSubdir.java in subdir result, got: " + result,
+                result.contains("AlsoInSubdir.java"));
+            assertFalse("Root.java must not appear when directory='subdir', got: " + result,
+                result.contains("Root.java"));
+        }
+    }
+
+    /**
+     * With {@code sort=size} the tool sorts by file size descending (largest
+     * first).  The large file's name must appear before the small file's name.
+     */
+    public void testListSortBySize() {
+        myFixture.addFileToProject("SizeSmall.txt", "hi"); // 2 bytes
+
+        StringBuilder large = new StringBuilder();
+        // ~2000 bytes
+        large.repeat("aaaaaaaaaaaaaaaaaaa\n", 100);
+        myFixture.addFileToProject("SizeLarge.txt", large.toString());
+
+        String result = tool.execute(args("pattern", "*.txt", "sort", "size"));
+
+        assertTrue("Expected SizeSmall.txt in result, got: " + result,
+            result.contains("SizeSmall.txt"));
+        assertTrue("Expected SizeLarge.txt in result, got: " + result,
+            result.contains("SizeLarge.txt"));
+
+        if (result.contains("files:")) {
+            int smallIdx = result.indexOf("SizeSmall.txt");
+            int largeIdx = result.indexOf("SizeLarge.txt");
+            assertTrue("Largest file should appear first when sorted by size descending",
+                largeIdx < smallIdx);
+        }
+    }
+
+    /**
+     * Each result entry must follow the format
+     * {@code <relpath> [<tag><typeName>, <size>, <timestamp>]}.
+     * Verifies that the metadata brackets appear in the output.
+     */
+    public void testResultFormatIncludesMetadataBrackets() {
+        myFixture.addFileToProject("MetaCheck.java", "public class MetaCheck {}");
+
+        String result = tool.execute(args("pattern", "MetaCheck.java"));
+
+        if (result.contains("files:")) {
+            assertTrue("Result should contain metadata opening bracket '[', got: " + result,
+                result.contains("["));
+            assertTrue("Result should contain metadata closing bracket ']', got: " + result,
+                result.contains("]"));
+            assertTrue("Result should contain MetaCheck.java, got: " + result,
+                result.contains("MetaCheck.java"));
+        }
+    }
+
+    /**
+     * An invalid {@code modified_after} timestamp string must return an error
+     * message beginning with "Error:".
+     */
+    public void testInvalidModifiedAfterReturnsError() {
+        String result = tool.execute(args("modified_after", "not-a-valid-timestamp-xyz"));
+
+        assertTrue("Expected error for invalid modified_after, got: " + result,
+            result.startsWith("Error:"));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationToolsExtendedTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationToolsExtendedTest.java
@@ -1,0 +1,213 @@
+package com.github.catatafishen.agentbridge.psi.tools.navigation;
+
+import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
+import com.github.catatafishen.agentbridge.psi.ToolUtils;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Extended platform tests for {@link GetFileOutlineTool} and
+ * {@link SearchSymbolsTool}.
+ *
+ * <p>JUnit 3 style (extends BasePlatformTestCase): test methods must be
+ * {@code public void testXxx()}.  Run via Gradle only:
+ * {@code ./gradlew :plugin-core:test}.
+ *
+ * <p>Both tools execute entirely inside
+ * {@code ApplicationManager.getApplication().runReadAction()} so they are
+ * synchronous when called from the EDT test thread — no extra threading
+ * machinery is needed.
+ *
+ * <p><b>File creation strategy:</b>
+ * <ul>
+ *   <li>{@link GetFileOutlineTool} takes a file path and resolves it via
+ *       {@code ToolUtils#resolveVirtualFile} ({@code LocalFileSystem#findFileByPath}).
+ *       Tests for this tool create real disk files under a temp directory and
+ *       register them in the VFS via {@code LocalFileSystem#refreshAndFindFileByPath}.
+ *   <li>{@link SearchSymbolsTool} searches the PSI project index without a file
+ *       path argument, so {@code myFixture.addFileToProject()} (TempFS) works fine.
+ * </ul>
+ *
+ * <p>Each test method uses a unique file name to avoid "file already exists"
+ * conflicts when multiple tests run in the same light project.
+ */
+public class NavigationToolsExtendedTest extends BasePlatformTestCase {
+
+    private GetFileOutlineTool getFileOutlineTool;
+    private SearchSymbolsTool searchSymbolsTool;
+    /**
+     * Real temp directory for tests that need {@code LocalFileSystem#findFileByPath}.
+     */
+    private Path tempDir;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Disable follow-agent UI (status-bar feedback, UsageView) that would
+        // be no-ops or noisy in a headless test environment.
+        PropertiesComponent.getInstance(getProject())
+            .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
+        getFileOutlineTool = new GetFileOutlineTool(getProject());
+        searchSymbolsTool = new SearchSymbolsTool(getProject());
+        tempDir = Files.createTempDirectory("nav-tools-test");
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            // Close any editors that may have been opened during the test.
+            FileEditorManager fem = FileEditorManager.getInstance(getProject());
+            for (VirtualFile openFile : fem.getOpenFiles()) {
+                fem.closeFile(openFile);
+            }
+            // Remove temp files created during this test.
+            try (var paths = Files.walk(tempDir)) {
+                paths.sorted(java.util.Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(java.io.File::delete);
+            }
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * Creates a real file on disk and registers it in the VFS so that
+     * {@code LocalFileSystem#findFileByPath} can find it during {@code execute()}.
+     */
+    private String createTestFile(String name, String content) throws IOException {
+        Path file = tempDir.resolve(name);
+        Files.writeString(file, content);
+        VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByPath(file.toString());
+        assertNotNull("Failed to register test file in VFS: " + file, vf);
+        return file.toString();
+    }
+
+    /**
+     * Builds a {@link JsonObject} from alternating key/value String pairs.
+     */
+    private static JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    // ── GetFileOutlineTool ────────────────────────────────────────────────────
+
+    /**
+     * After creating a Java file with a class and a method, the outline must
+     * start with {@code "Outline of"} and include the class or method name.
+     *
+     * <p>Uses a real disk file so that {@code resolveVirtualFile} can find it
+     * via {@code LocalFileSystem#findFileByPath}.
+     */
+    public void testGetFileOutlineWithJavaFile() throws Exception {
+        String path = createTestFile("OutlineClass.java", """
+            public class OutlineClass {
+                public String greet() {
+                    return "hello";
+                }
+            }
+            """);
+
+        String result = getFileOutlineTool.execute(args("path", path));
+
+        assertFalse("Expected non-error result, got: " + result,
+            result.startsWith(ToolUtils.ERROR_PREFIX));
+        assertTrue("Expected 'Outline of' header, got: " + result,
+            result.startsWith("Outline of"));
+        // The outline must mention either the class name or the method name.
+        assertTrue("Expected class or method name in outline, got: " + result,
+            result.contains("OutlineClass") || result.contains("greet"));
+    }
+
+    /**
+     * When the {@code path} parameter is omitted entirely, the tool must return
+     * the standard {@code "Error: 'path' parameter is required"} error.
+     */
+    public void testGetFileOutlineMissingPath() {
+        String result = getFileOutlineTool.execute(new JsonObject());
+
+        assertEquals(ToolUtils.ERROR_PATH_REQUIRED, result);
+    }
+
+    /**
+     * When the supplied path points to a file that does not exist, the tool
+     * must return a {@code "File not found:"} message.
+     */
+    public void testGetFileOutlineNonExistentPath() {
+        String result = getFileOutlineTool.execute(
+            args("path", "/no/such/path/DoesNotExist_99982.java"));
+
+        assertTrue("Expected 'File not found:' error, got: " + result,
+            result.startsWith(ToolUtils.ERROR_FILE_NOT_FOUND));
+    }
+
+    // ── SearchSymbolsTool ─────────────────────────────────────────────────────
+
+    /**
+     * After adding a Java file that defines {@code SearchTargetClass_7741},
+     * searching for that exact name must return a result containing the
+     * class name (verifying the PSI index found it).
+     *
+     * <p>Uses {@code myFixture.addFileToProject()} (TempFS) because
+     * {@link SearchSymbolsTool} queries the PSI index rather than a file path.
+     */
+    public void testSearchSymbolsFindsClass() {
+        myFixture.addFileToProject(
+            "SearchTargetClass_7741.java",
+            """
+                public class SearchTargetClass_7741 {
+                    public void doSomething() {}
+                }
+                """);
+
+        String result = searchSymbolsTool.execute(args("query", "SearchTargetClass_7741"));
+
+        assertFalse("Expected non-error result, got: " + result,
+            result.startsWith(ToolUtils.ERROR_PREFIX));
+        assertTrue("Expected class name in search result, got: " + result,
+            result.contains("SearchTargetClass_7741"));
+    }
+
+    /**
+     * Searching for a token that definitely does not exist in the project must
+     * return the tool's {@code "No symbols found matching '...'"} message.
+     */
+    public void testSearchSymbolsNoResults() {
+        String result = searchSymbolsTool.execute(
+            args("query", "zzzNeverExists_9283_UniqueToken"));
+
+        assertTrue("Expected no-match message, got: " + result,
+            result.contains("No symbols found matching 'zzzNeverExists_9283_UniqueToken'"));
+    }
+
+    /**
+     * When the {@code query} parameter is absent, the tool defaults to an empty
+     * query which triggers the wildcard path. Without a {@code type} filter, the
+     * tool returns guidance asking for a type filter rather than an empty result.
+     * The response must be non-null and non-blank.
+     */
+    public void testSearchSymbolsMissingQuery() {
+        // No "query" key in args — tool defaults to "" → searchWildcard("")
+        String result = searchSymbolsTool.execute(new JsonObject());
+
+        assertNotNull("Result should not be null", result);
+        assertFalse("Result should not be blank", result.isBlank());
+        // The wildcard path without a type filter returns a guidance message.
+        assertTrue("Expected guidance about 'type' filter, got: " + result,
+            result.contains("type"));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextToolTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextToolTest.java
@@ -1,0 +1,282 @@
+package com.github.catatafishen.agentbridge.psi.tools.navigation;
+
+import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+/**
+ * Platform tests for {@link SearchTextTool}.
+ *
+ * <p>JUnit 3 style (extends BasePlatformTestCase): test methods must be
+ * {@code public void testXxx()}.  Run via Gradle only:
+ * {@code ./gradlew :plugin-core:test}.
+ *
+ * <p>{@link SearchTextTool#execute} runs entirely inside
+ * {@code ApplicationManager.getApplication().runReadAction()} so it is
+ * synchronous when called from the EDT test thread — no extra threading is
+ * needed.
+ *
+ * <p>Files added via {@code myFixture.addFileToProject()} land in the
+ * project's in-memory VFS, are indexed by {@code ProjectFileIndex}, and are
+ * therefore found by the tool's {@code iterateContent} pass.
+ */
+public class SearchTextToolTest extends BasePlatformTestCase {
+
+    private SearchTextTool tool;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Disable follow-agent UI features (status-bar feedback, UsageView) that
+        // would be no-ops or noisy in a headless test environment.
+        PropertiesComponent.getInstance(getProject())
+            .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
+        tool = new SearchTextTool(getProject());
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * Builds a {@link JsonObject} from alternating String key/value pairs.
+     * For integer or boolean parameters use {@link JsonObject#addProperty}
+     * directly on the returned object.
+     */
+    private static JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Search for a unique token that exists in one project file.
+     * Expects the match count prefix and the file name to appear in the result.
+     */
+    public void testBasicTextSearch() {
+        myFixture.addFileToProject("Alpha.java",
+            """
+                public class Alpha {
+                    // UNIQUE_SEARCH_TOKEN_ALPHA_7261
+                    private String value = "hello";
+                }
+                """);
+
+        String result = tool.execute(args("query", "UNIQUE_SEARCH_TOKEN_ALPHA_7261"));
+
+        assertTrue("Expected match-count prefix, got: " + result,
+            result.contains("matches:"));
+        assertTrue("Expected file name in result, got: " + result,
+            result.contains("Alpha.java"));
+        assertTrue("Expected matching token in result, got: " + result,
+            result.contains("UNIQUE_SEARCH_TOKEN_ALPHA_7261"));
+    }
+
+    /**
+     * Searching for a string that does not appear in any project file must
+     * return the "No matches found" message.
+     */
+    public void testSearchWithNoResults() {
+        myFixture.addFileToProject("Beta.java",
+            "public class Beta { /* nothing interesting here */ }\n");
+
+        String result = tool.execute(args("query", "ZZZNOMATCHSTRINGZZZ_BETA_9999"));
+
+        assertTrue("Expected no-match message, got: " + result,
+            result.contains("No matches found"));
+    }
+
+    /**
+     * The {@code file_pattern} parameter restricts which files are searched.
+     * Adding the target token to both a {@code .java} and a {@code .txt} file
+     * and filtering to {@code *.txt} should yield a match only in the text file.
+     */
+    public void testSearchWithFilePattern() {
+        myFixture.addFileToProject("SearchMe.java",
+            "// FILEPATTERN_TOKEN_5512 java file\n");
+        myFixture.addFileToProject("SearchMe.txt",
+            "FILEPATTERN_TOKEN_5512 text file\n");
+
+        JsonObject a = args("query", "FILEPATTERN_TOKEN_5512", "file_pattern", "*.txt");
+        String result = tool.execute(a);
+
+        assertTrue("Expected match in .txt file, got: " + result,
+            result.contains("SearchMe.txt"));
+        assertFalse("Should not match .java file when pattern is *.txt, got: " + result,
+            result.contains("SearchMe.java"));
+    }
+
+    /**
+     * When {@code context_lines} is set to 1, the line immediately before and
+     * after each match must appear in the result alongside the matching line.
+     */
+    public void testSearchWithContextLines() {
+        myFixture.addFileToProject("ContextTest.java",
+            """
+                // line one
+                // line two
+                // TARGET_CONTEXT_LINE_8843
+                // line four
+                // line five
+                """);
+
+        JsonObject a = args("query", "TARGET_CONTEXT_LINE_8843");
+        a.addProperty("context_lines", 1);
+        String result = tool.execute(a);
+
+        assertTrue("Expected matching token in result, got: " + result,
+            result.contains("TARGET_CONTEXT_LINE_8843"));
+        // Context line immediately before the match
+        assertTrue("Expected 'line two' as context before match, got: " + result,
+            result.contains("line two"));
+        // Context line immediately after the match
+        assertTrue("Expected 'line four' as context after match, got: " + result,
+            result.contains("line four"));
+        // The line outside the context window must not appear
+        assertFalse("'line one' is outside the 1-line context window, got: " + result,
+            result.contains("line one"));
+    }
+
+    /**
+     * With {@code case_sensitive} defaulting to {@code true}, an all-uppercase
+     * query must not match a mixed-case string.  Setting {@code case_sensitive}
+     * to {@code false} must then find it.
+     */
+    public void testCaseInsensitiveSearch() {
+        myFixture.addFileToProject("CaseTest.java",
+            """
+                public class CaseTest {
+                    String value = "MixedCaseToken3391";
+                }
+                """);
+
+        // Case-sensitive (default) — should NOT match
+        String sensitiveResult = tool.execute(args("query", "MIXEDCASETOKEN3391"));
+        assertTrue("Case-sensitive search should not match, got: " + sensitiveResult,
+            sensitiveResult.contains("No matches found"));
+
+        // Case-insensitive — MUST match
+        JsonObject a = args("query", "MIXEDCASETOKEN3391");
+        a.addProperty("case_sensitive", false);
+        String insensitiveResult = tool.execute(a);
+
+        assertTrue("Expected match with case_sensitive=false, got: " + insensitiveResult,
+            insensitiveResult.contains("matches:"));
+        assertTrue("Expected CaseTest.java in case-insensitive result, got: " + insensitiveResult,
+            insensitiveResult.contains("CaseTest.java"));
+    }
+
+    /**
+     * With {@code regex=true} the query is compiled as a regular expression.
+     * The pattern {@code foo\d+} should match "foo123" but not "foobar".
+     */
+    public void testSearchRegexMode() {
+        myFixture.addFileToProject("RegexTest.java",
+            """
+                int foo123 = 42;
+                int bar456 = 99;
+                String foobar = "abc";
+                """);
+
+        JsonObject a = args("query", "foo\\d+");
+        a.addProperty("regex", true);
+        String result = tool.execute(a);
+
+        assertTrue("Expected regex match for foo\\d+, got: " + result,
+            result.contains("matches:"));
+        assertTrue("Expected RegexTest.java in result, got: " + result,
+            result.contains("RegexTest.java"));
+        assertTrue("Expected line containing 'foo123' in result, got: " + result,
+            result.contains("foo123"));
+    }
+
+    /**
+     * An invalid regex pattern (with {@code regex=true}) must return an error
+     * message that starts with "Error:".
+     */
+    public void testInvalidRegexReturnsError() {
+        JsonObject a = args("query", "[invalid(regex");
+        a.addProperty("regex", true);
+        String result = tool.execute(a);
+
+        assertTrue("Expected error for invalid regex, got: " + result,
+            result.startsWith("Error:"));
+    }
+
+    /**
+     * The {@code max_results} parameter must cap the number of returned matches.
+     * With 20 identical token lines and {@code max_results=5}, the result prefix
+     * must say "5 matches:".
+     */
+    public void testMaxResultsLimit() {
+        StringBuilder content = new StringBuilder();
+        for (int i = 1; i <= 20; i++) {
+            content.append("// REPEATED_TOKEN_MAX_4471 line ").append(i).append("\n");
+        }
+        myFixture.addFileToProject("MaxResults.java", content.toString());
+
+        JsonObject a = args("query", "REPEATED_TOKEN_MAX_4471");
+        a.addProperty("max_results", 5);
+        String result = tool.execute(a);
+
+        assertTrue("Expected match result, got: " + result,
+            result.contains("matches:"));
+        assertTrue("Expected exactly 5 matches reported, got: " + result,
+            result.startsWith("5 matches:"));
+    }
+
+    /**
+     * Results from multiple files must all be collected.  Two files each
+     * containing the search token should yield exactly 2 matches, one per file.
+     */
+    public void testSearchMultipleMatchesAcrossFiles() {
+        myFixture.addFileToProject("Multi1.java",
+            "// CROSS_FILE_TOKEN_6637 first occurrence\n");
+        myFixture.addFileToProject("Multi2.java",
+            "// CROSS_FILE_TOKEN_6637 second occurrence\n");
+
+        String result = tool.execute(args("query", "CROSS_FILE_TOKEN_6637"));
+
+        assertTrue("Expected 2 matches, got: " + result,
+            result.startsWith("2 matches:"));
+        assertTrue("Expected Multi1.java in result, got: " + result,
+            result.contains("Multi1.java"));
+        assertTrue("Expected Multi2.java in result, got: " + result,
+            result.contains("Multi2.java"));
+    }
+
+    /**
+     * When the {@code query} parameter is omitted entirely, the tool must return
+     * the standard error message referencing "query".
+     */
+    public void testMissingQueryReturnsError() {
+        String result = tool.execute(new JsonObject());
+
+        assertTrue("Expected error message for missing query, got: " + result,
+            result.startsWith("Error:"));
+        assertTrue("Expected 'query' mentioned in error, got: " + result,
+            result.contains("query"));
+    }
+
+    /**
+     * Each result entry follows the format {@code <relpath>:<line>: <linetext>}.
+     * Verifies that the output contains a colon-separated file and line number.
+     */
+    public void testResultFormatContainsLineReference() {
+        myFixture.addFileToProject("FormatCheck.java",
+            "// LINE_FORMAT_TOKEN_2219 check\n");
+
+        String result = tool.execute(args("query", "LINE_FORMAT_TOKEN_2219"));
+
+        assertTrue("Expected file-name:line: format in result, got: " + result,
+            result.matches("(?s).*FormatCheck\\.java:\\d+:.*"));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/project/ProjectToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/project/ProjectToolsTest.java
@@ -1,0 +1,221 @@
+package com.github.catatafishen.agentbridge.psi.tools.project;
+
+import com.github.catatafishen.agentbridge.psi.ClassResolverUtil;
+import com.github.catatafishen.agentbridge.psi.RunConfigurationService;
+import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+/**
+ * Platform tests for project tools: {@link GetProjectModulesTool},
+ * {@link GetProjectDependenciesTool}, {@link GetIndexingStatusTool},
+ * and {@link ListRunConfigurationsTool}.
+ *
+ * <p>JUnit 3 style (extends {@link BasePlatformTestCase}): test methods must be
+ * {@code public void testXxx()}. Run via Gradle only:
+ * {@code ./gradlew :plugin-core:test}.
+ *
+ * <p>{@link BasePlatformTestCase} creates a lightweight in-memory project with at
+ * least one module and ensures indexing is complete before each test runs.
+ */
+public class ProjectToolsTest extends BasePlatformTestCase {
+
+    private GetProjectModulesTool modulesTool;
+    private GetProjectDependenciesTool dependenciesTool;
+    private GetIndexingStatusTool indexingStatusTool;
+    private ListRunConfigurationsTool runConfigsTool;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Prevent followFileIfEnabled from opening editors during tests.
+        // Use the String overload — the boolean overload removes the key when value==defaultValue,
+        // which would leave the setting at its default (true) instead of setting it to false.
+        PropertiesComponent.getInstance(getProject())
+            .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
+
+        modulesTool = new GetProjectModulesTool(getProject());
+        dependenciesTool = new GetProjectDependenciesTool(getProject());
+        indexingStatusTool = new GetIndexingStatusTool(getProject());
+
+        // RunConfigurationService requires a ClassResolver. Provide a minimal stub that
+        // returns the class name unchanged — sufficient for listRunConfigurations(), which
+        // never calls resolveClass().
+        RunConfigurationService runConfigService = new RunConfigurationService(
+            getProject(),
+            cn -> new ClassResolverUtil.ClassInfo(cn, null)
+        );
+        runConfigsTool = new ListRunConfigurationsTool(getProject(), runConfigService);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    /**
+     * Builds a {@link JsonObject} from alternating key/value string pairs.
+     * Example: {@code args("module", "plugin-core")}
+     */
+    private JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    // ── GetProjectModulesTool ─────────────────────────────────────────────────────
+
+    /**
+     * Verifies that {@code execute()} returns a non-empty string.
+     * {@link BasePlatformTestCase} always provides at least one light test module.
+     */
+    public void testGetProjectModules() {
+        String result = modulesTool.execute(new JsonObject());
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Result should not be empty", result.isBlank());
+    }
+
+    /**
+     * Verifies the response uses the expected "Modules (N):" summary header format,
+     * confirming that at least one module was found in the test project.
+     */
+    public void testGetProjectModulesResponseFormat() {
+        String result = modulesTool.execute(new JsonObject());
+        // Either the summary header ("Modules (N):") or the detail field ("libraries:") must
+        // appear — both indicate the tool ran successfully and listed at least one module.
+        assertTrue("Expected module-listing format, got: " + result,
+            result.contains("Modules (") || result.contains("libraries:"));
+    }
+
+    /**
+     * Verifies that the per-module detail section ("libraries: N") is present,
+     * proving that {@link GetProjectModulesTool} introspected each module's
+     * {@code ModuleRootManager} order entries.
+     */
+    public void testGetProjectModulesContainsLibraryCount() {
+        String result = modulesTool.execute(new JsonObject());
+        assertTrue("Expected 'libraries:' per-module detail, got: " + result,
+            result.contains("libraries:"));
+    }
+
+    // ── GetProjectDependenciesTool ────────────────────────────────────────────────
+
+    /**
+     * Verifies that {@code execute()} with empty args returns the standard
+     * "Libraries in project (N):" header, confirming the tool ran successfully.
+     */
+    public void testGetProjectDependencies() {
+        String result = dependenciesTool.execute(new JsonObject());
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Result should not be empty", result.isBlank());
+        assertTrue("Expected 'Libraries in' header, got: " + result,
+            result.contains("Libraries in"));
+    }
+
+    /**
+     * Verifies that omitting the optional {@code module} parameter does not throw
+     * or produce an error message — the parameter is optional and must be handled
+     * gracefully when absent.
+     */
+    public void testGetProjectDependenciesEmptyArgs() {
+        String result = dependenciesTool.execute(new JsonObject());
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Result should not be empty", result.isBlank());
+        assertFalse("Result must not start with 'Error:'", result.startsWith("Error:"));
+    }
+
+    /**
+     * Verifies that filtering by a module name that does not exist returns a
+     * human-readable "not found" message rather than an exception or empty output.
+     */
+    public void testGetProjectDependenciesNonExistentModuleFilter() {
+        String result = dependenciesTool.execute(args("module", "nonexistent_xyz_module_abc"));
+        assertNotNull(result);
+        assertFalse("Expected non-empty response for unknown module", result.isBlank());
+        assertTrue("Expected module-not-found message, got: " + result,
+            result.contains("not found") || result.contains("nonexistent_xyz_module_abc"));
+    }
+
+    // ── GetIndexingStatusTool ─────────────────────────────────────────────────────
+
+    /**
+     * Verifies that {@code execute()} returns a non-empty string that describes the
+     * current indexing state in human-readable terms.
+     */
+    public void testGetIndexingStatus() throws Exception {
+        String result = indexingStatusTool.execute(new JsonObject());
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Result should not be empty", result.isBlank());
+        // The response must mention indexing state or IDE readiness
+        assertTrue("Expected indexing-state description, got: " + result,
+            result.contains("Indexing") || result.contains("indexing")
+                || result.contains("ready") || result.contains("Ready"));
+    }
+
+    /**
+     * Verifies that in a freshly-initialized test project (no dumb mode active),
+     * the tool reports that the IDE is ready and indexing is complete.
+     * {@link BasePlatformTestCase} guarantees indexing is finished before
+     * {@code setUp()} returns.
+     */
+    public void testGetIndexingStatusReportsReady() throws Exception {
+        String result = indexingStatusTool.execute(new JsonObject());
+        // The test framework guarantees the project is fully indexed at this point
+        assertTrue("Expected IDE-ready report in non-dumb test project, got: " + result,
+            result.contains("IDE is ready") || result.contains("ready") || result.contains("complete"));
+    }
+
+    /**
+     * Verifies that {@code wait=true} with a short timeout still returns a valid status
+     * message. In a test project that is already indexed the tool should return
+     * "IDE is ready. Indexing is complete." almost immediately (no actual waiting needed),
+     * since {@link com.intellij.openapi.project.DumbService#isDumb()} returns {@code false}
+     * and the wait branch is skipped entirely.
+     */
+    public void testGetIndexingStatusWait() throws Exception {
+        JsonObject waitArgs = new JsonObject();
+        waitArgs.addProperty("wait", true);
+        // Short timeout: the project is already indexed so this should never be reached
+        waitArgs.addProperty("timeout", 5);
+
+        String result = indexingStatusTool.execute(waitArgs);
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Result should not be empty", result.isBlank());
+        // Valid outcomes: immediate "IDE is ready" (not indexing) or a timeout/in-progress msg
+        boolean isValidResponse = result.contains("IDE is ready")
+            || result.contains("Indexing")
+            || result.contains("indexing")
+            || result.contains("timeout");
+        assertTrue("Expected valid indexing-wait response, got: " + result, isValidResponse);
+    }
+
+    // ── ListRunConfigurationsTool ─────────────────────────────────────────────────
+
+    /**
+     * Verifies that {@code execute()} returns a non-empty, non-error response.
+     * A pristine test project has no run configurations, so
+     * "No run configurations found" is the expected output.
+     */
+    public void testListRunConfigurations() throws Exception {
+        String result = runConfigsTool.execute(new JsonObject());
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Result should not be empty", result.isBlank());
+        // Either "No run configurations found" or "N run configurations:\n..."
+        boolean isValidResponse = result.contains("No run configurations found")
+            || result.contains("run configuration");
+        assertTrue("Expected run-configurations response, got: " + result, isValidResponse);
+    }
+
+    /**
+     * Verifies that a pristine {@link BasePlatformTestCase} project — which has no
+     * run configurations registered in {@code RunManager} — returns the standard
+     * empty-list message rather than an error or null.
+     */
+    public void testListRunConfigurationsEmptyProject() throws Exception {
+        String result = runConfigsTool.execute(new JsonObject());
+        // RunManager.getAllSettings() returns an empty list in a fresh light test project
+        assertTrue(
+            "Expected 'No run configurations found' in fresh test project, got: " + result,
+            result.contains("No run configurations found") || result.contains("run configuration"));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/DiffUtilsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/DiffUtilsTest.java
@@ -1,0 +1,228 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link DiffUtils#unifiedDiff(String, String, String)}.
+ *
+ * <p>{@code DiffUtils} is a package-private utility class that generates unified diffs
+ * using IntelliJ's {@code com.intellij.util.diff.Diff} algorithm. These tests run as
+ * plain JUnit 5 tests (no {@code BasePlatformTestCase} required) because
+ * {@code Diff.buildChanges} is a pure algorithm with no dependency on the IntelliJ
+ * Application lifecycle.
+ *
+ * <p>Run via Gradle: {@code ./gradlew :plugin-core:test}.
+ */
+class DiffUtilsTest {
+
+    // ── Identical content ─────────────────────────────────────────────────────
+
+    /**
+     * When both strings are the same, the diff must be empty (no changes to report).
+     */
+    @Test
+    void testIdenticalStringsReturnEmptyDiff() {
+        String result = DiffUtils.unifiedDiff("hello\n", "hello\n", "test.txt");
+        assertEquals("", result, "Diff of identical strings must be empty");
+    }
+
+    /**
+     * When both strings are completely empty, the diff must also be empty.
+     */
+    @Test
+    void testBothEmptyStringsReturnEmptyDiff() {
+        String result = DiffUtils.unifiedDiff("", "", "test.txt");
+        assertEquals("", result, "Diff of two empty strings must be empty");
+    }
+
+    // ── Diff header format ────────────────────────────────────────────────────
+
+    /**
+     * For any non-trivial change the output must start with the standard
+     * {@code diff --git a/<path> b/<path>} header so that {@code GitDiffRenderer}
+     * can render it correctly.
+     */
+    @Test
+    void testDiffStartsWithGitHeader() {
+        String result = DiffUtils.unifiedDiff("foo\n", "bar\n", "src/Foo.java");
+        assertTrue(result.startsWith("diff --git a/src/Foo.java b/src/Foo.java"),
+            "Diff output must start with 'diff --git' header, got:\n" + result);
+    }
+
+    /**
+     * The output must include {@code --- a/<filePath>} and {@code +++ b/<filePath>}
+     * lines so that standard patch tools and renderers can identify the file.
+     */
+    @Test
+    void testDiffContainsFromAndToFileHeaders() {
+        String result = DiffUtils.unifiedDiff("line1\n", "changed\n", "com/example/MyClass.java");
+        assertTrue(result.contains("--- a/com/example/MyClass.java"),
+            "Diff must contain '--- a/<filePath>' header, got:\n" + result);
+        assertTrue(result.contains("+++ b/com/example/MyClass.java"),
+            "Diff must contain '+++ b/<filePath>' header, got:\n" + result);
+    }
+
+    /**
+     * The hunk header must follow the {@code @@ -<from>,<count> +<to>,<count> @@} format.
+     */
+    @Test
+    void testDiffContainsHunkHeader() {
+        String result = DiffUtils.unifiedDiff("a\n", "b\n", "test.txt");
+        assertTrue(result.contains("@@"),
+            "Diff output must contain a hunk header starting with '@@', got:\n" + result);
+    }
+
+    // ── Changed lines ─────────────────────────────────────────────────────────
+
+    /**
+     * A single substituted line must produce a deletion line (starting with '-')
+     * for the old content and an insertion line (starting with '+') for the new.
+     */
+    @Test
+    void testSimpleSingleLineChange() {
+        String result = DiffUtils.unifiedDiff("hello\n", "world\n", "greet.txt");
+        assertFalse(result.isEmpty(), "Diff must be non-empty for a changed line");
+        assertTrue(result.contains("-hello"),
+            "Diff must mark removed line with '-', got:\n" + result);
+        assertTrue(result.contains("+world"),
+            "Diff must mark added line with '+', got:\n" + result);
+    }
+
+    /**
+     * Adding a new line at the end of the file must produce an insertion marker
+     * for that line and not mark the original lines as deleted.
+     */
+    @Test
+    void testAddedLine() {
+        String before = "line1\n";
+        String after = "line1\nline2\n";
+        String result = DiffUtils.unifiedDiff(before, after, "add.txt");
+        assertFalse(result.isEmpty(), "Diff must be non-empty when a line is added");
+        assertTrue(result.contains("+line2"),
+            "Diff must contain '+line2' for the added line, got:\n" + result);
+        assertFalse(result.contains("-line1"),
+            "Diff must NOT mark 'line1' as deleted when it is unchanged, got:\n" + result);
+    }
+
+    /**
+     * Removing a line must produce a deletion marker for that line
+     * and not mark the remaining lines as added.
+     */
+    @Test
+    void testDeletedLine() {
+        String before = "line1\nline2\n";
+        String after = "line1\n";
+        String result = DiffUtils.unifiedDiff(before, after, "del.txt");
+        assertFalse(result.isEmpty(), "Diff must be non-empty when a line is deleted");
+        assertTrue(result.contains("-line2"),
+            "Diff must contain '-line2' for the deleted line, got:\n" + result);
+        assertFalse(result.contains("+line1"),
+            "Diff must NOT mark 'line1' as added when it is unchanged, got:\n" + result);
+    }
+
+    /**
+     * Changes to non-adjacent lines separated by more than {@code 2 * CONTEXT_LINES}
+     * (= 6) unchanged lines must produce separate hunks, each with its own
+     * {@code @@} header.
+     */
+    @Test
+    void testDistantChangesProduceMultipleHunks() {
+        StringBuilder before = new StringBuilder();
+        StringBuilder after = new StringBuilder();
+        for (int i = 1; i <= 20; i++) {
+            before.append("line").append(i).append("\n");
+            if (i == 1 || i == 20) {
+                after.append("CHANGED").append(i).append("\n");
+            } else {
+                after.append("line").append(i).append("\n");
+            }
+        }
+        String result = DiffUtils.unifiedDiff(before.toString(), after.toString(), "multi.txt");
+        assertFalse(result.isEmpty(), "Diff must be non-empty for distant changes");
+        long hunkCount = result.lines().filter(l -> l.startsWith("@@")).count();
+        assertTrue(hunkCount >= 2,
+            "Expected at least 2 hunk headers for distant changes, got " + hunkCount
+                + " in:\n" + result);
+    }
+
+    /**
+     * Adjacent changes (within the context window) must be grouped into a single hunk
+     * rather than split across multiple {@code @@} sections.
+     */
+    @Test
+    void testAdjacentChangesProduceSingleHunk() {
+        String before = "aaa\nbbb\nccc\n";
+        String after = "AAA\nBBB\nccc\n";
+        String result = DiffUtils.unifiedDiff(before, after, "adjacent.txt");
+        assertFalse(result.isEmpty(), "Diff must be non-empty for adjacent changes");
+        long hunkCount = result.lines().filter(l -> l.startsWith("@@")).count();
+        assertEquals(1, hunkCount,
+            "Adjacent changes within context window must produce exactly 1 hunk, got "
+                + hunkCount + " in:\n" + result);
+    }
+
+    // ── Context lines ─────────────────────────────────────────────────────────
+
+    /**
+     * Lines immediately surrounding a change (context lines) must appear in the diff
+     * prefixed only with a space (neither '+' nor '-').
+     */
+    @Test
+    void testContextLinesArePrefixedWithSpace() {
+        String before = "ctx-before\nchanged\nctx-after\n";
+        String after = "ctx-before\nNEW\nctx-after\n";
+        String result = DiffUtils.unifiedDiff(before, after, "ctx.txt");
+        assertTrue(result.contains(" ctx-before"),
+            "Context line before change must be prefixed with space, got:\n" + result);
+        assertTrue(result.contains(" ctx-after"),
+            "Context line after change must be prefixed with space, got:\n" + result);
+    }
+
+    // ── File path in output ───────────────────────────────────────────────────
+
+    /**
+     * The supplied {@code filePath} must appear verbatim in all three header lines
+     * so that callers can identify the source file without extra parsing.
+     */
+    @Test
+    void testFilePathAppearsInAllHeaders() {
+        String filePath = "src/main/java/com/example/Foo.java";
+        String result = DiffUtils.unifiedDiff("old\n", "new\n", filePath);
+        assertTrue(result.contains("diff --git a/" + filePath + " b/" + filePath),
+            "Git header must contain the full file path, got:\n" + result);
+        assertTrue(result.contains("--- a/" + filePath),
+            "'---' header must contain the full file path, got:\n" + result);
+        assertTrue(result.contains("+++ b/" + filePath),
+            "'+++ ' header must contain the full file path, got:\n" + result);
+    }
+
+    // ── New-file / deleted-file edge cases ────────────────────────────────────
+
+    /**
+     * Adding content to a previously empty string must produce a diff with only
+     * insertion lines and no deletion lines in the hunk body.
+     */
+    @Test
+    void testNewFileFromEmpty() {
+        String result = DiffUtils.unifiedDiff("", "brand new content\n", "new.txt");
+        assertFalse(result.isEmpty(), "Diff must be non-empty when adding content to empty string");
+        assertTrue(result.contains("+brand new content"),
+            "Diff must contain the new content as an insertion, got:\n" + result);
+    }
+
+    /**
+     * Deleting all content (reducing to an empty string) must produce a diff with only
+     * deletion lines and no insertion lines in the hunk body.
+     */
+    @Test
+    void testDeleteAllContent() {
+        String result = DiffUtils.unifiedDiff("all gone\n", "", "gone.txt");
+        assertFalse(result.isEmpty(), "Diff must be non-empty when all content is removed");
+        assertTrue(result.contains("-all gone"),
+            "Diff must mark deleted content with '-', got:\n" + result);
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/QualityToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/QualityToolsTest.java
@@ -1,0 +1,350 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
+import com.github.catatafishen.agentbridge.psi.ToolUtils;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.util.ui.UIUtil;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+/**
+ * Platform tests for quality tools: {@link GetCompilationErrorsTool},
+ * {@link GetProblemsTool}, {@link FormatCodeTool}, and {@link OptimizeImportsTool}.
+ *
+ * <p>JUnit 3 style (extends {@link BasePlatformTestCase}): test methods must be
+ * {@code public void testXxx()}. Run via Gradle only:
+ * {@code ./gradlew :plugin-core:test}.
+ *
+ * <h3>Threading model</h3>
+ * <ul>
+ *   <li>{@link FormatCodeTool} and {@link OptimizeImportsTool} schedule work via
+ *       {@code EdtUtil.invokeLater} and then block on a {@code CompletableFuture}. Calling
+ *       {@code execute()} directly from the EDT test thread would deadlock (EDT blocked by
+ *       {@code future.get()}, so the {@code invokeLater} callback can never run). These tools
+ *       are driven via {@link #executeSync}, which runs {@code execute()} on a pooled thread
+ *       while pumping the EDT queue on the test thread.
+ *   <li>{@link GetCompilationErrorsTool} and {@link GetProblemsTool} submit work to a pooled
+ *       thread via {@code executeOnPooledThread}, then block on a future. Their pooled-thread
+ *       callbacks use only {@code runReadAction} (no EDT requirement), so it is safe to call
+ *       {@code execute()} directly from the EDT test thread.
+ * </ul>
+ *
+ * <h3>File creation</h3>
+ * {@code myFixture.addFileToProject()} creates files in an in-memory VFS namespace that
+ * {@code LocalFileSystem#findFileByPath} cannot see. Tests that pass file paths to tools
+ * therefore create real on-disk files under a temp directory and register them via
+ * {@code LocalFileSystem#refreshAndFindFileByPath}.
+ */
+public class QualityToolsTest extends BasePlatformTestCase {
+
+    private GetCompilationErrorsTool compilationErrorsTool;
+    private GetProblemsTool problemsTool;
+    private FormatCodeTool formatTool;
+    private OptimizeImportsTool optimizeImportsTool;
+
+    /**
+     * Temporary directory for on-disk test files; deleted in {@link #tearDown()}.
+     */
+    private Path tempDir;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Prevent followFileIfEnabled from opening editors during tests.
+        // Use the String overload — the boolean overload removes the key when value==defaultValue,
+        // which would leave the setting at its default (true) instead of setting it to false.
+        PropertiesComponent.getInstance(getProject())
+            .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
+
+        compilationErrorsTool = new GetCompilationErrorsTool(getProject());
+        problemsTool = new GetProblemsTool(getProject());
+        formatTool = new FormatCodeTool(getProject());
+        optimizeImportsTool = new OptimizeImportsTool(getProject());
+
+        tempDir = Files.createTempDirectory("quality-tools-test");
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            // Close any editors the tools may have opened to prevent DisposalException.
+            FileEditorManager fem = FileEditorManager.getInstance(getProject());
+            for (VirtualFile openFile : fem.getOpenFiles()) {
+                fem.closeFile(openFile);
+            }
+            deleteDir(tempDir);
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    /**
+     * Creates a real file on disk under {@link #tempDir} and registers it in the
+     * VFS via {@link LocalFileSystem#refreshAndFindFileByPath} so that
+     * {@code LocalFileSystem#findFileByPath} (used internally by the tools) can
+     * locate it.
+     */
+    private VirtualFile createTestFile(String name, String content) {
+        try {
+            Path file = tempDir.resolve(name);
+            Files.writeString(file, content);
+            VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByPath(file.toString());
+            assertNotNull("Failed to register test file in VFS: " + file, vf);
+            return vf;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create test file: " + name, e);
+        }
+    }
+
+    /**
+     * Recursively deletes a directory tree; best-effort (ignores errors).
+     */
+    private static void deleteDir(Path dir) {
+        if (dir == null || !Files.exists(dir)) return;
+        try (Stream<Path> walk = Files.walk(dir)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException ignored) {
+                    // best-effort cleanup
+                }
+            });
+        } catch (IOException ignored) {
+            // best-effort cleanup
+        }
+    }
+
+    /**
+     * Builds a {@link JsonObject} from alternating key/value string pairs.
+     * Example: {@code args("path", "/tmp/Foo.java")}
+     */
+    private JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    /**
+     * Runs the given {@code action} on a pooled background thread while pumping the EDT
+     * event queue on the calling thread.
+     *
+     * <p>Required for tools that use {@code EdtUtil.invokeLater} to schedule write-actions
+     * back onto the EDT: calling {@code execute()} directly from the EDT would block the
+     * queue and prevent the invokeLater callback from ever running. Running {@code execute()}
+     * off-EDT while pumping the queue breaks that cycle.
+     *
+     * @param action callable that invokes the tool and returns its result string
+     * @return the string returned by {@code action}
+     */
+    private String executeSync(ThrowingSupplier<String> action) throws Exception {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                future.complete(action.get());
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (!future.isDone()) {
+            UIUtil.dispatchAllInvocationEvents();
+            if (System.currentTimeMillis() > deadline) {
+                fail("executeSync timed out after 15 seconds");
+            }
+        }
+        return future.get();
+    }
+
+    /**
+     * Minimal checked-exception-throwing {@link java.util.function.Supplier} variant.
+     */
+    @FunctionalInterface
+    interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+
+    // ── GetCompilationErrorsTool ──────────────────────────────────────────────────
+
+    /**
+     * Calls the tool with no arguments (checks all source files). A fresh test project
+     * with no Java sources should report zero errors.
+     *
+     * <p>Safe to call directly from the EDT: the tool delegates to a pooled thread via
+     * {@code executeOnPooledThread} and only uses {@code runReadAction} (no EDT callback
+     * requirement), so blocking the EDT on {@code future.get()} will not deadlock.
+     */
+    public void testGetCompilationErrorsNoErrors() throws Exception {
+        String result = compilationErrorsTool.execute(new JsonObject());
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Result should not be empty", result.isBlank());
+        // A fresh test project with no source files has zero errors
+        assertTrue("Expected 'No compilation errors' response, got: " + result,
+            result.contains("No compilation errors"));
+    }
+
+    /**
+     * Calls the tool with an explicit path to a real Java file on disk. The file is
+     * outside the project's source roots so the tool scans 0 indexed files and reports
+     * "No compilation errors in 0 files checked." — a valid non-error response.
+     */
+    public void testGetCompilationErrorsWithPath() throws Exception {
+        VirtualFile vf = createTestFile("CheckMe.java",
+            "package com.example;\npublic class CheckMe {\n}\n");
+
+        String result = compilationErrorsTool.execute(args("path", vf.getPath()));
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Result should not be empty", result.isBlank());
+        // Must not be a hard error — either zero-errors report or a file listing
+        assertFalse("Expected non-error response for valid path, got: " + result,
+            result.startsWith("{\"error\""));
+        assertTrue("Expected compilation-errors response, got: " + result,
+            result.contains("compilation error") || result.contains("No compilation"));
+    }
+
+    // ── GetProblemsTool ───────────────────────────────────────────────────────────
+
+    /**
+     * Calls the tool with no arguments when no files are open in the editor.
+     * Expects a "No problems found in open files" response (no daemon highlights
+     * are available for un-opened files).
+     *
+     * <p>Safe to call directly from the EDT for the same reason as
+     * {@link #testGetCompilationErrorsNoErrors}.
+     */
+    public void testGetProblemsNoOpenFiles() throws Exception {
+        String result = problemsTool.execute(new JsonObject());
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Result should not be empty", result.isBlank());
+        assertTrue("Expected 'No problems found in open files', got: " + result,
+            result.contains("No problems found"));
+    }
+
+    /**
+     * Calls the tool with a path to a real Java file on disk. Since the daemon has not
+     * yet run on this file there are no cached highlights, so the tool should report
+     * "No problems found" (or a problem count — never a crash).
+     */
+    public void testGetProblemsWithPath() throws Exception {
+        VirtualFile vf = createTestFile("SomeClass.java",
+            "package com.example;\npublic class SomeClass {\n}\n");
+
+        String result = problemsTool.execute(args("path", vf.getPath()));
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Result should not be empty", result.isBlank());
+        assertFalse("Expected non-error response for valid path, got: " + result,
+            result.startsWith("{\"error\""));
+        assertTrue("Expected 'No problems found' or problem listing, got: " + result,
+            result.contains("No problems found") || result.contains("problems"));
+    }
+
+    // ── FormatCodeTool ────────────────────────────────────────────────────────────
+
+    /**
+     * Passes a real Java file to {@link FormatCodeTool} and verifies the success
+     * message "Code formatted: &lt;path&gt;" is returned.
+     *
+     * <p>Uses {@link #executeSync} because {@code FormatCodeTool} schedules the actual
+     * write-action via {@code EdtUtil.invokeLater}; calling {@code execute()} directly
+     * from the EDT would deadlock.
+     */
+    public void testFormatCodeWithValidFile() throws Exception {
+        VirtualFile vf = createTestFile("FormatMe.java",
+            "package com.example;\n\npublic class FormatMe {\npublic void foo(){\n}\n}\n");
+
+        String result = executeSync(() -> formatTool.execute(args("path", vf.getPath())));
+        assertNotNull("execute() must not return null", result);
+        assertTrue("Expected 'Code formatted' success message, got: " + result,
+            result.startsWith("Code formatted"));
+    }
+
+    /**
+     * Passes an empty path string to {@link FormatCodeTool}. The tool should return a
+     * file-not-found or cannot-parse error rather than "Code formatted".
+     *
+     * <p>An empty path may resolve to the project root directory (a directory has no
+     * PsiFile), so both {@link ToolUtils#ERROR_FILE_NOT_FOUND} and
+     * {@link ToolUtils#ERROR_CANNOT_PARSE} are valid error prefixes.
+     */
+    public void testFormatCodeMissingPath() throws Exception {
+        String result = executeSync(() -> formatTool.execute(args("path", "")));
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Expected error for empty path — must not be 'Code formatted', got: " + result,
+            result.startsWith("Code formatted"));
+        assertTrue("Expected file-resolution error, got: " + result,
+            result.startsWith(ToolUtils.ERROR_FILE_NOT_FOUND)
+                || result.startsWith(ToolUtils.ERROR_CANNOT_PARSE)
+                || result.contains("not found")
+                || result.contains("Cannot parse"));
+    }
+
+    /**
+     * Passes a non-existent absolute path to {@link FormatCodeTool}. The tool should
+     * return a {@link ToolUtils#ERROR_FILE_NOT_FOUND} error message.
+     */
+    public void testFormatCodeNonExistentPath() throws Exception {
+        String nonExistentPath = "/nonexistent/quality/path/does/not/exist_xyz.java";
+        String result = executeSync(() -> formatTool.execute(args("path", nonExistentPath)));
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Expected error — must not be 'Code formatted', got: " + result,
+            result.startsWith("Code formatted"));
+        assertTrue("Expected file-not-found error, got: " + result,
+            result.startsWith(ToolUtils.ERROR_FILE_NOT_FOUND)
+                || result.contains("not found"));
+    }
+
+    // ── OptimizeImportsTool ───────────────────────────────────────────────────────
+
+    /**
+     * Passes a real Java file to {@link OptimizeImportsTool} and verifies the success
+     * message "Imports optimized: &lt;path&gt;" is returned.
+     *
+     * <p>Uses {@link #executeSync} because {@code OptimizeImportsTool} schedules the
+     * actual write-action via {@code EdtUtil.invokeLater}; calling {@code execute()}
+     * directly from the EDT would deadlock.
+     */
+    public void testOptimizeImportsWithValidFile() throws Exception {
+        VirtualFile vf = createTestFile("OptimizeMe.java",
+            "package com.example;\n"
+                + "import java.util.ArrayList;\n"
+                + "import java.util.List;\n"
+                + "public class OptimizeMe {\n"
+                + "    private List<String> items = new ArrayList<>();\n"
+                + "}\n");
+
+        String result = executeSync(() -> optimizeImportsTool.execute(args("path", vf.getPath())));
+        assertNotNull("execute() must not return null", result);
+        assertTrue("Expected 'Imports optimized' success message, got: " + result,
+            result.startsWith("Imports optimized"));
+    }
+
+    /**
+     * Passes an empty path string to {@link OptimizeImportsTool}. The tool should
+     * return a file-resolution error rather than "Imports optimized".
+     */
+    public void testOptimizeImportsMissingPath() throws Exception {
+        String result = executeSync(() -> optimizeImportsTool.execute(args("path", "")));
+        assertNotNull("execute() must not return null", result);
+        assertFalse("Expected error for empty path — must not be 'Imports optimized', got: " + result,
+            result.startsWith("Imports optimized"));
+        assertTrue("Expected file-resolution error, got: " + result,
+            result.startsWith(ToolUtils.ERROR_FILE_NOT_FOUND)
+                || result.startsWith(ToolUtils.ERROR_CANNOT_PARSE)
+                || result.contains("not found")
+                || result.contains("Cannot parse"));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsExtendedTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsExtendedTest.java
@@ -1,0 +1,344 @@
+package com.github.catatafishen.agentbridge.psi.tools.refactoring;
+
+import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
+import com.github.catatafishen.agentbridge.psi.ToolUtils;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.util.ui.UIUtil;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+/**
+ * Platform tests for refactoring tools: {@link FindImplementationsTool},
+ * {@link GetCallHierarchyTool}, {@link GoToDeclarationTool},
+ * {@link GetSymbolInfoTool}, and {@link RefactorTool}.
+ *
+ * <p>JUnit 3 style (extends {@link BasePlatformTestCase}): test methods must be
+ * {@code public void testXxx()}. Run via Gradle only:
+ * {@code ./gradlew :plugin-core:test}.
+ *
+ * <h3>Threading model</h3>
+ * <ul>
+ *   <li>{@link FindImplementationsTool}, {@link GetCallHierarchyTool},
+ *       {@link GoToDeclarationTool} — validation errors return synchronously.
+ *       Successful searches use {@code runReadAction}, safe from the EDT test
+ *       thread.</li>
+ *   <li>{@link GetSymbolInfoTool} — uses {@code runReadAction} (Computable) only;
+ *       safe from EDT.</li>
+ *   <li>{@link RefactorTool} — validation errors return synchronously. Actual
+ *       refactoring dispatches via {@code EdtUtil.invokeLater} and must be driven
+ *       via {@link #executeSync}.</li>
+ * </ul>
+ *
+ * <h3>File creation</h3>
+ * Tools that use {@code LocalFileSystem#findFileByPath} need real on-disk files
+ * registered via {@code LocalFileSystem#refreshAndFindFileByPath}.
+ */
+public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
+
+    private FindImplementationsTool findImplementationsTool;
+    private GetCallHierarchyTool getCallHierarchyTool;
+    private GoToDeclarationTool goToDeclarationTool;
+    private GetSymbolInfoTool getSymbolInfoTool;
+    private RefactorTool refactorTool;
+
+    /**
+     * Temporary directory for on-disk test files; deleted in {@link #tearDown()}.
+     */
+    private Path tempDir;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Prevent followFileIfEnabled from opening editors during tests.
+        PropertiesComponent.getInstance(getProject())
+            .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
+
+        findImplementationsTool = new FindImplementationsTool(getProject());
+        getCallHierarchyTool = new GetCallHierarchyTool(getProject());
+        goToDeclarationTool = new GoToDeclarationTool(getProject());
+        getSymbolInfoTool = new GetSymbolInfoTool(getProject());
+        refactorTool = new RefactorTool(getProject());
+
+        tempDir = Files.createTempDirectory("refactoring-tools-ext-test");
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            // Close any editors opened by the tools to prevent DisposalException.
+            FileEditorManager fem = FileEditorManager.getInstance(getProject());
+            for (VirtualFile openFile : fem.getOpenFiles()) {
+                fem.closeFile(openFile);
+            }
+            deleteDir(tempDir);
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * Creates a real file on disk under {@link #tempDir} and registers it in the
+     * VFS via {@link LocalFileSystem#refreshAndFindFileByPath} so that
+     * {@code LocalFileSystem#findFileByPath} (used internally by the tools) can
+     * locate it.
+     */
+    private VirtualFile createTestFile(String name, String content) throws IOException {
+        Path file = tempDir.resolve(name);
+        Files.writeString(file, content);
+        VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByPath(file.toString());
+        assertNotNull("Failed to register test file in VFS: " + file, vf);
+        return vf;
+    }
+
+    /**
+     * Recursively deletes a directory tree; best-effort (ignores errors).
+     */
+    private static void deleteDir(Path dir) {
+        if (dir == null || !Files.exists(dir)) return;
+        try (Stream<Path> walk = Files.walk(dir)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException ignored) {
+                    // best-effort cleanup
+                }
+            });
+        } catch (IOException ignored) {
+            // best-effort cleanup
+        }
+    }
+
+    /**
+     * Builds a {@link JsonObject} from alternating key/value string pairs.
+     * Example: {@code args("symbol", "Runnable", "file", "/some/File.java")}
+     */
+    private static JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    /**
+     * Runs the given {@code action} on a pooled background thread while pumping the EDT
+     * event queue on the calling thread.
+     *
+     * <p>Required for tools that dispatch write-actions back to the EDT via
+     * {@code EdtUtil.invokeLater}: calling {@code execute()} directly from the EDT would
+     * deadlock because the EDT queue is blocked by {@code future.get()}.
+     */
+    private String executeSync(ThrowingSupplier<String> action) throws Exception {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                future.complete(action.get());
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (!future.isDone()) {
+            UIUtil.dispatchAllInvocationEvents();
+            if (System.currentTimeMillis() > deadline) {
+                fail("executeSync timed out after 30 seconds");
+            }
+        }
+        return future.get();
+    }
+
+    /**
+     * Minimal checked-exception-throwing {@link java.util.function.Supplier} variant.
+     */
+    @FunctionalInterface
+    interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+
+    // ── FindImplementationsTool ───────────────────────────────────────────────
+
+    /**
+     * Omitting the required {@code symbol} parameter must return the validation error
+     * "Error: 'symbol' parameter is required". This check is synchronous.
+     */
+    public void testFindImplementationsMissingSymbol() throws Exception {
+        String result = findImplementationsTool.execute(new JsonObject());
+        assertNotNull("Result must not be null", result);
+        assertTrue("Expected error for missing symbol, got: " + result,
+            result.startsWith("Error:") && result.contains("symbol"));
+    }
+
+    /**
+     * Searching for {@code Runnable} (a built-in Java interface) must return a
+     * non-error response. The project may or may not contain implementations, but
+     * the response must never be an error string.
+     *
+     * <p>Safe to call from the EDT: the tool uses {@code runReadAction} only.
+     */
+    public void testFindImplementationsForBuiltinInterface() throws Exception {
+        String result = findImplementationsTool.execute(args("symbol", "Runnable"));
+        assertNotNull("Result must not be null", result);
+        assertFalse("Expected non-error response for 'Runnable' symbol, got: " + result,
+            result.startsWith("Error:"));
+        assertFalse("Result must not be blank", result.isBlank());
+    }
+
+    // ── GetCallHierarchyTool ──────────────────────────────────────────────────
+
+    /**
+     * Omitting all required parameters must return the validation error
+     * "Error: 'symbol', 'file', and 'line' parameters are required".
+     */
+    public void testGetCallHierarchyMissingSymbol() throws Exception {
+        String result = getCallHierarchyTool.execute(new JsonObject());
+        assertNotNull("Result must not be null", result);
+        assertTrue("Expected validation error for missing symbol, got: " + result,
+            result.startsWith("Error:") && result.contains("symbol"));
+    }
+
+    /**
+     * Providing {@code symbol} but omitting {@code file} and {@code line} must return
+     * the combined validation error since all three are required.
+     */
+    public void testGetCallHierarchyMissingFile() throws Exception {
+        String result = getCallHierarchyTool.execute(args("symbol", "doSomething"));
+        assertNotNull("Result must not be null", result);
+        assertTrue("Expected validation error for missing file+line, got: " + result,
+            result.startsWith("Error:") && result.contains("file"));
+    }
+
+    /**
+     * Providing {@code symbol} and {@code file} but omitting {@code line} must return
+     * the combined validation error since all three are required.
+     */
+    public void testGetCallHierarchyMissingLine() throws Exception {
+        String result = getCallHierarchyTool.execute(
+            args("symbol", "doSomething", "file", "/some/path/MyClass.java"));
+        assertNotNull("Result must not be null", result);
+        assertTrue("Expected validation error for missing line, got: " + result,
+            result.startsWith("Error:") && result.contains("line"));
+    }
+
+    // ── GoToDeclarationTool ───────────────────────────────────────────────────
+
+    /**
+     * Omitting all required parameters must return the validation error
+     * "Error: 'file', 'symbol', and 'line' parameters are required".
+     */
+    public void testGoToDeclarationMissingFile() throws Exception {
+        String result = goToDeclarationTool.execute(new JsonObject());
+        assertNotNull("Result must not be null", result);
+        assertTrue("Expected validation error for missing file/symbol/line, got: " + result,
+            result.startsWith("Error:") && result.contains("file"));
+    }
+
+    /**
+     * Providing {@code file} but omitting {@code symbol} and {@code line} must return
+     * the same combined validation error.
+     */
+    public void testGoToDeclarationMissingSymbol() throws Exception {
+        String result = goToDeclarationTool.execute(args("file", "/some/path/MyClass.java"));
+        assertNotNull("Result must not be null", result);
+        assertTrue("Expected validation error for missing symbol+line, got: " + result,
+            result.startsWith("Error:") && result.contains("symbol"));
+    }
+
+    /**
+     * Providing {@code file} and {@code symbol} but omitting {@code line} must return
+     * the same combined validation error.
+     */
+    public void testGoToDeclarationMissingLine() throws Exception {
+        String result = goToDeclarationTool.execute(
+            args("file", "/some/path/MyClass.java", "symbol", "MyClass"));
+        assertNotNull("Result must not be null", result);
+        assertTrue("Expected validation error for missing line, got: " + result,
+            result.startsWith("Error:") && result.contains("line"));
+    }
+
+    // ── GetSymbolInfoTool ─────────────────────────────────────────────────────
+
+    /**
+     * Providing an empty string for {@code file} causes {@code resolveVirtualFile("")}
+     * to return {@code null}, so the tool returns a "File not found" error response.
+     *
+     * <p>Safe to call from the EDT: the tool uses {@code runReadAction} (Computable)
+     * only, with no EDT dispatch.
+     */
+    public void testGetSymbolInfoMissingFile() throws Exception {
+        // Empty path → resolveVirtualFile("") → null → ERROR_PREFIX + ERROR_FILE_NOT_FOUND
+        String result = getSymbolInfoTool.execute(args("file", "", "line", "1"));
+        assertNotNull("Result must not be null", result);
+        assertTrue("Expected 'Error: File not found' for empty file path, got: " + result,
+            result.startsWith(ToolUtils.ERROR_PREFIX));
+    }
+
+    /**
+     * Omitting the {@code line} parameter entirely causes the tool to throw a
+     * {@link NullPointerException} when it accesses {@code args.get("line").getAsInt()}
+     * without a null check. The NPE is thrown synchronously before any async dispatch.
+     */
+    public void testGetSymbolInfoMissingLine() {
+        JsonObject a = new JsonObject();
+        a.addProperty("file", "/nonexistent/path/GetSymbolInfoMissingLine.java");
+        // "line" intentionally omitted — tool will NPE on args.get("line").getAsInt()
+
+        try {
+            getSymbolInfoTool.execute(a);
+            fail("Expected exception when 'line' parameter is missing");
+        } catch (Exception e) {
+            // Expected: args.get("line") returns null; .getAsInt() on null throws NPE.
+        }
+    }
+
+    // ── RefactorTool ──────────────────────────────────────────────────────────
+
+    /**
+     * Omitting all required parameters ({@code operation}, {@code file},
+     * {@code symbol}) must return the validation error
+     * "Error: 'operation', 'file', and 'symbol' parameters are required".
+     * This check is synchronous and returns before any EDT dispatch.
+     */
+    public void testRefactorMissingOperation() throws Exception {
+        String result = refactorTool.execute(new JsonObject());
+        assertNotNull("Result must not be null", result);
+        assertTrue("Expected validation error for missing operation/file/symbol, got: " + result,
+            result.startsWith("Error:") && result.contains("operation"));
+    }
+
+    /**
+     * Providing an unrecognised {@code operation} value with a real file and a symbol
+     * that exists in that file must result in an error response. The refactoring
+     * dispatch uses {@code EdtUtil.invokeLater}, so {@link #executeSync} is required.
+     *
+     * <p>If the symbol is found, the operation-dispatch switch returns
+     * "Error: Unknown operation 'invalid_op'...". If the symbol or file cannot be
+     * resolved, the tool still returns an {@code "Error: ..."} response — either way
+     * the assertion that an invalid operation is rejected holds.
+     */
+    public void testRefactorInvalidOperation() throws Exception {
+        VirtualFile vf = createTestFile("RefactorInvalidOp.java",
+            "public class RefactorInvalidOp {\n    public void doWork() {}\n}\n");
+
+        String result = executeSync(() -> refactorTool.execute(args(
+            "operation", "invalid_op",
+            "file", vf.getPath(),
+            "symbol", "RefactorInvalidOp"
+        )));
+        assertNotNull("Result must not be null", result);
+        assertTrue("Expected error for invalid operation, got: " + result,
+            result.startsWith("Error:") || result.contains("Error"));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsTest.java
@@ -1,0 +1,154 @@
+package com.github.catatafishen.agentbridge.psi.tools.refactoring;
+
+import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+/**
+ * Platform tests for {@link GetDocumentationTool} and
+ * {@link GetTypeHierarchyTool}.
+ *
+ * <p>JUnit 3 style (extends BasePlatformTestCase): test methods must be
+ * {@code public void testXxx()}.  Run via Gradle only:
+ * {@code ./gradlew :plugin-core:test}.
+ *
+ * <p>Both tools execute inside
+ * {@code ApplicationManager.getApplication().runReadAction()} — they are
+ * synchronous when called from the EDT test thread so no extra threading
+ * machinery is required. Both declare {@code throws Exception} in their
+ * {@code execute()} signatures, so test methods follow suit.
+ *
+ * <p>{@link GetDocumentationTool} resolves symbols via
+ * {@code JavaPsiFacade.findClass} against {@code allScope}, which includes the
+ * JDK. Tests that look up built-in classes (e.g. {@code java.util.ArrayList})
+ * therefore work without adding any fixture files.
+ *
+ * <p>{@link GetTypeHierarchyTool} delegates to
+ * {@code RefactoringJavaSupport.getTypeHierarchy}, which also uses
+ * {@code JavaPsiFacade} and {@code allScope}. A project-local class added via
+ * {@code myFixture.addFileToProject()} is included in the scope and can be
+ * found by its fully-qualified name.
+ */
+public class RefactoringToolsTest extends BasePlatformTestCase {
+
+    private GetDocumentationTool getDocumentationTool;
+    private GetTypeHierarchyTool getTypeHierarchyTool;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Disable follow-agent UI (editor navigation, status-bar feedback)
+        // to avoid spurious editor-lifecycle failures in headless tests.
+        PropertiesComponent.getInstance(getProject())
+            .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
+        getDocumentationTool = new GetDocumentationTool(getProject());
+        getTypeHierarchyTool = new GetTypeHierarchyTool(getProject());
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            // Close any editors that may have been opened during the test.
+            FileEditorManager fem = FileEditorManager.getInstance(getProject());
+            for (VirtualFile openFile : fem.getOpenFiles()) {
+                fem.closeFile(openFile);
+            }
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /** Builds a {@link JsonObject} from alternating key/value String pairs. */
+    private static JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    // ── GetDocumentationTool ──────────────────────────────────────────────────
+
+    /**
+     * Looking up the documentation for the built-in {@code java.util.ArrayList}
+     * class must return a non-error response. The result should reference the
+     * class either as documentation text or as the "element found" fallback.
+     * It must not return the "symbol parameter required" validation error.
+     */
+    public void testGetDocumentationForBuiltinClass() throws Exception {
+        String result = getDocumentationTool.execute(args("symbol", "java.util.ArrayList"));
+
+        assertNotNull("Result should not be null", result);
+        // Must not be the validation error for missing 'symbol' argument.
+        assertFalse("Expected non-validation-error result, got: " + result,
+            result.startsWith("Error: 'symbol' parameter required"));
+        // Either doc content or the "element found" fallback must mention ArrayList.
+        assertTrue("Expected 'ArrayList' to appear in result, got: " + result,
+            result.contains("ArrayList"));
+    }
+
+    /**
+     * When the {@code symbol} parameter is absent (empty string), the tool must
+     * return the standard validation-error message beginning with
+     * {@code "Error: 'symbol' parameter required"}.
+     */
+    public void testGetDocumentationMissingSymbol() throws Exception {
+        String result = getDocumentationTool.execute(new JsonObject());
+
+        assertTrue("Expected validation-error prefix, got: " + result,
+            result.startsWith("Error: 'symbol' parameter required"));
+        assertTrue("Expected 'symbol' mentioned in error, got: " + result,
+            result.contains("symbol"));
+    }
+
+    // ── GetTypeHierarchyTool ──────────────────────────────────────────────────
+
+    /**
+     * After adding a Java class that implements {@code Runnable}, calling
+     * {@code get_type_hierarchy} for that class with {@code direction=supertypes}
+     * must return the standard {@code "Type hierarchy for:"} header and mention
+     * {@code Runnable} in the supertypes section.
+     */
+    public void testGetTypeHierarchyForClass() throws Exception {
+        myFixture.addFileToProject(
+            "com/example/MyRunnableClass_8831.java",
+            """
+                package com.example;
+                public class MyRunnableClass_8831 implements Runnable {
+                    @Override
+                    public void run() {}
+                }
+                """);
+
+        String result = getTypeHierarchyTool.execute(args(
+            "symbol", "com.example.MyRunnableClass_8831",
+            "direction", "supertypes"
+        ));
+
+        assertNotNull("Result should not be null", result);
+        // Must not be the "class not found" error path.
+        assertFalse("Expected class to be found in hierarchy, got: " + result,
+            result.startsWith("Error: Class/interface"));
+        // The tool always emits this header when a class is resolved.
+        assertTrue("Expected 'Type hierarchy for:' header, got: " + result,
+            result.contains("Type hierarchy for:"));
+        // MyRunnableClass_8831 implements Runnable, so Runnable must appear.
+        assertTrue("Expected 'Runnable' in supertypes section, got: " + result,
+            result.contains("Runnable"));
+    }
+
+    /**
+     * When the required {@code symbol} parameter is absent, the tool must
+     * return exactly {@code "Error: 'symbol' parameter is required"}.
+     */
+    public void testGetTypeHierarchyMissingSymbol() throws Exception {
+        String result = getTypeHierarchyTool.execute(new JsonObject());
+
+        assertEquals("Error: 'symbol' parameter is required", result);
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalToolsTest.java
@@ -1,0 +1,713 @@
+package com.github.catatafishen.agentbridge.psi.tools.terminal;
+
+import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
+import com.github.catatafishen.agentbridge.psi.tools.Tool;
+import com.google.gson.JsonObject;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.util.ui.UIUtil;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Platform tests for the four terminal tools: {@link ListTerminalsTool},
+ * {@link ReadTerminalOutputTool}, {@link WriteTerminalInputTool}, and
+ * {@link RunInTerminalTool}, plus the {@link TerminalToolFactory}.
+ *
+ * <p>JUnit 3 style (extends {@link BasePlatformTestCase}): test methods must be
+ * {@code public void testXxx()}. Run via Gradle only:
+ * {@code ./gradlew :plugin-core:test}.
+ *
+ * <p><b>Threading model:</b>
+ * <ul>
+ *   <li>{@link ListTerminalsTool} uses {@code EdtUtil.invokeAndWait} exclusively.
+ *       Because {@code invokeAndWait} detects {@code isDispatchThread() == true} and
+ *       runs the runnable inline, this tool can be called directly from test methods
+ *       (which already run on the EDT).</li>
+ *   <li>{@link ReadTerminalOutputTool}, {@link WriteTerminalInputTool}, and
+ *       {@link RunInTerminalTool} schedule their result on the EDT via
+ *       {@code EdtUtil.invokeLater} and then block on a {@code CompletableFuture}.
+ *       Calling {@code execute()} directly from the EDT would deadlock. These tools
+ *       must be invoked via {@link #executeSync}, which runs {@code execute()} on a
+ *       pooled thread while pumping the EDT event queue.</li>
+ *   <li>{@link WriteTerminalInputTool#execute} and {@link RunInTerminalTool#execute}
+ *       access the required {@code "input"}/{@code "command"} argument
+ *       <em>before</em> any EDT dispatch. Passing an empty {@link JsonObject} causes
+ *       a {@link NullPointerException} on the pooled thread, which propagates as
+ *       {@link ExecutionException} from {@code future.get()}.</li>
+ * </ul>
+ *
+ * <p><b>Test environment:</b> in the headless Gradle test sandbox the IntelliJ
+ * Terminal plugin ({@code TerminalToolWindowManager}) is not present on the
+ * classpath. {@link RunInTerminalTool} catches the resulting
+ * {@link ClassNotFoundException} and returns a graceful error message. Similarly,
+ * the Terminal tool window is not registered, so {@link ListTerminalsTool} and
+ * {@link ReadTerminalOutputTool} report that no tabs are available rather than
+ * throwing.
+ */
+public class TerminalToolsTest extends BasePlatformTestCase {
+
+    private ListTerminalsTool listTerminalsTool;
+    private ReadTerminalOutputTool readTerminalOutputTool;
+    private WriteTerminalInputTool writeTerminalInputTool;
+    private RunInTerminalTool runInTerminalTool;
+
+    // ── Lifecycle ──────────────────────────────────────────────────────────────
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        // Disable "follow agent files" UI navigation to prevent editor-lifecycle
+        // failures (DisposalException, focus stealing) in the headless test environment.
+        // Use the String overload — the boolean overload silently removes the key when
+        // value == defaultValue, which would leave the setting at its default.
+        PropertiesComponent.getInstance(getProject())
+            .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
+
+        listTerminalsTool = new ListTerminalsTool(getProject());
+        readTerminalOutputTool = new ReadTerminalOutputTool(getProject());
+        writeTerminalInputTool = new WriteTerminalInputTool(getProject());
+        runInTerminalTool = new RunInTerminalTool(getProject());
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    /**
+     * Builds a {@link JsonObject} from alternating key/value String pairs.
+     * Example: {@code args("tab_name", "myTab", "max_lines", "10")}.
+     */
+    private static JsonObject args(String... pairs) {
+        JsonObject obj = new JsonObject();
+        for (int i = 0; i < pairs.length; i += 2) {
+            obj.addProperty(pairs[i], pairs[i + 1]);
+        }
+        return obj;
+    }
+
+    /**
+     * Runs {@code tool.execute(argsObj)} on a pooled background thread while
+     * pumping the EDT event queue. Required for tools that use
+     * {@code EdtUtil.invokeLater}: calling {@code execute()} directly from the EDT
+     * would deadlock because the scheduled EDT callback can never run while the EDT
+     * thread is blocked inside {@code future.get()}.
+     *
+     * <p>If {@code execute()} throws (e.g. {@link NullPointerException} for a missing
+     * required parameter), the exception is wrapped in {@link ExecutionException} and
+     * re-thrown from {@code future.get()}.
+     *
+     * @throws ExecutionException    if {@code execute()} threw an exception on the
+     *                               pooled thread
+     * @throws IllegalStateException if the operation does not complete within 15 s
+     */
+    private String executeSync(Tool tool, JsonObject argsObj) throws Exception {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                future.complete(tool.execute(argsObj));
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+        long deadline = System.currentTimeMillis() + 15_000;
+        while (!future.isDone()) {
+            UIUtil.dispatchAllInvocationEvents();
+            if (System.currentTimeMillis() > deadline) {
+                fail("tool.execute() timed out after 15 seconds");
+            }
+        }
+        return future.get();
+    }
+
+    // ── TerminalToolFactory ────────────────────────────────────────────────────
+
+    /**
+     * {@link TerminalToolFactory#create} must return a list containing exactly the
+     * four expected tool instances. Availability of the terminal plugin is checked
+     * at execution time (via reflection), not at factory creation time — there is
+     * no guard to bypass at construction.
+     */
+    public void testTerminalToolFactoryCreatesAllFourTools() {
+        List<Tool> tools = TerminalToolFactory.create(getProject());
+
+        assertNotNull("Factory must not return null", tools);
+        assertEquals("Factory must create exactly 4 terminal tools", 4, tools.size());
+
+        long listCount = tools.stream().filter(ListTerminalsTool.class::isInstance).count();
+        long readCount = tools.stream().filter(ReadTerminalOutputTool.class::isInstance).count();
+        long writeCount = tools.stream().filter(WriteTerminalInputTool.class::isInstance).count();
+        long runCount = tools.stream().filter(RunInTerminalTool.class::isInstance).count();
+
+        assertEquals("Expected exactly one ListTerminalsTool", 1, listCount);
+        assertEquals("Expected exactly one ReadTerminalOutputTool", 1, readCount);
+        assertEquals("Expected exactly one WriteTerminalInputTool", 1, writeCount);
+        assertEquals("Expected exactly one RunInTerminalTool", 1, runCount);
+    }
+
+    /**
+     * Every tool produced by the factory must have a non-blank {@code id()},
+     * {@code displayName()}, and {@code description()}.
+     */
+    public void testTerminalToolFactoryMetadataIsValid() {
+        List<Tool> tools = TerminalToolFactory.create(getProject());
+
+        for (Tool tool : tools) {
+            String simpleName = tool.getClass().getSimpleName();
+            assertNotNull(simpleName + ": id() must not be null", tool.id());
+            assertFalse(simpleName + ": id() must not be blank", tool.id().isBlank());
+            assertNotNull(simpleName + ": displayName() must not be null", tool.displayName());
+            assertFalse(simpleName + ": displayName() must not be blank", tool.displayName().isBlank());
+            assertNotNull(simpleName + ": description() must not be null", tool.description());
+            assertFalse(simpleName + ": description() must not be blank", tool.description().isBlank());
+        }
+    }
+
+    // ── ListTerminalsTool ──────────────────────────────────────────────────────
+
+    /**
+     * In a fresh headless test project there are no open terminal tabs.
+     * {@code list_terminals} must still return a structured response containing the
+     * "Open terminal tabs:" section header and an indication that no tabs are
+     * available — it must never throw, return null, or return blank content.
+     *
+     * <p>{@link ListTerminalsTool} uses {@code EdtUtil.invokeAndWait} internally,
+     * which runs inline when already on the EDT, so calling {@code execute()}
+     * directly from the test method is safe.
+     */
+    public void testListTerminalsNoTerminals() throws Exception {
+        String result = listTerminalsTool.execute(new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertTrue("Expected 'Open terminal tabs:' section header in result, got: " + result,
+            result.contains("Open terminal tabs:"));
+
+        // In the headless test environment the Terminal tool window is either absent
+        // or reports no tabs — exactly one of these phrases must appear.
+        boolean noneIndicated = result.contains("(none)")
+            || result.contains("not available")
+            || result.contains("Could not list");
+        assertTrue(
+            "Expected no-terminals indication ('(none)' / 'not available' / 'Could not list'), got: " + result,
+            noneIndicated);
+    }
+
+    /**
+     * The response from {@code list_terminals} must always be non-null, non-blank,
+     * and must not start with "Error". It must include the "Available shells:" section
+     * and the closing tip line regardless of whether any terminal is open.
+     */
+    public void testListTerminalsResponseFormat() throws Exception {
+        String result = listTerminalsTool.execute(new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertFalse("Result must never start with 'Error', got: " + result,
+            result.startsWith("Error"));
+        assertTrue("Expected 'Available shells:' section in result, got: " + result,
+            result.contains("Available shells:"));
+        // The tip line is appended unconditionally at the end of execute()
+        assertTrue("Expected closing tip referencing read_terminal_output, got: " + result,
+            result.contains("read_terminal_output"));
+        assertTrue("Expected closing tip referencing write_terminal_input, got: " + result,
+            result.contains("write_terminal_input"));
+    }
+
+    /**
+     * The "Available shells:" section must list discovered shells or at least attempt
+     * to check common shell paths for the current OS. On POSIX systems {@code /bin/sh}
+     * is universally available, so at least one "&#x2713;" entry is expected; on Windows
+     * the section may list zero available entries but the header must still be present.
+     */
+    public void testListTerminalsAvailableShellsSection() throws Exception {
+        String result = listTerminalsTool.execute(new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        assertTrue("Expected 'Available shells:' section in result, got: " + result,
+            result.contains("Available shells:"));
+
+        String os = System.getProperty("os.name", "").toLowerCase();
+        if (!os.contains("win") && new java.io.File("/bin/sh").exists()) {
+            // /bin/sh is universally available on POSIX — at least one shell must be shown
+            assertTrue("Expected at least one '✓' shell entry on POSIX system, got: " + result,
+                result.contains("✓"));
+        }
+    }
+
+    /**
+     * The default-shell line must always appear: either the actual configured shell
+     * path ({@code "IntelliJ default shell: ..."}) or the graceful fallback message
+     * ({@code "Could not determine IntelliJ default shell."}) when the terminal plugin
+     * is absent in the test sandbox.
+     */
+    public void testListTerminalsDefaultShellSection() throws Exception {
+        String result = listTerminalsTool.execute(new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        boolean hasDefaultShellLine = result.contains("IntelliJ default shell:")
+            || result.contains("Could not determine IntelliJ default shell");
+        assertTrue("Expected a default-shell line in result, got: " + result,
+            hasDefaultShellLine);
+    }
+
+    /**
+     * {@code list_terminals} must be declared as {@link Tool.Kind#READ} and
+     * {@code isReadOnly()} must return {@code true}.
+     */
+    public void testListTerminalsIsReadOnly() {
+        assertEquals("list_terminals must be Kind.READ",
+            Tool.Kind.READ, listTerminalsTool.kind());
+        assertTrue("list_terminals must be read-only",
+            listTerminalsTool.isReadOnly());
+    }
+
+    // ── ReadTerminalOutputTool ─────────────────────────────────────────────────
+
+    /**
+     * When {@code tab_name} is omitted and no terminal tab is open, the tool must
+     * return the standard "No terminal tab is open" message — not null, not blank,
+     * and not a raw Java exception string.
+     *
+     * <p>{@link ReadTerminalOutputTool} uses {@code EdtUtil.invokeLater} and a
+     * {@code CompletableFuture}, so it must be called via {@link #executeSync}.
+     */
+    public void testReadTerminalOutputNoTabName() throws Exception {
+        String result = executeSync(readTerminalOutputTool, new JsonObject());
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertFalse("Result must not be a raw Java exception string",
+            result.startsWith("java."));
+        // resolveTerminalContent(null) → null when no Terminal tool window is registered
+        // → execute() returns "No terminal tab is open. Use run_in_terminal to start one."
+        assertTrue("Expected a no-terminal message, got: " + result,
+            result.contains("No terminal tab is open")
+                || result.contains("No terminal")
+                || result.contains("Terminal read timed out"));
+    }
+
+    /**
+     * When a non-existent {@code tab_name} is specified, the tool must return an
+     * error message that references the requested tab name and directs the user to
+     * {@code list_terminals}.
+     *
+     * <p>Expected message (when the Terminal tool window exists but the tab is absent):
+     * {@code "No terminal tab found matching 'NonExistentTabXYZ_99999'. Use list_terminals to see available tabs."}
+     */
+    public void testReadTerminalOutputNonExistentTab() throws Exception {
+        String nonExistentTab = "NonExistentTabXYZ_99999";
+        String result = executeSync(readTerminalOutputTool, args("tab_name", nonExistentTab));
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertFalse("Result must not be a raw Java exception string",
+            result.startsWith("java."));
+        // resolveTerminalContent(tabName) → null → "No terminal tab found matching '...'"
+        assertTrue("Expected error referencing the missing tab name, got: " + result,
+            result.contains(nonExistentTab)
+                || result.contains("No terminal tab found")
+                || result.contains("No terminal"));
+    }
+
+    /**
+     * When {@code max_lines} is set to {@code 0} (full-buffer request) and no terminal
+     * is open, the tool still returns a graceful message rather than throwing.
+     */
+    public void testReadTerminalOutputMaxLinesZeroNoTerminal() throws Exception {
+        JsonObject argsObj = new JsonObject();
+        argsObj.addProperty("max_lines", 0);
+
+        String result = executeSync(readTerminalOutputTool, argsObj);
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertFalse("Result must not start with 'Error'", result.startsWith("Error"));
+    }
+
+    /**
+     * {@code read_terminal_output} must be declared as {@link Tool.Kind#READ} and
+     * {@code isReadOnly()} must return {@code true}.
+     */
+    public void testReadTerminalOutputIsReadOnly() {
+        assertEquals("read_terminal_output must be Kind.READ",
+            Tool.Kind.READ, readTerminalOutputTool.kind());
+        assertTrue("read_terminal_output must be read-only",
+            readTerminalOutputTool.isReadOnly());
+    }
+
+    // ── WriteTerminalInputTool ─────────────────────────────────────────────────
+
+    /**
+     * When the required {@code "input"} argument is absent, the tool calls
+     * {@code args.get("input").getAsString()} without a null-check (Gson returns
+     * {@code null} for missing keys), which causes a {@link NullPointerException}
+     * on the pooled thread before any EDT work is dispatched. {@link #executeSync}
+     * wraps this in an {@link ExecutionException}.
+     *
+     * <p>This test documents the current behavior. If the implementation is later
+     * updated to validate parameters explicitly and return a graceful error message,
+     * this test should be updated to assert on that error string instead.
+     */
+    public void testWriteTerminalInputMissingInput() throws Exception {
+        try {
+            String result = executeSync(writeTerminalInputTool, new JsonObject());
+            // Future-proof: if the tool adds explicit validation, it must return
+            // a non-null, non-blank, non-exception error message.
+            assertNotNull("Result (if returned) must not be null", result);
+            assertFalse("Result (if returned) must not be blank", result.isBlank());
+            assertFalse("Result must not be a raw Java exception string",
+                result.startsWith("java."));
+        } catch (ExecutionException e) {
+            // Current behavior: NullPointerException from args.get("input").getAsString()
+            // when the "input" key is absent from the JsonObject.
+            Throwable cause = e.getCause();
+            assertNotNull("ExecutionException must have a non-null cause", cause);
+            assertTrue(
+                "Expected NullPointerException for absent required 'input' parameter, got: "
+                    + cause.getClass().getName(),
+                cause instanceof NullPointerException);
+        }
+    }
+
+    /**
+     * When {@code "input"} is provided but no terminal is running, the tool must
+     * return a helpful message directing the user to create a terminal first.
+     * In the headless test sandbox the terminal plugin class is absent
+     * ({@link ClassNotFoundException}), which is also caught gracefully.
+     *
+     * <p>Expected messages:
+     * <ul>
+     *   <li>Terminal plugin absent: {@code "Failed to write to terminal: ..."}</li>
+     *   <li>Plugin present but no widget: {@code "No terminal found. Use run_in_terminal to create one first."}</li>
+     *   <li>Timeout (very unlikely): {@code "Input sent (response timed out)."}</li>
+     * </ul>
+     */
+    public void testWriteTerminalInputNoTerminal() throws Exception {
+        String result = executeSync(writeTerminalInputTool, args("input", "echo hello"));
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertFalse("Result must not be a raw Java exception string",
+            result.startsWith("java."));
+
+        boolean noTerminalMessage = result.contains("No terminal found");
+        boolean failedWriteMessage = result.contains("Failed to write to terminal");
+        boolean timedOut = result.contains("timed out");
+        assertTrue(
+            "Expected no-terminal or write-failure message, got: " + result,
+            noTerminalMessage || failedWriteMessage || timedOut);
+    }
+
+    /**
+     * When both {@code "input"} and a non-existent {@code tab_name} are provided,
+     * the error message must either reference that tab name or be a generic
+     * no-terminal/write-failure message.
+     *
+     * <p>Primary expected message (when the terminal plugin is present):
+     * {@code "No terminal found matching 'GhostTabXYZ_54321'. Use run_in_terminal to create one first."}
+     */
+    public void testWriteTerminalInputNoTerminalWithTabName() throws Exception {
+        String ghostTab = "GhostTabXYZ_54321";
+        String result = executeSync(writeTerminalInputTool,
+            args("input", "ls -la", "tab_name", ghostTab));
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertFalse("Result must not be a raw Java exception string",
+            result.startsWith("java."));
+
+        boolean mentionsTabName = result.contains(ghostTab);
+        boolean genericError = result.contains("No terminal found")
+            || result.contains("Failed to write to terminal")
+            || result.contains("timed out");
+        assertTrue(
+            "Expected error mentioning the tab name or a graceful no-terminal message, got: " + result,
+            mentionsTabName || genericError);
+    }
+
+    /**
+     * {@code write_terminal_input} must be declared as {@link Tool.Kind#EDIT} and
+     * {@code isOpenWorld()} must return {@code true} (it interacts with the OS shell).
+     */
+    public void testWriteTerminalInputKindAndOpenWorld() {
+        assertEquals("write_terminal_input must be Kind.EDIT",
+            Tool.Kind.EDIT, writeTerminalInputTool.kind());
+        assertTrue("write_terminal_input must be open-world",
+            writeTerminalInputTool.isOpenWorld());
+    }
+
+    // ── RunInTerminalTool ──────────────────────────────────────────────────────
+
+    /**
+     * When the required {@code "command"} argument is absent, the tool calls
+     * {@code args.get("command").getAsString()} without a null-check, causing a
+     * {@link NullPointerException} on the pooled thread before any EDT work is
+     * dispatched. {@link #executeSync} wraps this in an {@link ExecutionException}.
+     *
+     * <p>This test documents the current behavior. Should the implementation add
+     * explicit parameter validation, update this test to assert on the error string.
+     */
+    public void testRunInTerminalMissingCommand() throws Exception {
+        try {
+            String result = executeSync(runInTerminalTool, new JsonObject());
+            // Future-proof: if the tool adds validation, result must be a proper error message.
+            assertNotNull("Result (if returned) must not be null", result);
+            assertFalse("Result (if returned) must not be blank", result.isBlank());
+            assertFalse("Result must not be a raw Java exception string",
+                result.startsWith("java."));
+        } catch (ExecutionException e) {
+            // Current behavior: NPE from args.get("command").getAsString() when absent
+            Throwable cause = e.getCause();
+            assertNotNull("ExecutionException must have a non-null cause", cause);
+            assertTrue(
+                "Expected NullPointerException for absent required 'command' parameter, got: "
+                    + cause.getClass().getName(),
+                cause instanceof NullPointerException);
+        }
+    }
+
+    /**
+     * When a valid {@code command} is provided, the tool must return a non-null,
+     * non-blank string and must never surface a raw Java exception.
+     *
+     * <p>In the headless test sandbox the expected response is
+     * {@code "Terminal plugin not available. Use run_command tool instead."} because
+     * {@code TerminalToolWindowManager} is absent from the classpath. Any other
+     * graceful response is also acceptable.
+     */
+    public void testRunInTerminalWithCommand() throws Exception {
+        String result = executeSync(runInTerminalTool, args("command", "echo hello"));
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertFalse("Result must not be a raw Java exception string",
+            result.startsWith("java."));
+
+        // All expected outcomes in the headless test environment:
+        //   a) Terminal plugin absent → "Terminal plugin not available. Use run_command tool instead."
+        //   b) Plugin present, creation fails → "Failed to open terminal: ... Use run_command tool instead."
+        //   c) Plugin present, command sent → "Command sent to terminal '...': echo hello"
+        //   d) Timeout (very unlikely) → "Terminal opened (response timed out, ...)"
+        boolean isPluginUnavailable = result.contains("Terminal plugin not available");
+        boolean isFailedToOpen = result.contains("Failed to open terminal");
+        boolean isCommandSent = result.contains("Command sent to terminal");
+        boolean isTimedOut = result.contains("timed out");
+        assertTrue(
+            "Expected a graceful response (plugin unavailable / failed to open / command sent / timed out), got: " + result,
+            isPluginUnavailable || isFailedToOpen || isCommandSent || isTimedOut);
+    }
+
+    /**
+     * {@link RunInTerminalTool} must reject shell commands that match documented
+     * abuse patterns (e.g., {@code rm -rf /}). The abuse check runs before any
+     * EDT work or terminal interaction is attempted, so the pooled thread returns
+     * a rejection message immediately. The result must not confirm execution.
+     */
+    public void testRunInTerminalAbuseRejection() throws Exception {
+        String result = executeSync(runInTerminalTool, args("command", "rm -rf /"));
+
+        assertNotNull("Result must not be null for abuse command", result);
+        assertFalse("Result must not be blank for abuse command", result.isBlank());
+        assertFalse("Abuse command must not confirm execution, got: " + result,
+            result.startsWith("Command sent to terminal"));
+    }
+
+    /**
+     * {@code sudo rm} commands must also be caught by the abuse guard before any
+     * terminal interaction occurs.
+     */
+    public void testRunInTerminalSudoRmAbuseRejection() throws Exception {
+        String result = executeSync(runInTerminalTool, args("command", "sudo rm -rf /tmp/foo"));
+
+        assertNotNull("Result must not be null", result);
+        assertFalse("Result must not be blank", result.isBlank());
+        assertFalse("sudo-rm abuse command must not be executed, got: " + result,
+            result.startsWith("Command sent to terminal"));
+    }
+
+    /**
+     * {@code run_in_terminal} must be declared as {@link Tool.Kind#EDIT} and
+     * {@code isOpenWorld()} must return {@code true} (it runs arbitrary OS commands).
+     */
+    public void testRunInTerminalKindAndOpenWorld() {
+        assertEquals("run_in_terminal must be Kind.EDIT",
+            Tool.Kind.EDIT, runInTerminalTool.kind());
+        assertTrue("run_in_terminal must be open-world",
+            runInTerminalTool.isOpenWorld());
+    }
+
+    // ── TerminalTool shared utilities ──────────────────────────────────────────
+
+    /**
+     * {@link TerminalTool#resolveInputEscapes} must map every documented escape
+     * sequence to its correct Unicode code point.
+     */
+    public void testResolveInputEscapes() {
+        assertEquals("\\n must map to newline (LF)",
+            "\n", TerminalTool.resolveInputEscapes("\\n"));
+        assertEquals("\\t must map to horizontal tab (HT)",
+            "\t", TerminalTool.resolveInputEscapes("\\t"));
+        assertEquals("{enter} must map to carriage return (CR)",
+            "\r", TerminalTool.resolveInputEscapes("{enter}"));
+        assertEquals("{tab} must map to horizontal tab (HT)",
+            "\t", TerminalTool.resolveInputEscapes("{tab}"));
+        assertEquals("{ctrl-c} must map to ETX (U+0003)",
+            "\u0003", TerminalTool.resolveInputEscapes("{ctrl-c}"));
+        assertEquals("{ctrl-d} must map to EOT (U+0004)",
+            "\u0004", TerminalTool.resolveInputEscapes("{ctrl-d}"));
+        assertEquals("{ctrl-z} must map to SUB (U+001A)",
+            "\u001A", TerminalTool.resolveInputEscapes("{ctrl-z}"));
+        assertEquals("{escape} must map to ESC (U+001B)",
+            "\u001B", TerminalTool.resolveInputEscapes("{escape}"));
+        assertEquals("{up} must map to ANSI cursor-up sequence",
+            "\u001B[A", TerminalTool.resolveInputEscapes("{up}"));
+        assertEquals("{down} must map to ANSI cursor-down sequence",
+            "\u001B[B", TerminalTool.resolveInputEscapes("{down}"));
+        assertEquals("{right} must map to ANSI cursor-right sequence",
+            "\u001B[C", TerminalTool.resolveInputEscapes("{right}"));
+        assertEquals("{left} must map to ANSI cursor-left sequence",
+            "\u001B[D", TerminalTool.resolveInputEscapes("{left}"));
+        assertEquals("{backspace} must map to DEL (U+007F)",
+            "\u007F", TerminalTool.resolveInputEscapes("{backspace}"));
+    }
+
+    /**
+     * Plain text with no escape sequences must pass through
+     * {@link TerminalTool#resolveInputEscapes} completely unchanged.
+     */
+    public void testResolveInputEscapesPlainText() {
+        String plain = "echo hello world";
+        assertEquals("Plain text must be returned unchanged",
+            plain, TerminalTool.resolveInputEscapes(plain));
+    }
+
+    /**
+     * Multiple escape sequences in a single string must all be resolved in one pass.
+     * "ls{enter}{ctrl-c}" → "ls\r\u0003".
+     */
+    public void testResolveInputEscapesMultiple() {
+        String result = TerminalTool.resolveInputEscapes("ls{enter}{ctrl-c}");
+        assertEquals("Multiple escape sequences must all be resolved in one pass",
+            "ls\r\u0003", result);
+    }
+
+    /**
+     * {@link TerminalTool#describeInput} must wrap the raw form in quotes and include
+     * a parenthesised character count when the input contains escape-sequence syntax
+     * (braces or backslash), and must use a simpler quoted form for plain text.
+     */
+    public void testDescribeInput() {
+        // Input with escape syntax: "'<raw>' (<len> chars)"
+        String escapedDescription = TerminalTool.describeInput("{ctrl-c}", "\u0003");
+        assertTrue("Escape-syntax description must contain the raw form, got: " + escapedDescription,
+            escapedDescription.contains("{ctrl-c}"));
+        assertTrue("Escape-syntax description must include parenthesised length, got: " + escapedDescription,
+            escapedDescription.matches(".*\\(\\d+ chars\\).*"));
+
+        // Plain text: "'<text>'" with no length annotation
+        String plainDescription = TerminalTool.describeInput("echo hello", "echo hello");
+        assertTrue("Plain-text description must quote the input, got: " + plainDescription,
+            plainDescription.contains("echo hello"));
+        assertFalse("Plain-text description must NOT include a parenthesised length, got: " + plainDescription,
+            plainDescription.matches(".*\\(\\d+ chars\\).*"));
+    }
+
+    /**
+     * {@link TerminalTool#tailLines} with {@code maxLines == 0} must return the full
+     * text (modulo {@code ToolUtils.truncateOutput} size limits), not an empty string.
+     */
+    public void testTailLinesZeroReturnsFullText() {
+        String text = "line1\nline2\nline3";
+        String result = TerminalTool.tailLines(text, 0);
+        assertNotNull("tailLines must not return null", result);
+        assertFalse("tailLines with maxLines=0 must not be empty", result.isBlank());
+        assertTrue("tailLines with maxLines=0 must contain all input lines, got: " + result,
+            result.contains("line1") && result.contains("line3"));
+    }
+
+    /**
+     * {@link TerminalTool#tailLines} with a positive {@code maxLines} that is smaller
+     * than the total line count must return exactly the last N lines.
+     * Input: "a\nb\nc\nd\ne" with maxLines=3 → "c\nd\ne".
+     */
+    public void testTailLinesPositiveMaxLines() {
+        String text = "a\nb\nc\nd\ne";
+        String result = TerminalTool.tailLines(text, 3);
+        assertNotNull("tailLines must not return null", result);
+        assertTrue("Expected 'c' in tail, got: " + result, result.contains("c"));
+        assertTrue("Expected 'd' in tail, got: " + result, result.contains("d"));
+        assertTrue("Expected 'e' in tail, got: " + result, result.contains("e"));
+        assertFalse("Expected 'a' to be trimmed from tail, got: " + result, result.contains("a"));
+        assertFalse("Expected 'b' to be trimmed from tail, got: " + result, result.contains("b"));
+    }
+
+    /**
+     * {@link TerminalTool#tailLines} must return the entire text unchanged when the
+     * total line count is less than or equal to {@code maxLines}.
+     */
+    public void testTailLinesFewLines() {
+        String text = "only\ntwo";
+        String result = TerminalTool.tailLines(text, 10);
+        assertNotNull("tailLines must not return null", result);
+        assertTrue("Expected 'only' in result, got: " + result, result.contains("only"));
+        assertTrue("Expected 'two' in result, got: " + result, result.contains("two"));
+    }
+
+    /**
+     * {@link TerminalTool#tailLines} with {@code maxLines} equal to the exact line
+     * count must return all lines (boundary condition: no trimming should occur).
+     */
+    public void testTailLinesExactBoundary() {
+        String text = "x\ny\nz";
+        String result = TerminalTool.tailLines(text, 3);
+        assertNotNull("tailLines must not return null", result);
+        assertTrue("All three lines must be present at exact boundary, got: " + result,
+            result.contains("x") && result.contains("y") && result.contains("z"));
+    }
+
+    /**
+     * {@link TerminalTool#truncateForTitle} must truncate commands longer than
+     * 40 characters to 37 characters followed by {@code "..."} — the same rule used
+     * when auto-naming new terminal tabs.
+     */
+    public void testTruncateForTitle() {
+        String shortCommand = "echo hello";
+        assertEquals("Short command must not be truncated",
+            shortCommand, TerminalTool.truncateForTitle(shortCommand));
+
+        String longCommand = "a".repeat(50);
+        String truncated = TerminalTool.truncateForTitle(longCommand);
+        assertEquals("Truncated title must be exactly 40 chars (37 + '...')",
+            40, truncated.length());
+        assertTrue("Truncated title must end with '...'", truncated.endsWith("..."));
+    }
+
+    /**
+     * A command of exactly 40 characters is at the boundary — it must not be
+     * truncated. The implementation uses {@code length > 40}, not {@code >= 40}.
+     */
+    public void testTruncateForTitleExactBoundary() {
+        String exactBoundary = "a".repeat(40);
+        assertEquals("Command of exactly 40 chars must not be truncated",
+            exactBoundary, TerminalTool.truncateForTitle(exactBoundary));
+    }
+
+    /**
+     * A command of exactly 41 characters is one over the limit — it must be
+     * truncated to 37 chars + {@code "..."}.
+     */
+    public void testTruncateForTitleOneOverBoundary() {
+        String oneOver = "a".repeat(41);
+        String truncated = TerminalTool.truncateForTitle(oneOver);
+        assertEquals("Command of 41 chars must be truncated to 40",
+            40, truncated.length());
+        assertTrue("Truncated title must end with '...'", truncated.endsWith("..."));
+    }
+}


### PR DESCRIPTION
…xclusion

- Narrow JaCoCo classDirectories exclusion from `**/settings/**` to only the actual UI classes that need an IDE runtime (`*Configurable*`, `QrCodePanel*`, `ThemeColorComboBox*`). Pure state/data classes in settings/ (BillingSettings, ChatHistorySettings, McpServerSettings, etc.) were previously excluded so their coverage data was silently discarded even though tests cover them.

- Add `BUILD_SOURCEMAPS=1` support to chat-ui/build.js: when the env var is set, esbuild embeds inline sourcemaps so V8 can map bundle-level coverage back to TypeScript source files.

- Add `build:coverage` script to chat-ui/package.json.

- Add `@vitest/coverage-v8` dependency and `test:coverage` script to js-tests. Configure Vitest v8 coverage provider to produce lcov + text-summary reports, mapping back to ../chat-ui/src/**/*.ts via inline sourcemaps.

- Update CI workflow (ci.yml):
  * Build chat-ui with sourcemaps first, run processResources so tests load the sourcemapped bundle from generated resources.
  * Run chat-ui tests with coverage (npm run test:coverage).
  * Rebuild chat-ui without sourcemaps for the production plugin bundle.
  * Replace generated resources with the production bundle before buildPlugin.
  * Upload chat-ui lcov to Codecov with flag `chat-ui`.