### PR TITLE
fix: add horizontal scrolling for tables on mobile viewports

### DIFF
--- a/plugin-core/chat-ui/src/chat.css
+++ b/plugin-core/chat-ui/src/chat.css
@@ -878,8 +878,21 @@ table {
     border-collapse: collapse;
     margin: var(--sp-4) 0;
     display: block;
-    max-width: 100%;
     overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+table::-webkit-scrollbar {
+    height: 4px;
+}
+
+table::-webkit-scrollbar-thumb {
+    background: var(--fg-muted);
+    border-radius: 2px;
+}
+
+table::-webkit-scrollbar-track {
+    background: transparent;
 }
 
 th, td {
@@ -887,6 +900,7 @@ th, td {
     border-bottom: 1px solid var(--tbl-border);
     padding: var(--sp-3) var(--sp-6);
     text-align: left;
+    white-space: nowrap;
 }
 
 th {

--- a/plugin-core/chat-ui/src/chat.css
+++ b/plugin-core/chat-ui/src/chat.css
@@ -880,6 +880,9 @@ table {
     display: block;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
+    /* Firefox */
+    scrollbar-width: thin;
+    scrollbar-color: var(--fg-muted) transparent;
 }
 
 table::-webkit-scrollbar {
@@ -889,6 +892,11 @@ table::-webkit-scrollbar {
 table::-webkit-scrollbar-thumb {
     background: var(--fg-muted);
     border-radius: 2px;
+}
+
+/* Override global ::-webkit-scrollbar-thumb:hover to keep table scrollbar muted */
+table::-webkit-scrollbar-thumb:hover {
+    background: var(--fg-muted);
 }
 
 table::-webkit-scrollbar-track {


### PR DESCRIPTION
## Problem

Markdown tables in chat message bubbles get cramped on narrow/mobile screens. Cells wrap text aggressively to fit within the container width, making table content unreadable.

## Solution

- **`white-space: nowrap`** on `th, td` — cells maintain natural width instead of wrapping
- **`overflow-x: auto`** on `table` — horizontal scroll appears when table exceeds container width
- **`-webkit-overflow-scrolling: touch`** — smooth momentum scrolling on iOS
- **Thin scrollbar styling** — 4px height, muted color for discoverability without visual clutter
- Removed `max-width: 100%` which prevented overflow from activating

## Testing

Applies to both the JCEF embedded chat panel and the standalone web UI (both use `chat.css`).

Chat UI rebuilt with `npm run build` — production bundle updated.