### PR TITLE
fix: align Kiro session export format with native structure

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/KiroClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/KiroClientExporter.java
@@ -247,7 +247,11 @@ public final class KiroClientExporter {
                 toolUseBlock.add("data", toolUseData);
 
                 // Build tool_result block
+                boolean isError = "error".equals(toolCall.getStatus());
                 JsonObject resultContent = parseResultContent(resultStr);
+                if (!resultContent.has("isError")) {
+                    resultContent.addProperty("isError", isError);
+                }
 
                 JsonObject jsonContentBlock = new JsonObject();
                 jsonContentBlock.addProperty("kind", CONTENT_KIND_JSON);
@@ -259,6 +263,7 @@ public final class KiroClientExporter {
                 JsonObject toolResultData = new JsonObject();
                 toolResultData.addProperty(KEY_TOOL_USE_ID, toolCallId);
                 toolResultData.add(KEY_CONTENT, resultContentArray);
+                toolResultData.addProperty("status", isError ? "error" : "success");
 
                 JsonObject toolResultBlock = new JsonObject();
                 toolResultBlock.addProperty("kind", CONTENT_KIND_TOOL_RESULT);
@@ -266,7 +271,7 @@ public final class KiroClientExporter {
 
                 assistantBlocks.add(toolUseBlock);
                 pendingTools.add(new ToolPair(toolCallId, toolName, inputObj,
-                    toolUseBlock, toolResultBlock, resultContent));
+                    toolUseBlock, toolResultBlock, resultContent, isError));
                 seenToolUse = true;
 
             }
@@ -507,8 +512,11 @@ public final class KiroClientExporter {
             JsonObject toolKind = new JsonObject();
             toolKind.add("Mcp", mcpInfo);
 
+            JsonObject toolDescription = new JsonObject();
+            toolDescription.add("kind", toolKind);
+
             JsonObject toolMeta = new JsonObject();
-            toolMeta.add("tool", toolKind);
+            toolMeta.add("tool", toolDescription);
 
             JsonArray items = new JsonArray();
             JsonObject jsonItem = new JsonObject();
@@ -519,7 +527,11 @@ public final class KiroClientExporter {
             successWrapper.add("items", items);
 
             JsonObject resultWrapper = new JsonObject();
-            resultWrapper.add("Success", successWrapper);
+            if (pair.isError) {
+                resultWrapper.add("Error", successWrapper);
+            } else {
+                resultWrapper.add("Success", successWrapper);
+            }
             toolMeta.add(STATE_RESULT, resultWrapper);
 
             results.add(pair.toolCallId, toolMeta);
@@ -584,7 +596,8 @@ public final class KiroClientExporter {
         @NotNull JsonObject input,
         @NotNull JsonObject toolUseBlock,
         @NotNull JsonObject toolResultBlock,
-        @NotNull JsonObject resultContent
+        @NotNull JsonObject resultContent,
+        boolean isError
     ) {
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/exporters/KiroClientExporterTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/exporters/KiroClientExporterTest.java
@@ -319,7 +319,7 @@ class KiroClientExporterTest {
         String toolCallId = results.keySet().iterator().next();
         JsonObject toolEntry = results.getAsJsonObject(toolCallId);
 
-        JsonObject mcp = toolEntry.getAsJsonObject("tool").getAsJsonObject("Mcp");
+        JsonObject mcp = toolEntry.getAsJsonObject("tool").getAsJsonObject("kind").getAsJsonObject("Mcp");
         assertEquals("search_text", mcp.get("toolName").getAsString());
         assertEquals("agentbridge", mcp.get("serverName").getAsString());
         assertEquals("hello", mcp.getAsJsonObject("params").get("query").getAsString());
@@ -511,6 +511,80 @@ class KiroClientExporterTest {
     }
 
     // ── Helper methods ──────────────────────────────────────────────
+
+    @Test
+    void toolResultHasStatusField() {
+        List<JsonObject> kiroMessages = KiroClientExporter.toKiroMessages(
+            List.of(
+                userPrompt("do it"),
+                toolCall("read_file", "{}", "{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}")
+            ));
+
+        JsonObject trData = kiroMessages.get(2).getAsJsonObject("data");
+        JsonArray trContent = trData.getAsJsonArray("content");
+        JsonObject toolResultData = trContent.get(0).getAsJsonObject().getAsJsonObject("data");
+
+        assertTrue(toolResultData.has("status"), "toolResult data must have 'status' field");
+        assertEquals("success", toolResultData.get("status").getAsString());
+    }
+
+    @Test
+    void toolResultContentHasIsErrorField() {
+        List<JsonObject> kiroMessages = KiroClientExporter.toKiroMessages(
+            List.of(
+                userPrompt("do it"),
+                toolCall("read_file", "{}", "{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}")
+            ));
+
+        JsonObject trData = kiroMessages.get(2).getAsJsonObject("data");
+        JsonArray trContent = trData.getAsJsonArray("content");
+        JsonObject jsonData = trContent.get(0).getAsJsonObject().getAsJsonObject("data")
+            .getAsJsonArray("content").get(0).getAsJsonObject().getAsJsonObject("data");
+
+        assertTrue(jsonData.has("isError"), "result content JSON must have 'isError' field");
+        assertFalse(jsonData.get("isError").getAsBoolean());
+    }
+
+    @Test
+    void errorToolCallProducesErrorStatusAndResultWrapper() {
+        EntryData.ToolCall errorTool = new EntryData.ToolCall(
+            "read_file", "{\"path\":\"/missing\"}", "other",
+            "{\"content\":[{\"type\":\"text\",\"text\":\"File not found\"}],\"isError\":true}");
+        errorTool.setStatus("error");
+
+        List<JsonObject> kiroMessages = KiroClientExporter.toKiroMessages(
+            List.of(userPrompt("read it"), errorTool));
+
+        // Check toolResult status
+        JsonObject trData = kiroMessages.get(2).getAsJsonObject("data");
+        JsonObject toolResultData = trData.getAsJsonArray("content").get(0)
+            .getAsJsonObject().getAsJsonObject("data");
+        assertEquals("error", toolResultData.get("status").getAsString());
+
+        // Check results map uses "Error" key instead of "Success"
+        String toolCallId = trData.getAsJsonObject("results").keySet().iterator().next();
+        JsonObject toolEntry = trData.getAsJsonObject("results").getAsJsonObject(toolCallId);
+        assertTrue(toolEntry.getAsJsonObject("result").has("Error"),
+            "Error tool calls should use 'Error' key in result wrapper");
+        assertFalse(toolEntry.getAsJsonObject("result").has("Success"));
+    }
+
+    @Test
+    void toolResultsMapHasKindWrapper() {
+        List<JsonObject> kiroMessages = KiroClientExporter.toKiroMessages(
+            List.of(
+                userPrompt("go"),
+                toolCall("search_text", "{\"query\":\"x\"}", "found")
+            ));
+
+        JsonObject results = kiroMessages.get(2).getAsJsonObject("data").getAsJsonObject("results");
+        String id = results.keySet().iterator().next();
+        JsonObject toolInfo = results.getAsJsonObject(id).getAsJsonObject("tool");
+
+        assertTrue(toolInfo.has("kind"), "tool info must have 'kind' wrapper");
+        assertTrue(toolInfo.getAsJsonObject("kind").has("Mcp"),
+            "kind must contain 'Mcp' for agentbridge tools");
+    }
 
     private static EntryData.Prompt userPrompt(String text) {
         return new EntryData.Prompt(text);


### PR DESCRIPTION
## Problem

Kiro's Rust binary panics (crashes) when loading sessions exported by our plugin. The crash occurs during `session/prompt` because our exported JSONL format has three structural mismatches compared to Kiro's native format.

## Root Cause

Compared our exported session files against native Kiro-generated sessions and identified three discrepancies:

1. **Missing `status` field** in toolResult content blocks — Kiro requires `"success"` or `"error"` on each tool result data object; serde deserialization fails without it → `.unwrap()` → panic
2. **Missing `kind` wrapper** in results map tool description — native format uses `{"tool":{"kind":{"Mcp":{...}}}}` but we exported `{"tool":{"Mcp":{...}}}`
3. **Missing `isError` field** in result content JSON — and corresponding `Error`/`Success` key selection in result wrapper

## Changes

- `KiroClientExporter.java`: Added all three missing fields/wrappers
- `KiroClientExporterTest.java`: Updated existing test for `kind` wrapper path, added 4 new tests verifying `status`, `isError`, `Error` wrapper key, and `kind` wrapper structure

## Testing

All 25 tests in `KiroClientExporterTest` pass.