### PR TITLE
fix: lower SSE queue-full log to INFO; reconnect stats DB on DBMOVED

### DIFF
--- a/.github/agents/read-plugin-logs.md
+++ b/.github/agents/read-plugin-logs.md
@@ -1,0 +1,122 @@
+<!-- Deployed by AgentBridge — edits are preserved, delete to stop auto-deploy -->
+---
+name: read-plugin-logs
+description: "Reads IntelliJ IDE logs to surface plugin health issues: errors, warnings, tool timeouts, UI freezes,
+and unhandled/unexpected ACP protocol messages from Copilot and other agent clients."
+model: claude-haiku-4.5
+tools:
+
+# IDE log and analysis
+
+- agentbridge/read_ide_log
+- agentbridge/run_command
+- agentbridge/list_project_files
+- agentbridge/read_file
+
+# Memory (to recall known issues and patterns)
+
+- agentbridge/memory_search
+- agentbridge/memory_recall
+
+---
+
+You are a log analysis agent for the AgentBridge IntelliJ plugin.
+
+Your job: read IDE logs (and optionally thread dump files) and surface issues caused by or related to the plugin.
+You do NOT modify source files.
+
+## Our Plugin Package
+
+All plugin code lives under `com.github.catatafishen.agentbridge`. Logs from this package are most relevant.
+Only escalate warnings/errors from IntelliJ-internal packages if they clearly trace back to plugin code.
+
+## Step-by-Step Analysis
+
+### 1. Read Recent WARN + ERROR logs
+
+```
+read_ide_log(level="WARN,ERROR", lines=300)
+```
+
+Filter by relevance using these rules:
+
+**Always investigate (our code):**
+- `com.github.catatafishen.agentbridge.*` — any WARN or ERROR
+- Stack traces that include `agentbridge` anywhere in the trace
+- `TimeoutException` during MCP tool calls (tool `execute()` blocked > 30s)
+- `unknown session update type` — unhandled ACP protocol message from an agent client
+- `SQLITE_READONLY_DBMOVED` or any SQLite error in `ToolCallStatisticsService`
+- `SSE event dropped` — queue full in `ChatWebServer`
+- Any `NullPointerException` or `ClassCastException` in our stack
+
+**Investigate if repeated (IntelliJ-internal but may indicate our fault):**
+- `RunContentManagerImpl: ContentDescriptorId was not assigned` — spurious if only once; our bug if frequent
+- EDT read/write violations during tool dispatch
+
+**Ignore (known noise, not our code):**
+- `DeprecationBanner: Leaving`
+- `KonanLog: lldbHome`
+- `ProjectIndexableFilesFilterHealthCheck`
+- `KotlinBuildToolFusFlowProcessor`
+- SonarLint migration warnings
+- `VectorizationProvider`
+
+### 2. Check for UI Freezes
+
+Freeze thread dumps are stored in `~/Library/Logs/JetBrains/*/threadDumps-freeze-*` (macOS) or
+`~/.cache/JetBrains/*/threadDumps-freeze-*` (Linux). Run:
+
+```
+run_command("ls ~/.cache/JetBrains/ 2>/dev/null || ls ~/Library/Logs/JetBrains/ 2>/dev/null")
+run_command("find ~/.cache/JetBrains -name 'threadDump*.txt' -newer /tmp -ls 2>/dev/null | tail -20")
+```
+
+For each recent freeze dump, check the **EDT (Event Dispatch Thread)** stack:
+- If it contains `agentbridge` frames → our plugin caused the freeze (escalate)
+- If it contains `blockingWaitForCompositeFileOpen`, `FileEditorManagerImpl`, or other IntelliJ-internal frames → IDE-internal, not our fault (note but don't escalate unless frequent)
+- Key freeze signatures from our code: `WriteAction.run()` holding the lock too long, `invokeAndWait()` deadlock patterns
+
+### 3. Check for MCP Tool Timeouts
+
+Look for lines matching `TimeoutException` in the last 1000 IDE log lines. Context:
+- Tool calls complete asynchronously via `CompletableFuture.get(30, SECONDS)`
+- A timeout means either: (a) a modal dialog blocked the EDT during tool dispatch, or (b) a genuine bug in the tool
+- Check if a "Usage Statistics" or other modal dialog is logged around the same time — that's the common cause
+- If no modal is visible, investigate the tool implementation
+
+### 4. Check for Unhandled ACP Messages
+
+Look for:
+```
+unknown session update type: '...'
+```
+logged by `AcpMessageParser`. Known message types handled by the plugin:
+`agent_message_chunk`, `agent_thought_chunk`, `user_message_chunk`, `tool_call`, `tool_call_update`,
+`plan`, `turn_usage`, `banner`, `usage_update`, `config_option_update`.
+
+If a new unknown type appears, investigate:
+1. What agent client sent it (Copilot CLI, OpenCode, Junie, Kiro)?
+2. What fields does the JSON payload contain? (look for the raw log line before the WARN)
+3. Should we parse it into a new `SessionUpdate` type, or silently ignore at DEBUG?
+
+### 5. Verify ACP Message Handling Still Works as Expected
+
+Periodically confirm that the key message types are being parsed correctly by checking INFO logs for:
+- `tool_call` events generating chip entries in the chat
+- `tool_call_update` events completing chips correctly
+- `turn_usage` / `usage_update` being reflected in the toolbar stats
+- `banner` messages appearing in the UI
+
+If any of these stop working, clients may have changed their message format — check the raw JSON.
+
+## Output Format
+
+Report findings grouped by severity:
+
+**🔴 Errors** — list each with timestamp, class, and message
+**🟡 Warnings (our code)** — list with timestamp and brief analysis
+**🟡 Warnings (IntelliJ-internal, likely our fault)** — list if relevant
+**🔵 Info** — freezes, timeouts, unhandled messages
+**✅ No issues** — if nothing found
+
+For each issue, include: timestamp, log class, message excerpt, and a suggested action.

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpMessageParser.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpMessageParser.java
@@ -31,6 +31,9 @@ class AcpMessageParser {
     private static final String KEY_STATUS = "status";
     private static final String KEY_RESULT = "result";
     private static final String KEY_TOOL_CALL_ID = "toolCallId";
+    private static final String KEY_DESCRIPTION = "description";
+    private static final String KEY_RAW_INPUT = "rawInput";
+    private static final String KEY_THINKING = "thinking";
 
     /**
      * Callbacks into the owning client for the three points where agent-specific logic is needed.
@@ -90,6 +93,12 @@ class AcpMessageParser {
             // Currently used by: OpenCode (fields: used, size, cost.amount, cost.currency).
             // 'used' is cumulative context tokens (not per-turn delta), so the toolbar value grows each turn.
             case "usage_update" -> parseUsageUpdate(params);
+            // config_option_update: sent by Copilot CLI when agent configuration changes (e.g. model,
+            // tool filters). Fields are undocumented; we acknowledge and ignore for now.
+            case "config_option_update" -> {
+                LOG.debug(displayName.get() + ": received config_option_update (not yet handled)");
+                yield null;
+            }
             default -> {
                 LOG.warn(displayName.get() + ": unknown session update type: '" + type + "'");
                 yield null;
@@ -138,7 +147,7 @@ class AcpMessageParser {
         String subAgentDesc = null;
         String subAgentPrompt = null;
         if (agentType != null && argumentsObj != null) {
-            subAgentDesc = argumentsObj.has("description") ? argumentsObj.get("description").getAsString() : null;
+            subAgentDesc = argumentsObj.has(KEY_DESCRIPTION) ? argumentsObj.get(KEY_DESCRIPTION).getAsString() : null;
             subAgentPrompt = argumentsObj.has("prompt") ? argumentsObj.get("prompt").getAsString() : null;
         }
 
@@ -154,13 +163,13 @@ class AcpMessageParser {
         }
 
         String error = params.has("error") ? params.get("error").getAsString() : null;
-        String description = params.has("description") ? params.get("description").getAsString() : null;
+        String description = params.has(KEY_DESCRIPTION) ? params.get(KEY_DESCRIPTION).getAsString() : null;
         String result = extractResultText(params);
 
         // Extract rawInput for tool correlation - this contains the actual tool arguments
         String arguments = null;
-        if (params.has("rawInput") && params.get("rawInput").isJsonObject()) {
-            arguments = params.get("rawInput").getAsJsonObject().toString();
+        if (params.has(KEY_RAW_INPUT) && params.get(KEY_RAW_INPUT).isJsonObject()) {
+            arguments = params.get(KEY_RAW_INPUT).getAsJsonObject().toString();
         }
 
         return new SessionUpdate.ToolCallUpdate(toolCallId, status, result, error, description, false, null, arguments);
@@ -264,8 +273,8 @@ class AcpMessageParser {
         String blockType = block.has("type") ? block.get("type").getAsString() : "text";
         if ("text".equals(blockType) && block.has("text")) {
             return new ContentBlock.Text(block.get("text").getAsString());
-        } else if ("thinking".equals(blockType) && block.has("thinking")) {
-            return new ContentBlock.Thinking(block.get("thinking").getAsString());
+        } else if (KEY_THINKING.equals(blockType) && block.has(KEY_THINKING)) {
+            return new ContentBlock.Thinking(block.get(KEY_THINKING).getAsString());
         } else if (KEY_CONTENT.equals(blockType) && block.has(KEY_CONTENT)) {
             // Spec: tool_call_update content items wrap blocks as {type:"content", content:{type,text}}
             JsonElement inner = block.get(KEY_CONTENT);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
@@ -447,8 +447,9 @@ public final class PlatformApiCompat {
         var vcsLog = com.intellij.vcs.log.impl.VcsProjectLog.getInstance(project);
         var data = vcsLog.getDataManager();
         if (data == null) {
-            // Log not yet initialized — fall back to direct navigation
-            com.intellij.vcs.log.impl.VcsProjectLog.showRevisionInMainLog(project, hash);
+            // VCS log not yet initialized — skip navigation to avoid a "commit not found" error
+            // bubble. The log hasn't indexed the commit yet, and there's no UI panel to navigate
+            // to anyway. Best-effort follow-mode only runs when the log is already open.
             return;
         }
 
@@ -474,17 +475,17 @@ public final class PlatformApiCompat {
                         case "toString" -> {
                             return "DataPackChangeListenerProxy@" + Integer.toHexString(System.identityHashCode(proxy));
                         }
+                        case "onDataPackChange" -> { /* handled below */ }
+                        default -> {
+                            return null;
+                        }
                     }
-                    if (!"onDataPackChange".equals(method.getName())) return null;
 
                     // The data pack can change multiple times during a refresh (e.g., once when
                     // branch pointers update, again when new commits are indexed). Only navigate
                     // after the new commit is actually present in the VCS log storage — otherwise
                     // showRevisionInMainLog shows a "commit could not be found" error bubble.
-                    boolean commitIndexed = data.getLogProviders().keySet().stream()
-                        .anyMatch(root -> data.getStorage().containsCommit(
-                            new com.intellij.vcs.log.CommitId(hash, root)));
-                    if (!commitIndexed) return null;
+                    if (!isCommitIndexed(data, hash)) return null;
 
                     if (!navigated.compareAndSet(false, true)) return null;
                     data.removeDataPackChangeListener(
@@ -495,14 +496,16 @@ public final class PlatformApiCompat {
                 });
 
         data.addDataPackChangeListener(listener);
+        refreshVcsLogForProject(project, data);
 
-        // Trigger VCS log refresh to pick up the new commit
-        String basePath = project.getBasePath();
-        if (basePath != null) {
-            var root = com.intellij.openapi.vfs.LocalFileSystem.getInstance().findFileByPath(basePath);
-            if (root != null) {
-                data.refresh(java.util.List.of(root));
-            }
+        // Race-condition guard: the commit may have already been indexed between getDataManager()
+        // and addDataPackChangeListener (e.g., IntelliJ auto-refreshed from a filesystem event).
+        // In that case the listener would never fire, so check immediately after registering it.
+        if (isCommitIndexed(data, hash) && navigated.compareAndSet(false, true)) {
+            data.removeDataPackChangeListener(listener);
+            com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater(() ->
+                com.intellij.vcs.log.impl.VcsProjectLog.showRevisionInMainLog(project, hash));
+            return;
         }
 
         // Timeout: clean up listener after 10 seconds to prevent leak
@@ -512,6 +515,26 @@ public final class PlatformApiCompat {
                     data.removeDataPackChangeListener(listener);
                 }
             }, 10, java.util.concurrent.TimeUnit.SECONDS);
+    }
+
+    private static boolean isCommitIndexed(
+        com.intellij.vcs.log.data.VcsLogData data,
+        com.intellij.vcs.log.Hash hash) {
+        return data.getLogProviders().keySet().stream()
+            .anyMatch(root -> data.getStorage().containsCommit(
+                new com.intellij.vcs.log.CommitId(hash, root)));
+    }
+
+    private static void refreshVcsLogForProject(
+        @NotNull Project project,
+        @NotNull com.intellij.vcs.log.data.VcsLogData data) {
+        // Trigger VCS log refresh to pick up the new commit
+        String basePath = project.getBasePath();
+        if (basePath == null) return;
+        var root = com.intellij.openapi.vfs.LocalFileSystem.getInstance().findFileByPath(basePath);
+        if (root != null) {
+            data.refresh(java.util.List.of(root));
+        }
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -42,7 +42,7 @@ public final class PsiBridgeService implements Disposable {
     public interface ToolCallListener {
         void toolCalled(String toolName, long durationMs, boolean success,
                         long inputSizeBytes, long outputSizeBytes, String clientId,
-                        @Nullable String category);
+                        @Nullable String category, @Nullable String errorMessage);
     }
 
     /**
@@ -219,13 +219,15 @@ public final class PsiBridgeService implements Disposable {
         long inputSize = arguments != null ? arguments.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8).length : 0;
         ToolDefinition def = registry.findDefinition(toolName);
         if (def == null || !def.hasExecutionHandler()) {
-            fireToolCallEvent(toolName, System.currentTimeMillis(), false, inputSize, 0, null);
-            return "Unknown tool: " + toolName;
+            String unknownErr = "Unknown tool: " + toolName;
+            fireToolCallEvent(toolName, System.currentTimeMillis(), false, inputSize, 0, null, unknownErr);
+            return unknownErr;
         }
         String categoryName = def.category() != null ? def.category().name() : null;
         long outputSize = 0;
         long startMs = System.currentTimeMillis();
         boolean success = true;
+        String errorMessage = null;
 
         String argumentsHash = ToolChipRegistry.computeBaseHash(arguments);
 
@@ -265,7 +267,7 @@ public final class PsiBridgeService implements Disposable {
                 writeBatchCoordinator.unregisterWrite();
                 writeRegistered = false;
             }
-            fireToolCallEvent(toolName, startMs, false, inputSize, 0, categoryName);
+            fireToolCallEvent(toolName, startMs, false, inputSize, 0, categoryName, denied);
             return denied;
         }
 
@@ -352,8 +354,9 @@ public final class PsiBridgeService implements Disposable {
             return result;
         } catch (com.intellij.openapi.application.ex.ApplicationUtil.CannotRunReadActionException e) {
             success = false;
+            errorMessage = "Error: IDE is busy, please retry. " + e.getMessage();
             if (writeRegistered) writeBatchCoordinator.unregisterWrite();
-            return "Error: IDE is busy, please retry. " + e.getMessage();
+            return errorMessage;
         } catch (Exception e) {
             LOG.warn("Tool call error: " + toolName, e);
             success = false;
@@ -361,13 +364,15 @@ public final class PsiBridgeService implements Disposable {
             String modalDetail = EdtUtil.describeModalBlocker();
             String base = "Error: " + e.getMessage();
             if (!modalDetail.isEmpty()) {
-                return base + "\n" + modalDetail.trim()
+                errorMessage = base + "\n" + modalDetail.trim()
                     + "\nUse the interact_with_modal tool to respond to the dialog.";
+            } else {
+                errorMessage = base;
             }
-            return base;
+            return errorMessage;
         } finally {
             if (needsGlobalLock && !semaphoreReleasedEarly) writeToolSemaphore.release();
-            fireToolCallEvent(toolName, startMs, success, inputSize, outputSize, categoryName);
+            fireToolCallEvent(toolName, startMs, success, inputSize, outputSize, categoryName, errorMessage);
             if (chatWasActive) {
                 fireFocusRestoreEvent();
             }
@@ -398,26 +403,28 @@ public final class PsiBridgeService implements Disposable {
                                     long inputSizeBytes, @Nullable String category) {
         try {
             if (!writeToolSemaphore.tryAcquire(60, java.util.concurrent.TimeUnit.SECONDS)) {
-                fireToolCallEvent(toolName, startTimeMs, false, inputSizeBytes, 0, category);
-                return "Error: IDE is busy processing another tool call. Please retry shortly.";
+                String err = "Error: IDE is busy processing another tool call. Please retry shortly.";
+                fireToolCallEvent(toolName, startTimeMs, false, inputSizeBytes, 0, category, err);
+                return err;
             }
             return null;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            fireToolCallEvent(toolName, startTimeMs, false, inputSizeBytes, 0, category);
-            return "Error: Interrupted waiting for write lock.";
+            String err = "Error: Interrupted waiting for write lock.";
+            fireToolCallEvent(toolName, startTimeMs, false, inputSizeBytes, 0, category, err);
+            return err;
         }
     }
 
     private void fireToolCallEvent(String toolName, long startTimeMs, boolean success,
                                    long inputSizeBytes, long outputSizeBytes,
-                                   @Nullable String category) {
+                                   @Nullable String category, @Nullable String errorMessage) {
         long duration = System.currentTimeMillis() - startTimeMs;
         String clientId = ActiveAgentManager.getInstance(project).getActiveProfileId();
         try {
             PlatformApiCompat.syncPublisher(project, TOOL_CALL_TOPIC)
                 .toolCalled(toolName, duration, success, inputSizeBytes, outputSizeBytes,
-                    clientId, category);
+                    clientId, category, errorMessage);
         } catch (Exception e) {
             LOG.debug("Failed to fire tool call event", e);
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ChatWebServer.java
@@ -1254,7 +1254,7 @@ public final class ChatWebServer implements Disposable {
     private void broadcast(String json) {
         for (SseClient c : sseClients) {
             if (!c.offer(json)) {
-                LOG.warn("SSE event dropped for a client — queue full (capacity 300). " +
+                LOG.info("SSE event dropped for a client — queue full (capacity 300). " +
                     "PWA may show stale or incomplete content.");
             }
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallRecord.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallRecord.java
@@ -9,14 +9,15 @@ import java.time.Instant;
  * Immutable record of a single MCP tool call, capturing identity, sizing,
  * timing, and outcome. Stored in SQLite by {@link ToolCallStatisticsService}.
  *
- * @param toolName       MCP tool ID (e.g. "read_file", "search_text")
- * @param category       tool category from ToolDefinition (e.g. "FILE", "GIT")
- * @param inputSizeBytes byte length of the JSON arguments
+ * @param toolName        MCP tool ID (e.g. "read_file", "search_text")
+ * @param category        tool category from ToolDefinition (e.g. "FILE", "GIT")
+ * @param inputSizeBytes  byte length of the JSON arguments
  * @param outputSizeBytes byte length of the response text
- * @param durationMs     wall-clock execution time in milliseconds
- * @param success        true if the tool completed without error
- * @param clientId       active agent profile ID (e.g. "copilot", "opencode")
- * @param timestamp      instant when the call started
+ * @param durationMs      wall-clock execution time in milliseconds
+ * @param success         true if the tool completed without error
+ * @param errorMessage    error text when success is false (null on success)
+ * @param clientId        active agent profile ID (e.g. "copilot", "opencode")
+ * @param timestamp       instant when the call started
  */
 public record ToolCallRecord(
     @NotNull String toolName,
@@ -25,6 +26,7 @@ public record ToolCallRecord(
     long outputSizeBytes,
     long durationMs,
     boolean success,
+    @Nullable String errorMessage,
     @NotNull String clientId,
     @NotNull Instant timestamp
 ) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -197,6 +197,7 @@ public final class ToolCallStatisticsService implements Disposable {
         long avgDurationMs,
         long totalInputBytes,
         long totalOutputBytes,
+        long avgTotalBytes,
         long errorCount
     ) {
     }
@@ -232,6 +233,7 @@ public final class ToolCallStatisticsService implements Disposable {
                    AVG(duration_ms) AS avg_duration,
                    SUM(input_size) AS total_input,
                    SUM(output_size) AS total_output,
+                   AVG(input_size + output_size) AS avg_total,
                    SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) AS error_count
             FROM tool_calls
             WHERE 1=1
@@ -251,6 +253,7 @@ public final class ToolCallStatisticsService implements Disposable {
                         rs.getLong("avg_duration"),
                         rs.getLong("total_input"),
                         rs.getLong("total_output"),
+                        rs.getLong("avg_total"),
                         rs.getLong("error_count")
                     ));
                 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -118,10 +118,10 @@ public final class ToolCallStatisticsService implements Disposable {
             stmt.execute("ALTER TABLE tool_calls ADD COLUMN error_message TEXT");
             LOG.info("Migrated tool_calls table: added error_message column");
         } catch (SQLException e) {
-            // Column already exists — expected for new databases or already-migrated ones
             if (e.getMessage() == null || !e.getMessage().contains("duplicate column")) {
-                LOG.debug("error_message column migration skipped", e);
+                LOG.warn("Unexpected error migrating tool_calls schema (error_message column)", e);
             }
+            // else: duplicate column — expected for databases that have already been migrated
         }
     }
 
@@ -246,10 +246,10 @@ public final class ToolCallStatisticsService implements Disposable {
         StringBuilder sql = new StringBuilder("""
             SELECT tool_name, category,
                    COUNT(*) AS call_count,
-                   AVG(duration_ms) AS avg_duration,
+                   ROUND(AVG(duration_ms)) AS avg_duration,
                    SUM(input_size) AS total_input,
                    SUM(output_size) AS total_output,
-                   AVG(input_size + output_size) AS avg_total,
+                   ROUND(AVG(input_size + output_size)) AS avg_total,
                    SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) AS error_count
             FROM tool_calls
             WHERE 1=1

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -92,30 +92,45 @@ public final class ToolCallStatisticsService implements Disposable {
         try (var stmt = connection.createStatement()) {
             stmt.execute("""
                 CREATE TABLE IF NOT EXISTS tool_calls (
-                    id         INTEGER PRIMARY KEY AUTOINCREMENT,
-                    tool_name  TEXT    NOT NULL,
-                    category   TEXT,
-                    input_size INTEGER NOT NULL,
-                    output_size INTEGER NOT NULL,
-                    duration_ms INTEGER NOT NULL,
-                    success    INTEGER NOT NULL,
-                    client_id  TEXT    NOT NULL,
-                    timestamp  TEXT    NOT NULL
+                    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                    tool_name     TEXT    NOT NULL,
+                    category      TEXT,
+                    input_size    INTEGER NOT NULL,
+                    output_size   INTEGER NOT NULL,
+                    duration_ms   INTEGER NOT NULL,
+                    success       INTEGER NOT NULL,
+                    error_message TEXT,
+                    client_id     TEXT    NOT NULL,
+                    timestamp     TEXT    NOT NULL
                 )
                 """);
             stmt.execute(
                 "CREATE INDEX IF NOT EXISTS idx_tool_calls_timestamp ON tool_calls(timestamp)");
             stmt.execute(
                 "CREATE INDEX IF NOT EXISTS idx_tool_calls_tool_name ON tool_calls(tool_name)");
+            // Migration: add error_message column to existing databases
+            migrateAddErrorMessageColumn(stmt);
+        }
+    }
+
+    private void migrateAddErrorMessageColumn(java.sql.Statement stmt) {
+        try {
+            stmt.execute("ALTER TABLE tool_calls ADD COLUMN error_message TEXT");
+            LOG.info("Migrated tool_calls table: added error_message column");
+        } catch (SQLException e) {
+            // Column already exists — expected for new databases or already-migrated ones
+            if (e.getMessage() == null || !e.getMessage().contains("duplicate column")) {
+                LOG.debug("error_message column migration skipped", e);
+            }
         }
     }
 
     private void subscribeToToolCallEvents() {
         disconnectHandle = PlatformApiCompat.subscribeToolCallListener(project,
-            (toolName, durationMs, success, inputSizeBytes, outputSizeBytes, clientId, category) ->
+            (toolName, durationMs, success, inputSizeBytes, outputSizeBytes, clientId, category, errorMessage) ->
                 recordCall(new ToolCallRecord(
                     toolName, category, inputSizeBytes, outputSizeBytes,
-                    durationMs, success, clientId, Instant.now())));
+                    durationMs, success, errorMessage, clientId, Instant.now())));
     }
 
     public synchronized void recordCall(@NotNull ToolCallRecord callRecord) {
@@ -137,8 +152,8 @@ public final class ToolCallStatisticsService implements Disposable {
 
     private void insertRecord(@NotNull ToolCallRecord callRecord) throws SQLException {
         String sql = """
-            INSERT INTO tool_calls (tool_name, category, input_size, output_size, duration_ms, success, client_id, timestamp)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO tool_calls (tool_name, category, input_size, output_size, duration_ms, success, error_message, client_id, timestamp)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """;
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
             stmt.setString(1, callRecord.toolName());
@@ -147,8 +162,9 @@ public final class ToolCallStatisticsService implements Disposable {
             stmt.setLong(4, callRecord.outputSizeBytes());
             stmt.setLong(5, callRecord.durationMs());
             stmt.setInt(6, callRecord.success() ? 1 : 0);
-            stmt.setString(7, callRecord.clientId());
-            stmt.setString(8, callRecord.timestamp().toString());
+            stmt.setString(7, callRecord.errorMessage());
+            stmt.setString(8, callRecord.clientId());
+            stmt.setString(9, callRecord.timestamp().toString());
             stmt.executeUpdate();
         }
     }
@@ -310,6 +326,54 @@ public final class ToolCallStatisticsService implements Disposable {
             LOG.warn("Failed to query tool call summary", e);
         }
         return summary;
+    }
+
+    /**
+     * A single failed tool call with its error message, for display in the errors tab.
+     */
+    public record ToolError(
+        @NotNull String toolName,
+        @Nullable String category,
+        @NotNull String clientId,
+        long durationMs,
+        @NotNull String errorMessage,
+        @NotNull String timestamp
+    ) {
+    }
+
+    /**
+     * Returns recent failed tool calls with their error messages, ordered by most recent first.
+     */
+    public synchronized List<ToolError> queryRecentErrors(@Nullable String since, @Nullable String clientId, int limit) {
+        if (connection == null) return List.of();
+        StringBuilder sql = new StringBuilder("""
+            SELECT tool_name, category, client_id, duration_ms, error_message, timestamp
+            FROM tool_calls
+            WHERE success = 0 AND error_message IS NOT NULL
+            """);
+        List<String> params = appendFilters(sql, since, clientId);
+        sql.append(" ORDER BY timestamp DESC LIMIT ?");
+
+        List<ToolError> results = new ArrayList<>();
+        try (PreparedStatement stmt = connection.prepareStatement(sql.toString())) {
+            bindParams(stmt, params);
+            stmt.setInt(params.size() + 1, limit);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    results.add(new ToolError(
+                        rs.getString("tool_name"),
+                        rs.getString("category"),
+                        rs.getString("client_id"),
+                        rs.getLong("duration_ms"),
+                        rs.getString("error_message"),
+                        rs.getString("timestamp")
+                    ));
+                }
+            }
+        } catch (SQLException e) {
+            LOG.warn("Failed to query recent errors", e);
+        }
+        return results;
     }
 
     public static ToolCallStatisticsService getInstance(@NotNull Project project) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -118,12 +118,24 @@ public final class ToolCallStatisticsService implements Disposable {
                     durationMs, success, clientId, Instant.now())));
     }
 
-    /**
-     * Records a single tool call. Synchronized because a single {@link Connection} is shared
-     * across MCP handler threads and the EDT.
-     */
     public synchronized void recordCall(@NotNull ToolCallRecord callRecord) {
         if (connection == null) return;
+        try {
+            insertRecord(callRecord);
+        } catch (SQLException e) {
+            if (isDbMoved(e) && tryReconnect()) {
+                try {
+                    insertRecord(callRecord);
+                } catch (SQLException retryEx) {
+                    LOG.warn("Failed to record tool call after reconnect", retryEx);
+                }
+            } else {
+                LOG.warn("Failed to record tool call", e);
+            }
+        }
+    }
+
+    private void insertRecord(@NotNull ToolCallRecord callRecord) throws SQLException {
         String sql = """
             INSERT INTO tool_calls (tool_name, category, input_size, output_size, duration_ms, success, client_id, timestamp)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
@@ -138,8 +150,38 @@ public final class ToolCallStatisticsService implements Disposable {
             stmt.setString(7, callRecord.clientId());
             stmt.setString(8, callRecord.timestamp().toString());
             stmt.executeUpdate();
+        }
+    }
+
+    private static boolean isDbMoved(@NotNull SQLException e) {
+        return e.getMessage() != null && e.getMessage().contains("SQLITE_READONLY_DBMOVED");
+    }
+
+    private boolean tryReconnect() {
+        if (project == null) return false;
+        closeConnectionQuietly();
+        try {
+            String basePath = project.getBasePath();
+            if (basePath == null) return false;
+            Path dbPath = Path.of(basePath, ".agentbridge", DB_FILENAME);
+            initializeWithConnection(DriverManager.getConnection("jdbc:sqlite:" + dbPath));
+            LOG.info("Reconnected to ToolCallStatisticsService database after file move");
+            return true;
         } catch (SQLException e) {
-            LOG.warn("Failed to record tool call", e);
+            LOG.warn("Failed to reconnect to ToolCallStatisticsService database", e);
+            connection = null;
+            return false;
+        }
+    }
+
+    private void closeConnectionQuietly() {
+        if (connection == null) return;
+        try {
+            connection.close();
+        } catch (SQLException ignored) {
+            // Best-effort close of stale connection
+        } finally {
+            connection = null;
         }
     }
 
@@ -285,12 +327,6 @@ public final class ToolCallStatisticsService implements Disposable {
         if (disconnectHandle != null) {
             disconnectHandle.run();
         }
-        if (connection != null) {
-            try {
-                connection.close();
-            } catch (SQLException e) {
-                LOG.debug("Failed to close tool-stats DB", e);
-            }
-        }
+        closeConnectionQuietly();
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/AcpConnectPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/AcpConnectPanel.kt
@@ -425,7 +425,7 @@ class AcpConnectPanel(
 
         connection.subscribe(
             PsiBridgeService.TOOL_CALL_TOPIC,
-            PsiBridgeService.ToolCallListener { toolName, durationMs, success, _, _, _, _ ->
+            PsiBridgeService.ToolCallListener { toolName, durationMs, success, _, _, _, _, _ ->
                 ApplicationManager.getApplication().invokeLater { addToolCallEntry(toolName, durationMs, success) }
             })
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/ToolStatisticsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/ToolStatisticsPanel.java
@@ -75,9 +75,10 @@ public class ToolStatisticsPanel extends JPanel {
         table.getColumnModel().getColumn(1).setPreferredWidth(120); // Category
         table.getColumnModel().getColumn(2).setPreferredWidth(60);  // Calls
         table.getColumnModel().getColumn(3).setPreferredWidth(120); // Avg Duration
-        table.getColumnModel().getColumn(4).setPreferredWidth(90);  // Total Input
-        table.getColumnModel().getColumn(5).setPreferredWidth(90);  // Total Output
-        table.getColumnModel().getColumn(6).setPreferredWidth(80);  // Error Rate
+        table.getColumnModel().getColumn(4).setPreferredWidth(90);  // Avg Data
+        table.getColumnModel().getColumn(5).setPreferredWidth(90);  // Total Input
+        table.getColumnModel().getColumn(6).setPreferredWidth(90);  // Total Output
+        table.getColumnModel().getColumn(7).setPreferredWidth(80);  // Error Rate
 
         return new JBScrollPane(table);
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/ToolStatisticsTableModel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/ToolStatisticsTableModel.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 /**
  * Table model for the Tool Statistics tab. Columns: Tool, Category, Calls,
- * Avg Duration (ms), Total Input, Total Output, Error Rate (%).
+ * Avg Duration (ms), Avg Data, Total Input, Total Output, Error Rate (%).
  * The Client column is omitted — it is redundant because the client filter
  * is shown in the toolbar dropdown above the table.
  */
@@ -17,12 +17,12 @@ public class ToolStatisticsTableModel extends AbstractTableModel {
 
     private static final String[] COLUMN_NAMES = {
         "Tool", "Category", "Calls", "Avg Duration (ms)",
-        "Total Input", "Total Output", "Error Rate (%)"
+        "Avg Data", "Total Input", "Total Output", "Error Rate (%)"
     };
 
     private static final Class<?>[] COLUMN_TYPES = {
         String.class, String.class, Long.class, Long.class,
-        String.class, String.class, String.class
+        String.class, String.class, String.class, String.class
     };
 
     private final List<ToolAggregate> data = new ArrayList<>();
@@ -55,9 +55,10 @@ public class ToolStatisticsTableModel extends AbstractTableModel {
             case 1 -> row.category() != null ? row.category() : "—";
             case 2 -> row.callCount();
             case 3 -> row.avgDurationMs();
-            case 4 -> formatBytes(row.totalInputBytes());
-            case 5 -> formatBytes(row.totalOutputBytes());
-            case 6 -> row.callCount() > 0
+            case 4 -> formatBytes(row.avgTotalBytes());
+            case 5 -> formatBytes(row.totalInputBytes());
+            case 6 -> formatBytes(row.totalOutputBytes());
+            case 7 -> row.callCount() > 0
                 ? String.format("%.1f", 100.0 * row.errorCount() / row.callCount())
                 : "0.0";
             default -> "";

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
@@ -59,9 +59,9 @@ final class UsageStatisticsLoader {
 
         for (SessionStoreV2.SessionRecord session : sessions) {
             String agentDisplay = session.agent();
-            String agentId = toAgentId(agentDisplay);
-            agentIds.add(agentId);
-            agentDisplayNames.putIfAbsent(agentId, agentDisplay);
+            String fallbackAgentId = toAgentId(agentDisplay);
+            agentIds.add(fallbackAgentId);
+            agentDisplayNames.putIfAbsent(fallbackAgentId, agentDisplay);
 
             Path jsonlPath = sessionsDir.toPath().resolve(session.id() + ".jsonl");
             if (!Files.exists(jsonlPath)) {
@@ -69,7 +69,8 @@ final class UsageStatisticsLoader {
                 continue;
             }
 
-            collectTurnStats(jsonlPath, agentId, startDate, endDate, accumulators);
+            collectTurnStats(jsonlPath, fallbackAgentId, startDate, endDate,
+                accumulators, agentIds, agentDisplayNames);
         }
 
         List<UsageStatisticsData.DailyAgentStats> dailyStats = buildDailyStats(accumulators);
@@ -108,11 +109,14 @@ final class UsageStatisticsLoader {
         return result;
     }
 
-    private static void collectTurnStats(Path jsonlPath, String agentId,
+    private static void collectTurnStats(Path jsonlPath, String fallbackAgentId,
                                          LocalDate startDate, LocalDate endDate,
-                                         Map<DayAgentKey, Accumulator> accumulators) {
+                                         Map<DayAgentKey, Accumulator> accumulators,
+                                         Set<String> agentIds,
+                                         Map<String, String> agentDisplayNames) {
         try (BufferedReader reader = Files.newBufferedReader(jsonlPath)) {
             String lastSeenTimestamp = null;
+            String currentAgentId = fallbackAgentId;
             String line;
             while ((line = reader.readLine()) != null) {
                 // Track timestamps from all entries for date attribution.
@@ -130,6 +134,23 @@ final class UsageStatisticsLoader {
                     }
                 }
 
+                int agentIdx = line.indexOf("\"agent\":\"");
+                if (agentIdx >= 0) {
+                    try {
+                        JsonObject obj = JsonParser.parseString(line).getAsJsonObject();
+                        if (obj.has("agent")) {
+                            String agentDisplay = obj.get("agent").getAsString();
+                            if (!agentDisplay.isEmpty()) {
+                                currentAgentId = toAgentId(agentDisplay);
+                                agentIds.add(currentAgentId);
+                                agentDisplayNames.putIfAbsent(currentAgentId, agentDisplay);
+                            }
+                        }
+                    } catch (Exception e) {
+                        LOG.debug("Skipping agent metadata in " + jsonlPath.getFileName() + ": " + e.getMessage());
+                    }
+                }
+
                 if (!line.contains("\"turnStats\"")) continue;
 
                 try {
@@ -144,7 +165,7 @@ final class UsageStatisticsLoader {
                     }
                     if (date.isBefore(startDate) || date.isAfter(endDate)) continue;
 
-                    DayAgentKey key = new DayAgentKey(date, agentId);
+                    DayAgentKey key = new DayAgentKey(date, currentAgentId);
                     Accumulator acc = accumulators.computeIfAbsent(key, k -> new Accumulator());
                     acc.turns++;
                     acc.inputTokens += stats.getInputTokens();

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallRecordTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallRecordTest.java
@@ -17,7 +17,7 @@ class ToolCallRecordTest {
     @Test
     void fieldsStoredCorrectly() {
         Instant ts = Instant.parse("2026-01-15T12:00:00Z");
-        var rec = new ToolCallRecord("read_file", "FILE", 256, 4096, 42, true, "copilot", ts);
+        var rec = new ToolCallRecord("read_file", "FILE", 256, 4096, 42, true, null, "copilot", ts);
 
         assertEquals("read_file", rec.toolName());
         assertEquals("FILE", rec.category());
@@ -25,21 +25,29 @@ class ToolCallRecordTest {
         assertEquals(4096, rec.outputSizeBytes());
         assertEquals(42, rec.durationMs());
         assertTrue(rec.success());
+        assertNull(rec.errorMessage());
         assertEquals("copilot", rec.clientId());
         assertEquals(ts, rec.timestamp());
     }
 
     @Test
+    void errorMessageStoredOnFailure() {
+        var rec = new ToolCallRecord("write_file", "FILE", 100, 0, 10, false,
+            "Error: Permission denied", "copilot", Instant.now());
+        assertEquals("Error: Permission denied", rec.errorMessage());
+    }
+
+    @Test
     void nullCategoryAllowed() {
-        var rec = new ToolCallRecord("custom", null, 0, 0, 10, true, "unknown", Instant.now());
+        var rec = new ToolCallRecord("custom", null, 0, 0, 10, true, null, "unknown", Instant.now());
         assertNull(rec.category());
     }
 
     @Test
     void equalityByValue() {
         Instant ts = Instant.parse("2026-01-15T12:00:00Z");
-        var a = new ToolCallRecord("tool", "CAT", 100, 200, 50, false, "client", ts);
-        var b = new ToolCallRecord("tool", "CAT", 100, 200, 50, false, "client", ts);
+        var a = new ToolCallRecord("tool", "CAT", 100, 200, 50, false, "Error: test", "client", ts);
+        var b = new ToolCallRecord("tool", "CAT", 100, 200, 50, false, "Error: test", "client", ts);
         assertEquals(a, b);
         assertEquals(a.hashCode(), b.hashCode());
     }
@@ -47,14 +55,14 @@ class ToolCallRecordTest {
     @Test
     void inequalityOnDifferentFields() {
         Instant ts = Instant.now();
-        var a = new ToolCallRecord("tool_a", "CAT", 100, 200, 50, true, "client", ts);
-        var b = new ToolCallRecord("tool_b", "CAT", 100, 200, 50, true, "client", ts);
+        var a = new ToolCallRecord("tool_a", "CAT", 100, 200, 50, true, null, "client", ts);
+        var b = new ToolCallRecord("tool_b", "CAT", 100, 200, 50, true, null, "client", ts);
         assertNotEquals(a, b);
     }
 
     @Test
     void toStringContainsAllFields() {
-        var rec = new ToolCallRecord("search_text", "NAV", 512, 1024, 75, true, "opencode", Instant.EPOCH);
+        var rec = new ToolCallRecord("search_text", "NAV", 512, 1024, 75, true, null, "opencode", Instant.EPOCH);
         String str = rec.toString();
         assertTrue(str.contains("search_text"));
         assertTrue(str.contains("NAV"));
@@ -65,7 +73,7 @@ class ToolCallRecordTest {
 
     @Test
     void zeroSizesAllowed() {
-        var rec = new ToolCallRecord("noop", null, 0, 0, 0, true, "test", Instant.now());
+        var rec = new ToolCallRecord("noop", null, 0, 0, 0, true, null, "test", Instant.now());
         assertEquals(0, rec.inputSizeBytes());
         assertEquals(0, rec.outputSizeBytes());
         assertEquals(0, rec.durationMs());

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
@@ -63,6 +63,7 @@ class ToolCallStatisticsServiceTest {
         assertEquals(42, agg.avgDurationMs());
         assertEquals(256, agg.totalInputBytes());
         assertEquals(4096, agg.totalOutputBytes());
+        assertEquals(4352, agg.avgTotalBytes());
         assertEquals(0, agg.errorCount());
     }
 
@@ -81,6 +82,7 @@ class ToolCallStatisticsServiceTest {
         assertEquals(100, agg.avgDurationMs()); // (50+150+100)/3
         assertEquals(450, agg.totalInputBytes());
         assertEquals(6000, agg.totalOutputBytes());
+        assertEquals(2150, agg.avgTotalBytes()); // (2100+3200+1150)/3 = 6450/3 = 2150
         assertEquals(1, agg.errorCount());
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
@@ -20,8 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link ToolCallStatisticsService} — exercises the actual service code
- * (recordCall, queryAggregates, querySummary, getDistinctClients) against a
- * test-owned in-memory SQLite database via {@code initializeWithConnection()}.
+ * (recordCall, queryAggregates, querySummary, getDistinctClients, queryRecentErrors)
+ * against a test-owned in-memory SQLite database via {@code initializeWithConnection()}.
  */
 class ToolCallStatisticsServiceTest {
 
@@ -50,7 +50,7 @@ class ToolCallStatisticsServiceTest {
     @Test
     void recordAndQuerySingleCall() {
         service.recordCall(new ToolCallRecord(
-            "read_file", "FILE", 256, 4096, 42, true, "copilot",
+            "read_file", "FILE", 256, 4096, 42, true, null, "copilot",
             Instant.parse("2026-01-15T10:30:00Z")));
 
         var aggregates = service.queryAggregates(null, null);
@@ -70,9 +70,9 @@ class ToolCallStatisticsServiceTest {
     @Test
     void aggregatesMultipleCallsSameTool() {
         Instant base = Instant.parse("2026-01-15T10:00:00Z");
-        service.recordCall(new ToolCallRecord("search_text", "NAV", 100, 2000, 50, true, "copilot", base));
-        service.recordCall(new ToolCallRecord("search_text", "NAV", 200, 3000, 150, true, "copilot", base.plusSeconds(60)));
-        service.recordCall(new ToolCallRecord("search_text", "NAV", 150, 1000, 100, false, "copilot", base.plusSeconds(120)));
+        service.recordCall(new ToolCallRecord("search_text", "NAV", 100, 2000, 50, true, null, "copilot", base));
+        service.recordCall(new ToolCallRecord("search_text", "NAV", 200, 3000, 150, true, null, "copilot", base.plusSeconds(60)));
+        service.recordCall(new ToolCallRecord("search_text", "NAV", 150, 1000, 100, false, "Error: test", "copilot", base.plusSeconds(120)));
 
         var aggregates = service.queryAggregates(null, null);
         assertEquals(1, aggregates.size());
@@ -88,9 +88,9 @@ class ToolCallStatisticsServiceTest {
 
     @Test
     void filterByTimestamp() {
-        service.recordCall(new ToolCallRecord("read_file", "FILE", 100, 200, 10, true, "copilot",
+        service.recordCall(new ToolCallRecord("read_file", "FILE", 100, 200, 10, true, null, "copilot",
             Instant.parse("2026-01-10T00:00:00Z")));
-        service.recordCall(new ToolCallRecord("read_file", "FILE", 300, 400, 20, true, "copilot",
+        service.recordCall(new ToolCallRecord("read_file", "FILE", 300, 400, 20, true, null, "copilot",
             Instant.parse("2026-01-20T00:00:00Z")));
 
         var filtered = service.queryAggregates("2026-01-15T00:00:00Z", null);
@@ -101,8 +101,8 @@ class ToolCallStatisticsServiceTest {
     @Test
     void filterByClient() {
         Instant ts = Instant.parse("2026-01-15T10:00:00Z");
-        service.recordCall(new ToolCallRecord("read_file", "FILE", 100, 200, 10, true, "copilot", ts));
-        service.recordCall(new ToolCallRecord("read_file", "FILE", 300, 400, 20, true, "opencode", ts));
+        service.recordCall(new ToolCallRecord("read_file", "FILE", 100, 200, 10, true, null, "copilot", ts));
+        service.recordCall(new ToolCallRecord("read_file", "FILE", 300, 400, 20, true, null, "opencode", ts));
 
         var filtered = service.queryAggregates(null, "opencode");
         assertEquals(1, filtered.size());
@@ -111,11 +111,11 @@ class ToolCallStatisticsServiceTest {
 
     @Test
     void filterByBothTimestampAndClient() {
-        service.recordCall(new ToolCallRecord("tool_a", "CAT", 100, 200, 10, true, "copilot",
+        service.recordCall(new ToolCallRecord("tool_a", "CAT", 100, 200, 10, true, null, "copilot",
             Instant.parse("2026-01-10T00:00:00Z")));
-        service.recordCall(new ToolCallRecord("tool_a", "CAT", 200, 300, 20, true, "copilot",
+        service.recordCall(new ToolCallRecord("tool_a", "CAT", 200, 300, 20, true, null, "copilot",
             Instant.parse("2026-01-20T00:00:00Z")));
-        service.recordCall(new ToolCallRecord("tool_a", "CAT", 400, 500, 30, true, "opencode",
+        service.recordCall(new ToolCallRecord("tool_a", "CAT", 400, 500, 30, true, null, "opencode",
             Instant.parse("2026-01-20T00:00:00Z")));
 
         var filtered = service.queryAggregates("2026-01-15T00:00:00Z", "copilot");
@@ -126,9 +126,9 @@ class ToolCallStatisticsServiceTest {
     @Test
     void distinctClients() {
         Instant ts = Instant.now();
-        service.recordCall(new ToolCallRecord("a", null, 0, 0, 0, true, "copilot", ts));
-        service.recordCall(new ToolCallRecord("b", null, 0, 0, 0, true, "opencode", ts));
-        service.recordCall(new ToolCallRecord("c", null, 0, 0, 0, true, "copilot", ts));
+        service.recordCall(new ToolCallRecord("a", null, 0, 0, 0, true, null, "copilot", ts));
+        service.recordCall(new ToolCallRecord("b", null, 0, 0, 0, true, null, "opencode", ts));
+        service.recordCall(new ToolCallRecord("c", null, 0, 0, 0, true, null, "copilot", ts));
 
         List<String> clients = service.getDistinctClients();
         assertEquals(2, clients.size());
@@ -139,8 +139,8 @@ class ToolCallStatisticsServiceTest {
     @Test
     void querySummary() {
         Instant ts = Instant.now();
-        service.recordCall(new ToolCallRecord("read_file", "FILE", 100, 200, 50, true, "copilot", ts));
-        service.recordCall(new ToolCallRecord("write_file", "FILE", 300, 400, 150, false, "copilot", ts));
+        service.recordCall(new ToolCallRecord("read_file", "FILE", 100, 200, 50, true, null, "copilot", ts));
+        service.recordCall(new ToolCallRecord("write_file", "FILE", 300, 400, 150, false, "Error: write failed", "copilot", ts));
 
         Map<String, Long> summary = service.querySummary(null, null);
         assertEquals(2L, summary.get("totalCalls"));
@@ -161,7 +161,7 @@ class ToolCallStatisticsServiceTest {
 
     @Test
     void nullCategoryStoredCorrectly() {
-        service.recordCall(new ToolCallRecord("custom_tool", null, 50, 100, 30, true, "copilot", Instant.now()));
+        service.recordCall(new ToolCallRecord("custom_tool", null, 50, 100, 30, true, null, "copilot", Instant.now()));
 
         var aggregates = service.queryAggregates(null, null);
         assertEquals(1, aggregates.size());
@@ -172,9 +172,9 @@ class ToolCallStatisticsServiceTest {
     void groupsByToolNameAndCategory() {
         // Calls from different clients with the same tool are collapsed into one aggregate row
         Instant ts = Instant.now();
-        service.recordCall(new ToolCallRecord("read_file", "FILE", 100, 200, 10, true, "copilot", ts));
-        service.recordCall(new ToolCallRecord("read_file", "FILE", 100, 200, 10, true, "opencode", ts));
-        service.recordCall(new ToolCallRecord("write_file", "FILE", 100, 200, 10, true, "copilot", ts));
+        service.recordCall(new ToolCallRecord("read_file", "FILE", 100, 200, 10, true, null, "copilot", ts));
+        service.recordCall(new ToolCallRecord("read_file", "FILE", 100, 200, 10, true, null, "opencode", ts));
+        service.recordCall(new ToolCallRecord("write_file", "FILE", 100, 200, 10, true, null, "copilot", ts));
 
         var aggregates = service.queryAggregates(null, null);
         assertEquals(2, aggregates.size());
@@ -190,8 +190,8 @@ class ToolCallStatisticsServiceTest {
     @Test
     void querySummaryWithFilters() {
         Instant ts = Instant.parse("2026-01-20T00:00:00Z");
-        service.recordCall(new ToolCallRecord("tool", "CAT", 100, 200, 50, true, "copilot", ts));
-        service.recordCall(new ToolCallRecord("tool", "CAT", 300, 400, 100, false, "opencode", ts));
+        service.recordCall(new ToolCallRecord("tool", "CAT", 100, 200, 50, true, null, "copilot", ts));
+        service.recordCall(new ToolCallRecord("tool", "CAT", 300, 400, 100, false, "Error: test", "opencode", ts));
 
         Map<String, Long> summary = service.querySummary(null, "copilot");
         assertEquals(1L, summary.get("totalCalls"));
@@ -203,8 +203,10 @@ class ToolCallStatisticsServiceTest {
     void highVolumeRecordAndQuery() {
         Instant base = Instant.parse("2026-01-15T00:00:00Z");
         for (int i = 0; i < 100; i++) {
+            boolean success = i % 10 != 0;
             service.recordCall(new ToolCallRecord(
-                "tool_" + (i % 5), "CAT", i * 10, i * 20, i, i % 10 != 0,
+                "tool_" + (i % 5), "CAT", i * 10, i * 20, i, success,
+                success ? null : "Error: iteration " + i,
                 "client_" + (i % 3), base.plusSeconds(i)));
         }
 
@@ -213,5 +215,60 @@ class ToolCallStatisticsServiceTest {
 
         long totalCalls = aggregates.stream().mapToLong(ToolCallStatisticsService.ToolAggregate::callCount).sum();
         assertEquals(100, totalCalls);
+    }
+
+    @Test
+    void queryRecentErrors() {
+        Instant base = Instant.parse("2026-01-15T10:00:00Z");
+        service.recordCall(new ToolCallRecord("read_file", "FILE", 100, 0, 10, false,
+            "Error: File not found", "copilot", base));
+        service.recordCall(new ToolCallRecord("write_file", "FILE", 200, 0, 20, false,
+            "Error: Permission denied", "copilot", base.plusSeconds(60)));
+        service.recordCall(new ToolCallRecord("search_text", "NAV", 50, 1000, 5, true,
+            null, "copilot", base.plusSeconds(30)));
+
+        var errors = service.queryRecentErrors(null, null, 10);
+        assertEquals(2, errors.size());
+        // Most recent first
+        assertEquals("write_file", errors.get(0).toolName());
+        assertEquals("Error: Permission denied", errors.get(0).errorMessage());
+        assertEquals("read_file", errors.get(1).toolName());
+        assertEquals("Error: File not found", errors.get(1).errorMessage());
+    }
+
+    @Test
+    void queryRecentErrorsFilterByClient() {
+        Instant ts = Instant.parse("2026-01-15T10:00:00Z");
+        service.recordCall(new ToolCallRecord("tool_a", "CAT", 100, 0, 10, false,
+            "Error: A failed", "copilot", ts));
+        service.recordCall(new ToolCallRecord("tool_b", "CAT", 100, 0, 10, false,
+            "Error: B failed", "opencode", ts));
+
+        var errors = service.queryRecentErrors(null, "opencode", 10);
+        assertEquals(1, errors.size());
+        assertEquals("tool_b", errors.get(0).toolName());
+        assertEquals("opencode", errors.get(0).clientId());
+    }
+
+    @Test
+    void errorMessageNullOnSuccess() {
+        service.recordCall(new ToolCallRecord("read_file", "FILE", 100, 200, 10, true,
+            null, "copilot", Instant.now()));
+
+        var errors = service.queryRecentErrors(null, null, 10);
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void schemaMigrationIdempotent() throws Exception {
+        // Calling initializeWithConnection again should not fail (migration re-runs safely)
+        service.dispose();
+        Path dbPath2 = tempDir.resolve("tool-stats-2.db");
+        Connection conn2 = DriverManager.getConnection("jdbc:sqlite:" + dbPath2);
+        var service2 = new ToolCallStatisticsService();
+        service2.initializeWithConnection(conn2);
+        // Second init on same connection — migration should be idempotent
+        service2.initializeWithConnection(conn2);
+        service2.dispose();
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/statistics/ToolStatisticsTableModelTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/statistics/ToolStatisticsTableModelTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for {@link ToolStatisticsTableModel} — column rendering, byte formatting, error rate.
@@ -23,7 +23,7 @@ class ToolStatisticsTableModelTest {
     @Test
     void emptyModelHasZeroRows() {
         assertEquals(0, model.getRowCount());
-        assertEquals(7, model.getColumnCount());
+        assertEquals(8, model.getColumnCount());
     }
 
     @Test
@@ -32,16 +32,17 @@ class ToolStatisticsTableModelTest {
         assertEquals("Category", model.getColumnName(1));
         assertEquals("Calls", model.getColumnName(2));
         assertEquals("Avg Duration (ms)", model.getColumnName(3));
-        assertEquals("Total Input", model.getColumnName(4));
-        assertEquals("Total Output", model.getColumnName(5));
-        assertEquals("Error Rate (%)", model.getColumnName(6));
+        assertEquals("Avg Data", model.getColumnName(4));
+        assertEquals("Total Input", model.getColumnName(5));
+        assertEquals("Total Output", model.getColumnName(6));
+        assertEquals("Error Rate (%)", model.getColumnName(7));
     }
 
     @Test
     void setDataPopulatesRows() {
         model.setData(List.of(
-            new ToolAggregate("read_file", "FILE", 10, 42, 2048, 8192, 1),
-            new ToolAggregate("write_file", "FILE", 5, 100, 512, 1024, 0)
+            new ToolAggregate("read_file", "FILE", 10, 42, 2048, 8192, 1024, 1),
+            new ToolAggregate("write_file", "FILE", 5, 100, 512, 1024, 307, 0)
         ));
         assertEquals(2, model.getRowCount());
     }
@@ -49,22 +50,23 @@ class ToolStatisticsTableModelTest {
     @Test
     void getValueAtReturnsCorrectValues() {
         model.setData(List.of(
-            new ToolAggregate("search_text", "NAV", 25, 75, 10240, 2097152, 3)
+            new ToolAggregate("search_text", "NAV", 25, 75, 10240, 2097152, 84320, 3)
         ));
 
         assertEquals("search_text", model.getValueAt(0, 0));
         assertEquals("NAV", model.getValueAt(0, 1));
         assertEquals(25L, model.getValueAt(0, 2));
         assertEquals(75L, model.getValueAt(0, 3));
-        assertEquals("10.0 KB", model.getValueAt(0, 4));
-        assertEquals("2.0 MB", model.getValueAt(0, 5));
-        assertEquals("12.0", model.getValueAt(0, 6)); // 3/25 * 100
+        assertEquals("82.3 KB", model.getValueAt(0, 4));
+        assertEquals("10.0 KB", model.getValueAt(0, 5));
+        assertEquals("2.0 MB", model.getValueAt(0, 6));
+        assertEquals("12.0", model.getValueAt(0, 7)); // 3/25 * 100
     }
 
     @Test
     void nullCategoryShowsDash() {
         model.setData(List.of(
-            new ToolAggregate("custom", null, 1, 10, 100, 200, 0)
+            new ToolAggregate("custom", null, 1, 10, 100, 200, 300, 0)
         ));
         assertEquals("—", model.getValueAt(0, 1));
     }
@@ -72,9 +74,9 @@ class ToolStatisticsTableModelTest {
     @Test
     void zeroCallsShowsZeroErrorRate() {
         model.setData(List.of(
-            new ToolAggregate("tool", "CAT", 0, 0, 0, 0, 0)
+            new ToolAggregate("tool", "CAT", 0, 0, 0, 0, 0, 0)
         ));
-        assertEquals("0.0", model.getValueAt(0, 6));
+        assertEquals("0.0", model.getValueAt(0, 7));
     }
 
     @Test
@@ -100,13 +102,13 @@ class ToolStatisticsTableModelTest {
     @Test
     void setDataClearsPrevious() {
         model.setData(List.of(
-            new ToolAggregate("a", null, 1, 1, 1, 1, 0),
-            new ToolAggregate("b", null, 1, 1, 1, 1, 0)
+            new ToolAggregate("a", null, 1, 1, 1, 1, 2, 0),
+            new ToolAggregate("b", null, 1, 1, 1, 1, 2, 0)
         ));
         assertEquals(2, model.getRowCount());
 
         model.setData(List.of(
-            new ToolAggregate("x", null, 1, 1, 1, 1, 0)
+            new ToolAggregate("x", null, 1, 1, 1, 1, 2, 0)
         ));
         assertEquals(1, model.getRowCount());
         assertEquals("x", model.getValueAt(0, 0));
@@ -121,5 +123,6 @@ class ToolStatisticsTableModelTest {
         assertEquals(String.class, model.getColumnClass(4));
         assertEquals(String.class, model.getColumnClass(5));
         assertEquals(String.class, model.getColumnClass(6));
+        assertEquals(String.class, model.getColumnClass(7));
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoaderTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoaderTest.java
@@ -249,7 +249,7 @@ class UsageStatisticsLoaderTest {
     @Test
     void collectTurnStats_entryOutsideDateRange_producesNoAccumulators(@TempDir Path tempDir) throws Exception {
         Path jsonlPath = tempDir.resolve("old.jsonl");
-        // Entry is in 2023; range is restricted to 2025
+        // Entry is in 2023; range is restricted to 2024
         String line = "{\"type\":\"turnStats\",\"turnId\":\"t1\",\"durationMs\":1000,"
             + "\"inputTokens\":10,\"outputTokens\":20,\"toolCallCount\":1,"
             + "\"linesAdded\":1,\"linesRemoved\":0,\"multiplier\":\"1x\","

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoaderTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoaderTest.java
@@ -11,8 +11,10 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -185,14 +187,50 @@ class UsageStatisticsLoaderTest {
         Files.writeString(jsonlPath, line1 + "\n" + line2 + "\n");
 
         Map<Object, Object> accumulators = new LinkedHashMap<>();
-        Method m = UsageStatisticsLoader.class.getDeclaredMethod(
-            "collectTurnStats", Path.class, String.class, LocalDate.class, LocalDate.class, Map.class);
-        m.setAccessible(true);
-        m.invoke(null, jsonlPath, "copilot",
-            LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), accumulators);
+        LinkedHashSet<String> agentIds = new LinkedHashSet<>();
+        Map<String, String> agentDisplayNames = new LinkedHashMap<>();
+        invokeCollectTurnStats(jsonlPath, "copilot", accumulators, agentIds, agentDisplayNames);
 
         assertEquals(1, accumulators.size(),
             "Two entries on the same date/agent should produce exactly one accumulator bucket");
+    }
+
+    @Test
+    void collectTurnStats_tracksAgentChangesWithinSession(@TempDir Path tempDir) throws Exception {
+        Path jsonlPath = tempDir.resolve("mixed.jsonl");
+        String line1 = "{\"type\":\"text\",\"raw\":\"hello\",\"agent\":\"GitHub Copilot\","
+            + "\"entryId\":\"e1\"}";
+        String line2 = "{\"type\":\"turnStats\",\"turnId\":\"t1\",\"durationMs\":5000,"
+            + "\"inputTokens\":100,\"outputTokens\":200,\"toolCallCount\":3,"
+            + "\"linesAdded\":10,\"linesRemoved\":5,\"multiplier\":\"1x\","
+            + "\"timestamp\":\"2024-06-15T10:00:00Z\",\"entryId\":\"e2\"}";
+        String line3 = "{\"type\":\"text\",\"raw\":\"hello\",\"agent\":\"Claude Code\","
+            + "\"entryId\":\"e3\"}";
+        String line4 = "{\"type\":\"turnStats\",\"turnId\":\"t2\",\"durationMs\":3000,"
+            + "\"inputTokens\":50,\"outputTokens\":100,\"toolCallCount\":1,"
+            + "\"linesAdded\":5,\"linesRemoved\":2,\"multiplier\":\"1x\","
+            + "\"timestamp\":\"2024-06-15T11:00:00Z\",\"entryId\":\"e4\"}";
+        Files.writeString(jsonlPath, line1 + "\n" + line2 + "\n" + line3 + "\n" + line4 + "\n");
+
+        Map<Object, Object> accumulators = new LinkedHashMap<>();
+        LinkedHashSet<String> agentIds = new LinkedHashSet<>();
+        Map<String, String> agentDisplayNames = new LinkedHashMap<>();
+        invokeCollectTurnStats(jsonlPath, "unknown", accumulators, agentIds, agentDisplayNames);
+
+        Method buildMethod = UsageStatisticsLoader.class.getDeclaredMethod("buildDailyStats", Map.class);
+        buildMethod.setAccessible(true);
+        List<?> result = (List<?>) buildMethod.invoke(null, accumulators);
+
+        assertEquals(2, result.size());
+        assertTrue(agentIds.contains("copilot"));
+        assertTrue(agentIds.contains("claude-cli"));
+        assertEquals("GitHub Copilot", agentDisplayNames.get("copilot"));
+        assertEquals("Claude Code", agentDisplayNames.get("claude-cli"));
+
+        UsageStatisticsData.DailyAgentStats first = (UsageStatisticsData.DailyAgentStats) result.get(0);
+        UsageStatisticsData.DailyAgentStats second = (UsageStatisticsData.DailyAgentStats) result.get(1);
+        assertTrue(Set.of(first.agentId(), second.agentId()).contains("copilot"));
+        assertTrue(Set.of(first.agentId(), second.agentId()).contains("claude-cli"));
     }
 
     @Test
@@ -201,11 +239,9 @@ class UsageStatisticsLoaderTest {
         Files.writeString(jsonlPath, "");
 
         Map<Object, Object> accumulators = new LinkedHashMap<>();
-        Method m = UsageStatisticsLoader.class.getDeclaredMethod(
-            "collectTurnStats", Path.class, String.class, LocalDate.class, LocalDate.class, Map.class);
-        m.setAccessible(true);
-        m.invoke(null, jsonlPath, "copilot",
-            LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), accumulators);
+        LinkedHashSet<String> agentIds = new LinkedHashSet<>();
+        Map<String, String> agentDisplayNames = new LinkedHashMap<>();
+        invokeCollectTurnStats(jsonlPath, "copilot", accumulators, agentIds, agentDisplayNames);
 
         assertTrue(accumulators.isEmpty(), "Empty JSONL file should produce no accumulators");
     }
@@ -221,11 +257,9 @@ class UsageStatisticsLoaderTest {
         Files.writeString(jsonlPath, line + "\n");
 
         Map<Object, Object> accumulators = new LinkedHashMap<>();
-        Method m = UsageStatisticsLoader.class.getDeclaredMethod(
-            "collectTurnStats", Path.class, String.class, LocalDate.class, LocalDate.class, Map.class);
-        m.setAccessible(true);
-        m.invoke(null, jsonlPath, "copilot",
-            LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31), accumulators);
+        LinkedHashSet<String> agentIds = new LinkedHashSet<>();
+        Map<String, String> agentDisplayNames = new LinkedHashMap<>();
+        invokeCollectTurnStats(jsonlPath, "copilot", accumulators, agentIds, agentDisplayNames);
 
         assertTrue(accumulators.isEmpty(), "Entry outside the date range should not be accumulated");
     }
@@ -249,11 +283,9 @@ class UsageStatisticsLoaderTest {
         Files.writeString(jsonlPath, line + "\n");
 
         Map<Object, Object> accumulators = new LinkedHashMap<>();
-        Method collectMethod = UsageStatisticsLoader.class.getDeclaredMethod(
-            "collectTurnStats", Path.class, String.class, LocalDate.class, LocalDate.class, Map.class);
-        collectMethod.setAccessible(true);
-        collectMethod.invoke(null, jsonlPath, "copilot",
-            LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), accumulators);
+        LinkedHashSet<String> agentIds = new LinkedHashSet<>();
+        Map<String, String> agentDisplayNames = new LinkedHashMap<>();
+        invokeCollectTurnStats(jsonlPath, "copilot", accumulators, agentIds, agentDisplayNames);
 
         assertFalse(accumulators.isEmpty(), "Precondition: accumulators must be populated by collectTurnStats");
 
@@ -278,5 +310,17 @@ class UsageStatisticsLoaderTest {
         Method m = UsageStatisticsLoader.class.getDeclaredMethod("extractDate", JsonObject.class, String.class);
         m.setAccessible(true);
         return (LocalDate) m.invoke(null, obj, fallback);
+    }
+
+    private static void invokeCollectTurnStats(Path jsonlPath, String agentId,
+                                               Map<Object, Object> accumulators,
+                                               Set<String> agentIds,
+                                               Map<String, String> agentDisplayNames) throws Exception {
+        Method m = UsageStatisticsLoader.class.getDeclaredMethod(
+            "collectTurnStats", Path.class, String.class, LocalDate.class, LocalDate.class, Map.class, Set.class, Map.class);
+        m.setAccessible(true);
+        m.invoke(null, jsonlPath, agentId,
+            LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31),
+            accumulators, agentIds, agentDisplayNames);
     }
 }


### PR DESCRIPTION
## Changes

### ChatWebServer
- Demote "SSE event dropped — queue full" from `WARN` to `INFO`. The event is fully handled (client reconnects and catches up), so this was noise.

### ToolCallStatisticsService
- Handle `SQLITE_READONLY_DBMOVED` by automatically reconnecting and retrying the insert once. This was causing repeated WARN spam when the project directory is moved while the IDE is open.
- Extracted `insertRecord()`, `isDbMoved()`, `tryReconnect()`, and `closeConnectionQuietly()` helpers.
- `dispose()` now delegates to `closeConnectionQuietly()`.