### PR TITLE
fix: remove duplicate persist-credentials key in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0  # Full history for conventional commit analysis
-          persist-credentials: false
 
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0


### PR DESCRIPTION
## Problem

The checkout step in `.github/workflows/release.yml` had `persist-credentials: false` duplicated twice, causing GitHub Actions to reject the entire workflow file with "This run likely failed because of a workflow file issue.".

A previous fix added `gh auth setup-git` and switched to `gh release create --target` (API-based tag creation), but forgot to remove the second occurrence of the duplicate key.

## Fix

Removes the extra `persist-credentials: false` line, keeping exactly one occurrence. The `persist-credentials: false` security hardening remains intact — no credentials are stored post-checkout.

## Security

- `persist-credentials: false` is preserved (still one occurrence)
- Tag creation uses `gh release create --target $GITHUB_SHA` via API (`GH_TOKEN`)
- No git credentials required at any point in the workflow