### PR TITLE
chore: ignore Kotlin 2.3.20+ in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,12 @@ updates:
       gradle-dependencies:
         patterns:
           - "*"
+    ignore:
+      # Kotlin 2.3.20+ is not supported by GitHub CodeQL (as of April 2026).
+      # Bumping causes CI failures in the code-scanning workflow.
+      # Remove this ignore rule once CodeQL adds support for newer Kotlin versions.
+      - dependency-name: "org.jetbrains.kotlin:*"
+        versions: [ ">= 2.3.20" ]
     cooldown:
       default-days: 7
       semver-major-days: 30


### PR DESCRIPTION
CodeQL does not support Kotlin >= 2.3.20 (as of April 2026), causing CI failures in the code-scanning workflow. This ignore rule prevents Dependabot from proposing unsupported versions.