### PR TITLE
fix: fetch missed events on PWA wake instead of showing connection lost

### DIFF
--- a/plugin-core/chat-ui/src/web-app.ts
+++ b/plugin-core/chat-ui/src/web-app.ts
@@ -422,16 +422,29 @@ function connectSSE(): void {
     };
 }
 
-// Reconnect SSE when the page becomes visible again — mobile browsers
-// freeze/kill background connections, so we need to re-establish on wake.
+// Reconnect SSE and catch up on missed events when the page becomes visible.
+// Mobile browsers freeze/kill background SSE connections, so on wake:
+//   1. Always force-reconnect SSE (the connection may look OPEN but be dead).
+//   2. Immediately fetch missed events via REST so content appears before SSE opens.
 document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'visible') {
-        if (!currentEs || currentEs.readyState === EventSource.CLOSED) {
-            if (sseRetry) clearTimeout(sseRetry);
-            connectSSE();
-        }
+        if (sseRetry) clearTimeout(sseRetry);
+        fetchCatchUp();
+        connectSSE();
     }
 });
+
+function fetchCatchUp(): void {
+    fetch('/catch-up?from=' + lastSeq)
+        .then(r => r.json() as Promise<{ events?: SseEvent[]; seq?: number }>)
+        .then(st => {
+            (st.events || []).forEach(ev => {
+                if (!ev.seq || ev.seq > lastSeq) processEvent(ev, false);
+            });
+        })
+        .catch(() => { /* SSE reconnect will recover */
+        });
+}
 
 // ── Notifications ───────────────────────────────────────────────────────────
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
@@ -309,6 +309,7 @@ public final class ChatWebServer implements Disposable {
         server.createContext("/cert.crt", this::handleCert);
         server.createContext("/events", this::handleSse);
         server.createContext("/state", this::handleState);
+        server.createContext("/catch-up", this::handleCatchUp);
         server.createContext("/info", this::handleInfo);
         server.createContext("/prompt", ex -> handleAction(ex, body -> {
             String text = jsonString(body, "text");
@@ -1189,6 +1190,32 @@ public final class ChatWebServer implements Disposable {
             sb.append(snapshot.get(i));
         }
         sb.append("],\"info\":").append(buildInfoJson()).append("}");
+        sendJson(exchange, sb.toString());
+    }
+
+    private void handleCatchUp(HttpExchange exchange) throws IOException {
+        if (!"GET".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            exchange.close();
+            return;
+        }
+        int fromSeq = parseFromQuery(exchange.getRequestURI().getQuery());
+        List<String> snapshot;
+        int seq;
+        synchronized (this) {
+            snapshot = new ArrayList<>(eventLog);
+            seq = nextSeq - 1;
+        }
+        StringBuilder sb = new StringBuilder("{\"seq\":").append(seq).append(",\"events\":[");
+        boolean first = true;
+        for (String ev : snapshot) {
+            if (extractSeq(ev) > fromSeq) {
+                if (!first) sb.append(',');
+                sb.append(ev);
+                first = false;
+            }
+        }
+        sb.append("]}");
         sendJson(exchange, sb.toString());
     }
 


### PR DESCRIPTION
## Problem

When a mobile browser tab wakes from the background, the PWA always shows a "Connection lost, reconnecting…" banner for ~3 seconds, even when the IDE is running and has new events.

**Root cause**: mobile browsers freeze/kill background SSE connections. When the tab wakes, `visibilitychange` fires first — but at that moment `currentEs.readyState` is still `OPEN` (the OS hasn't detected the dead TCP socket yet). The previous guard `readyState === EventSource.CLOSED` would miss this window entirely. Shortly after, `onerror` fires → offline banner → 3-second retry.

## Fix

### Server: `GET /catch-up?from=<seq>`

New lightweight endpoint returning only events newer than the given sequence number:
```json
{"seq": 42, "events": [...]}
```
This lets the client immediately fetch missed content without waiting for an SSE reconnect.

### Client: always reconnect + fetch on wake

```typescript
document.addEventListener('visibilitychange', () => {
    if (document.visibilityState === 'visible') {
        if (sseRetry) clearTimeout(sseRetry);
        fetchCatchUp();  // ← immediate REST fetch, no waiting for SSE
        connectSSE();    // ← force reconnect (drop readyState guard)
    }
});
```

- **`fetchCatchUp()`**: fetches `/catch-up?from=lastSeq` and processes events with seq dedup (`ev.seq > lastSeq`) to avoid double-processing if SSE also replays them
- **`connectSSE()`**: no longer guards on `readyState === CLOSED` — always force-reconnects because the connection may look OPEN but be silently dead

## Result

New messages appear immediately when the user opens the PWA from background — no offline banner, no waiting.