### PR TITLE
fix: strip ANSI codes from Kiro crash messages and clear stale panic state

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/KiroClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/KiroClient.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public final class KiroClient extends AcpClient {
 
@@ -18,6 +19,11 @@ public final class KiroClient extends AcpClient {
     private static final String KEY_RAW_INPUT = "rawInput";
     private static final String KEY_AGENTBRIDGE = "@agentbridge/";
     private static final String KEY_STATUS = "status";
+
+    /**
+     * Matches ANSI escape sequences (e.g. {@code \033[31m}, {@code \033[0m}).
+     */
+    private static final Pattern ANSI_ESCAPE = Pattern.compile("\\x1b\\[[\\d;]*[a-zA-Z]");
 
     /**
      * Rolling buffer of the last few stderr lines for crash diagnostics.
@@ -39,6 +45,13 @@ public final class KiroClient extends AcpClient {
 
     @Override
     protected void registerHandlers() {
+        // Clear crash state from any previous process lifecycle so stale panic lines
+        // don't leak into error messages after a restart.
+        capturedPanicLine = null;
+        synchronized (recentStderr) {
+            recentStderr.clear();
+        }
+
         // Register combined handler for both standard and Kiro-specific notifications
         transport.onNotification(notification -> {
             String method = notification.method();
@@ -62,7 +75,7 @@ public final class KiroClient extends AcpClient {
             // With RUST_BACKTRACE=1, the backtrace can exceed the rolling buffer size,
             // evicting the panic header before tryRecoverPromptException is called.
             if (capturedPanicLine == null && isPanicLine(line)) {
-                capturedPanicLine = line.trim();
+                capturedPanicLine = stripAnsi(line.trim());
             }
             // When Kiro's agent-loop thread panics, the Rust panic hook prints the message to
             // stderr but the main process thread stays alive — stdout remains open, so readLoop
@@ -294,6 +307,14 @@ public final class KiroClient extends AcpClient {
     }
 
     /**
+     * Strips ANSI escape sequences (color codes, bold, etc.) from a string.
+     * Kiro's Rust stderr output includes ANSI codes that would appear as garbled text in the UI.
+     */
+    static String stripAnsi(@NotNull String s) {
+        return ANSI_ESCAPE.matcher(s).replaceAll("");
+    }
+
+    /**
      * When Kiro crashes (Rust panic), the process writes the panic message to stderr and the
      * transport stops. The generic "Transport stopped" message is unhelpful; this override
      * inspects the eagerly-captured panic line (or falls back to the rolling buffer) and surfaces
@@ -314,6 +335,7 @@ public final class KiroClient extends AcpClient {
                 panicLine = recentStderr.stream()
                     .filter(l -> l.contains("panicked") || l.contains("Message:"))
                     .reduce((first, second) -> second) // keep last matching line
+                    .map(l -> stripAnsi(l.trim()))
                     .orElse(null);
             }
         }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/KiroClientTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/KiroClientTest.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class KiroClientTest {
 
@@ -33,6 +35,39 @@ class KiroClientTest {
     @Test
     void isPanicLine_containsPanickedAtMiddle() throws Exception {
         assertTrue(invokeIsPanicLine("error: thread 'tokio-runtime' panicked at core/event.rs:128"));
+    }
+
+    // ── stripAnsi (package-private static) ────────────────────────────
+
+    @Test
+    void stripAnsi_removesColorCodes() {
+        assertEquals(
+            "The application panicked (crashed).",
+            KiroClient.stripAnsi("\u001b[31mThe application panicked (crashed).\u001b[0m")
+        );
+    }
+
+    @Test
+    void stripAnsi_removesMultipleCodes() {
+        assertEquals(
+            "thread 'agent' panicked at src/main.rs:42",
+            KiroClient.stripAnsi("\u001b[33mthread 'agent' panicked at \u001b[35msrc/main.rs\u001b[0m:\u001b[35m42\u001b[0m")
+        );
+    }
+
+    @Test
+    void stripAnsi_noOpForCleanString() {
+        assertEquals("no ansi here", KiroClient.stripAnsi("no ansi here"));
+    }
+
+    @Test
+    void stripAnsi_emptyString() {
+        assertEquals("", KiroClient.stripAnsi(""));
+    }
+
+    @Test
+    void stripAnsi_boldAndReset() {
+        assertEquals("bold text", KiroClient.stripAnsi("\u001b[1mbold text\u001b[0m"));
     }
 
     // ── Reflection helpers ──────────────────────────────────────────────


### PR DESCRIPTION
## Problem

When Kiro's Rust process panics, the crash message includes ANSI escape codes (color, bold, reset) that leak into the user-facing error message, appearing as garbled text like `[31mThe application panicked[0m`.

Additionally, `capturedPanicLine` was never cleared on process restart, so a stale panic line from a previous crash could incorrectly override future error messages.

## Fix

- **ANSI stripping**: Added `stripAnsi()` method using a compiled regex pattern. Applied both when eagerly capturing the panic line from stderr and in the `recentStderr` fallback path.
- **Lifecycle cleanup**: Clear `capturedPanicLine` and `recentStderr` at the start of `registerHandlers()`, which runs on each process launch, so stale crash state doesn't persist across restarts.

## Tests

Added 5 unit tests for `stripAnsi()` covering: color codes, multiple codes, clean strings, empty strings, bold+reset.