### PR TITLE
feat: web UI improvements — FAB, empty state, error handling, chip sc…

### DIFF
--- a/plugin-core/chat-ui/src/ChatController.ts
+++ b/plugin-core/chat-ui/src/ChatController.ts
@@ -143,6 +143,9 @@ const ChatController = {
     _currentProfile: '',
     _currentClientType: '',
     _ctx: {} as Record<string, TurnContext & { thinkingMsg?: HTMLElement | null; thinkingChip?: HTMLElement | null }>,
+    /** Caches the first known timestamp for each turn key (turnId-agentId) so late
+     *  events (e.g. finalizeAgentText after compaction) can reuse it. */
+    _turnTimestamps: {} as Record<string, string>,
 
     _getCtx(turnId: string, agentId: string): TurnContext & {
         thinkingMsg?: HTMLElement | null;
@@ -163,14 +166,16 @@ const ChatController = {
         thinkingMsg?: HTMLElement | null;
         thinkingChip?: HTMLElement | null
     } {
+        const key = turnId + '-' + agentId;
+        if (timestamp) this._turnTimestamps[key] = timestamp;
         const ctx = this._getCtx(turnId, agentId);
         if (!ctx.msg) {
             const msg = document.createElement('chat-message');
             msg.setAttribute('type', 'agent');
             const meta = document.createElement('message-meta');
             meta.className = 'meta';
-            const ts = timestamp || (() => {
-                console.warn('[_ensureMsg] No timestamp provided for turn', turnId, '— showing placeholder');
+            const ts = timestamp || this._turnTimestamps[key] || (() => {
+                console.warn('[_ensureMsg] No timestamp for turn', turnId, '— showing placeholder');
                 return '--:--';
             })();
             const tsSpan = document.createElement('span');

--- a/plugin-core/chat-ui/src/chat.css
+++ b/plugin-core/chat-ui/src/chat.css
@@ -400,10 +400,17 @@ working-indicator .working-text {
 .chip-strip {
     display: flex;
     gap: var(--sp-2);
-    overflow: hidden;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-x;
     flex: 1;
     min-width: 0;
     cursor: grab;
+}
+
+.chip-strip::-webkit-scrollbar {
+    display: none;
 }
 
 .chip-strip.dragging {

--- a/plugin-core/chat-ui/src/web-app.css
+++ b/plugin-core/chat-ui/src/web-app.css
@@ -126,7 +126,7 @@ chat-container {
     font: inherit;
     resize: none;
     min-height: 36px;
-    max-height: 120px;
+    max-height: 160px;
     overflow-y: auto;
     outline: none;
 }
@@ -436,4 +436,52 @@ tool-chip .chip-expand {
     font-size: .85em;
     color: var(--fg-muted);
     min-height: 1.2em;
+}
+
+#ab-connect-status.error {
+    color: var(--error);
+}
+
+/* ── Scroll-to-bottom FAB ───────────────────────────────────────────────── */
+
+#ab-scroll-fab {
+    position: absolute;
+    bottom: 10px;
+    right: 14px;
+    z-index: 20;
+    border: none;
+    border-radius: 20px;
+    background: var(--user-a12);
+    color: var(--user);
+    padding: 5px 12px;
+    cursor: pointer;
+    font: inherit;
+    font-size: .88em;
+    font-weight: 600;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, .25);
+    transition: opacity .15s, background .15s;
+}
+
+#ab-scroll-fab:hover {
+    background: var(--user-a16);
+}
+
+/* ── Empty-state placeholder ────────────────────────────────────────────── */
+
+#messages:empty::after {
+    content: 'Ask Copilot something…';
+    display: block;
+    text-align: center;
+    color: var(--fg-muted);
+    font-size: .95em;
+    margin-top: 40px;
+    pointer-events: none;
+}
+
+/* ── Narrow-screen header ───────────────────────────────────────────────── */
+
+@media (max-width: 480px) {
+    #ab-model {
+        display: none;
+    }
 }

--- a/plugin-core/chat-ui/src/web-app.ts
+++ b/plugin-core/chat-ui/src/web-app.ts
@@ -72,12 +72,35 @@ const menuModelSection = document.getElementById('ab-menu-model-section')!;
 // ── Auto-scroll: track whether user is near the bottom ──────────────────────
 
 let atBottom = true;
+let unreadCount = 0;
+
+// Scroll-to-bottom FAB (injected into the #ab-chat wrapper)
+const scrollFab = document.createElement('button');
+scrollFab.id = 'ab-scroll-fab';
+scrollFab.setAttribute('aria-label', 'Scroll to bottom');
+scrollFab.hidden = true;
+chatAreaEl.appendChild(scrollFab);
+
+function updateScrollFab(): void {
+    scrollFab.hidden = atBottom;
+    scrollFab.textContent = unreadCount > 0 ? `↓ ${unreadCount}` : '↓';
+}
+
+scrollFab.addEventListener('click', () => {
+    unreadCount = 0;
+    scrollToBottom();
+});
+
 chatEl.addEventListener('scroll', () => {
     atBottom = chatEl.scrollHeight - chatEl.scrollTop - chatEl.clientHeight < 120;
+    if (atBottom) unreadCount = 0;
+    updateScrollFab();
 }, {passive: true});
 
 function scrollToBottom(): void {
     chatEl.scrollTop = chatEl.scrollHeight;
+    atBottom = true;
+    updateScrollFab();
 }
 
 // ── Track agent state via ChatController overrides ──────────────────────────
@@ -95,6 +118,10 @@ const origFinalizeTurn = ChatController.finalizeTurn.bind(ChatController);
 ChatController.finalizeTurn = function (...args: unknown[]) {
     (origFinalizeTurn as (...a: unknown[]) => void)(...args);
     agentRunning = false;
+    if (!atBottom) {
+        unreadCount++;
+        updateScrollFab();
+    }
     updateButtons();
 };
 
@@ -216,6 +243,9 @@ fetch('/info')
         else showConnectView(info.profiles);
     })
     .catch(() => {
+        showConnectView();
+        connectStatusEl.textContent = 'Failed to reach plugin — check that IntelliJ is running';
+        connectStatusEl.classList.add('error');
     });
 
 // ── Hamburger menu ──────────────────────────────────────────────────────────
@@ -487,7 +517,7 @@ document.addEventListener('quick-reply', (e: Event) => {
 
 inputEl.addEventListener('input', () => {
     inputEl.style.height = 'auto';
-    inputEl.style.height = Math.min(inputEl.scrollHeight, 120) + 'px';
+    inputEl.style.height = Math.min(inputEl.scrollHeight, 160) + 'px';
 });
 
 inputEl.addEventListener('keydown', (e: KeyboardEvent) => {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
@@ -1495,7 +1495,7 @@ public final class ChatWebServer implements Disposable {
             + "          <button id=\"ab-connect-stop-btn\" hidden class=\"ab-card-stop-btn\">⏹</button>\n"
             + "        </div>\n"
             + "        <div class=\"ab-card-content\">\n"
-            + "          <select id=\"ab-connect-profile\"></select>\n"
+            + "          <select id=\"ab-connect-profile\" aria-label=\"ACP profile\"></select>\n"
             + "          <button id=\"ab-connect-btn\">Connect</button>\n"
             + "          <div id=\"ab-connect-status\"></div>\n"
             + "        </div>\n"


### PR DESCRIPTION
…roll

- Scroll-to-bottom FAB with unread-message counter (shows ↓ N when new messages arrive while scrolled up; hides when at bottom)
- Empty-state placeholder "Ask Copilot something…" via CSS ::after
- /info fetch error now shows "Failed to reach plugin — check that IntelliJ is running" in red instead of a silent empty connect form
- ChatController._turnTimestamps cache so late finalizeAgentText events reuse the first-seen timestamp instead of showing --:--
- chip-strip: overflow-x: auto + scrollbar-width: none for touch scrolling
- textarea max-height raised from 120px → 160px
- ab-connect-profile gets aria-label="ACP profile"
- ab-model label hidden on narrow screens (≤ 480px)