### PR TITLE
fix: prefix Codex rollout tool names with agentbridge_ for MCP tool matching

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/agent/codex/CodexAppServerClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/agent/codex/CodexAppServerClient.java
@@ -637,6 +637,16 @@ public final class CodexAppServerClient extends AbstractAgentClient {
             } catch (AgentException e) {
                 LOG.warn("thread/resume failed (thread may be expired), starting new thread: " + e.getMessage());
                 persistCodexThreadId(null);
+
+                com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater(() ->
+                    com.intellij.notification.NotificationGroupManager.getInstance()
+                        .getNotificationGroup("AgentBridge Notifications")
+                        .createNotification(
+                            "Codex session restore failed",
+                            "Could not resume previous Codex thread: " + e.getMessage()
+                                + ". A new thread was started — previous conversation context is lost.",
+                            com.intellij.notification.NotificationType.WARNING)
+                        .notify(project));
             }
         }
         return startThread(sessionId, model);

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/SessionSwitchService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/SessionSwitchService.java
@@ -578,7 +578,7 @@ public final class SessionSwitchService implements Disposable {
     private void exportToCodex(@NotNull List<SessionMessage> messages, @Nullable String basePath) {
         Path sessionsDir = CodexClientExporter.defaultSessionsDir();
         Path dbPath = CodexClientExporter.defaultDbPath();
-        String threadId = CodexClientExporter.exportSession(messages, sessionsDir, dbPath);
+        String threadId = CodexClientExporter.exportSession(messages, sessionsDir, dbPath, basePath);
         if (threadId != null) {
             // Set the thread ID so CodexAppServerClient will try thread/resume on next startup
             PropertiesComponent.getInstance(project)

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/AnthropicClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/AnthropicClientExporter.java
@@ -17,7 +17,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 
 public final class AnthropicClientExporter {
 
@@ -32,29 +31,6 @@ public final class AnthropicClientExporter {
     private static final String STATE_RESULT = "result";
     private static final String ROLE_USER = "user";
     private static final String ROLE_ASSISTANT = "assistant";
-
-    private static final int MAX_TOOL_NAME_LENGTH = 200;
-    private static final Pattern INVALID_TOOL_NAME_CHARS = Pattern.compile("[^a-zA-Z0-9_-]");
-    private static final Pattern CONSECUTIVE_UNDERSCORES = Pattern.compile("_{3,}");
-
-    /**
-     * Sanitizes a tool name for the Anthropic API, which requires tool_use names to match
-     * {@code [a-zA-Z0-9_-]+} and be at most 200 characters.
-     *
-     * <p>Our session data stores human-readable titles for tool calls (e.g., "git add src/Foo.java",
-     * "Viewing .../ChatConsolePanel.kt") which can exceed the API limit. This method replaces
-     * invalid characters, collapses runs of 3+ underscores (preserving the {@code __} MCP
-     * separator), and truncates to fit.</p>
-     */
-    public static String sanitizeToolName(@NotNull String rawName) {
-        if (rawName.isEmpty()) return "unknown_tool";
-        String sanitized = INVALID_TOOL_NAME_CHARS.matcher(rawName).replaceAll("_");
-        sanitized = CONSECUTIVE_UNDERSCORES.matcher(sanitized).replaceAll("__");
-        if (sanitized.startsWith("_")) sanitized = sanitized.substring(1);
-        if (sanitized.endsWith("_")) sanitized = sanitized.substring(0, sanitized.length() - 1);
-        if (sanitized.length() > MAX_TOOL_NAME_LENGTH) sanitized = sanitized.substring(0, MAX_TOOL_NAME_LENGTH);
-        return sanitized.isEmpty() ? "unknown_tool" : sanitized;
-    }
 
     private AnthropicClientExporter() {
     }
@@ -181,7 +157,7 @@ public final class AnthropicClientExporter {
         if (!STATE_RESULT.equals(state)) return null;
 
         String toolCallId = inv.has("toolCallId") ? inv.get("toolCallId").getAsString() : "";
-        String toolName = sanitizeToolName(
+        String toolName = ExporterUtil.sanitizeToolName(
             inv.has("toolName") ? inv.get("toolName").getAsString() : "unknown");
         String argsStr = inv.has("args") ? inv.get("args").getAsString() : "{}";
         String resultStr = inv.has(STATE_RESULT) ? inv.get(STATE_RESULT).getAsString() : "";

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/CodexClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/CodexClientExporter.java
@@ -132,6 +132,8 @@ public final class CodexClientExporter {
         if (cwd != null) {
             payload.addProperty("cwd", cwd);
         }
+        payload.addProperty("originator", "intellij-copilot-plugin");
+        payload.addProperty("cli_version", "0.0.0");
         payload.addProperty("source", "vscode");
         payload.addProperty("model_provider", "openai");
 

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/CodexClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/CodexClientExporter.java
@@ -21,6 +21,8 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
 
@@ -28,6 +30,11 @@ public final class CodexClientExporter {
 
     private static final Logger LOG = Logger.getInstance(CodexClientExporter.class);
     private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
+
+    private static final String F_TYPE = "type";
+    private static final String F_CONTENT = "content";
+    private static final String F_TIMESTAMP = "timestamp";
+    private static final String F_RESULT = "result";
 
     private CodexClientExporter() {
     }
@@ -42,11 +49,37 @@ public final class CodexClientExporter {
         return Path.of(System.getProperty("user.home"), ".codex", "codex.db");
     }
 
+    /**
+     * Exports a v2 session to Codex rollout format.
+     *
+     * @param messages    the conversation messages to export
+     * @param sessionsDir the Codex sessions directory (e.g. {@code ~/.codex/sessions/})
+     * @param dbPath      the Codex SQLite database path (e.g. {@code ~/.codex/codex.db})
+     * @return the thread ID on success, or {@code null} on failure
+     */
     @Nullable
     public static String exportSession(
         @NotNull List<SessionMessage> messages,
         @NotNull Path sessionsDir,
         @NotNull Path dbPath) {
+        return exportSession(messages, sessionsDir, dbPath, null);
+    }
+
+    /**
+     * Exports a v2 session to Codex rollout format with optional working directory.
+     *
+     * @param messages    the conversation messages to export
+     * @param sessionsDir the Codex sessions directory
+     * @param dbPath      the Codex SQLite database path
+     * @param cwd         the working directory to record in the session metadata (nullable)
+     * @return the thread ID on success, or {@code null} on failure
+     */
+    @Nullable
+    public static String exportSession(
+        @NotNull List<SessionMessage> messages,
+        @NotNull Path sessionsDir,
+        @NotNull Path dbPath,
+        @Nullable String cwd) {
         if (messages.isEmpty()) return null;
 
         try {
@@ -55,7 +88,7 @@ public final class CodexClientExporter {
             Files.createDirectories(sessionDir);
 
             Path rolloutFile = sessionDir.resolve("rollout.jsonl");
-            writeRolloutFile(messages, rolloutFile);
+            writeRolloutFile(messages, rolloutFile, threadId, cwd);
 
             if (Files.exists(dbPath)) {
                 insertThread(dbPath, threadId, rolloutFile.toString());
@@ -69,28 +102,70 @@ public final class CodexClientExporter {
         }
     }
 
-    static void writeRolloutFile(@NotNull List<SessionMessage> messages, @NotNull Path rolloutFile) throws IOException {
+    /**
+     * Writes a Codex-format rollout JSONL file.
+     * <p>
+     * Native Codex rollout files start with a {@code session_meta} header line (containing the
+     * thread ID that Codex parses during {@code thread/resume}), followed by content items
+     * wrapped in {@code response_item} envelopes with ISO-8601 timestamps.
+     */
+    static void writeRolloutFile(@NotNull List<SessionMessage> messages, @NotNull Path rolloutFile,
+                                 @NotNull String threadId, @Nullable String cwd) throws IOException {
         StringBuilder sb = new StringBuilder();
+        String timestamp = DateTimeFormatter.ISO_INSTANT.format(Instant.now());
+
+        writeSessionMeta(sb, threadId, timestamp, cwd);
+
         for (SessionMessage msg : messages) {
             if ("separator".equals(msg.role)) continue;
-            convertMessageToRolloutItems(msg, sb);
+            convertMessageToRolloutItems(msg, sb, timestamp);
         }
         Files.writeString(rolloutFile, sb.toString(), StandardCharsets.UTF_8,
             StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
     }
 
-    private static void convertMessageToRolloutItems(@NotNull SessionMessage msg, @NotNull StringBuilder sb) {
+    private static void writeSessionMeta(@NotNull StringBuilder sb, @NotNull String threadId,
+                                         @NotNull String timestamp, @Nullable String cwd) {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("id", threadId);
+        payload.addProperty(F_TIMESTAMP, timestamp);
+        if (cwd != null) {
+            payload.addProperty("cwd", cwd);
+        }
+        payload.addProperty("source", "vscode");
+        payload.addProperty("model_provider", "openai");
+
+        JsonObject meta = new JsonObject();
+        meta.addProperty(F_TIMESTAMP, timestamp);
+        meta.addProperty(F_TYPE, "session_meta");
+        meta.add("payload", payload);
+        sb.append(GSON.toJson(meta)).append('\n');
+    }
+
+    private static void writeResponseItem(@NotNull StringBuilder sb, @NotNull JsonObject item,
+                                          @NotNull String timestamp) {
+        JsonObject envelope = new JsonObject();
+        envelope.addProperty(F_TIMESTAMP, timestamp);
+        envelope.addProperty(F_TYPE, "response_item");
+        envelope.add("payload", item);
+        sb.append(GSON.toJson(envelope)).append('\n');
+    }
+
+    private static void convertMessageToRolloutItems(@NotNull SessionMessage msg,
+                                                     @NotNull StringBuilder sb,
+                                                     @NotNull String timestamp) {
         if ("user".equals(msg.role)) {
-            convertUserMessage(msg, sb);
+            convertUserMessage(msg, sb, timestamp);
         } else if ("assistant".equals(msg.role)) {
-            convertAssistantMessage(msg, sb);
+            convertAssistantMessage(msg, sb, timestamp);
         }
     }
 
-    private static void convertUserMessage(@NotNull SessionMessage msg, @NotNull StringBuilder sb) {
+    private static void convertUserMessage(@NotNull SessionMessage msg, @NotNull StringBuilder sb,
+                                           @NotNull String timestamp) {
         StringBuilder textBuilder = new StringBuilder();
         for (JsonObject part : msg.parts) {
-            String type = JsonlUtil.getStr(part, "type");
+            String type = JsonlUtil.getStr(part, F_TYPE);
             if ("text".equals(type)) {
                 String text = JsonlUtil.getStr(part, "text");
                 if (text != null) textBuilder.append(text);
@@ -98,66 +173,69 @@ public final class CodexClientExporter {
         }
 
         JsonObject item = new JsonObject();
-        item.addProperty("type", "message");
+        item.addProperty(F_TYPE, "message");
         item.addProperty("role", "user");
         JsonArray content = new JsonArray();
         JsonObject inputText = new JsonObject();
-        inputText.addProperty("type", "input_text");
+        inputText.addProperty(F_TYPE, "input_text");
         inputText.addProperty("text", textBuilder.toString());
         content.add(inputText);
-        item.add("content", content);
-        sb.append(GSON.toJson(item)).append('\n');
+        item.add(F_CONTENT, content);
+        writeResponseItem(sb, item, timestamp);
     }
 
-    private static void convertAssistantMessage(@NotNull SessionMessage msg, @NotNull StringBuilder sb) {
+    private static void convertAssistantMessage(@NotNull SessionMessage msg, @NotNull StringBuilder sb,
+                                                @NotNull String timestamp) {
         for (JsonObject part : msg.parts) {
-            String type = JsonlUtil.getStr(part, "type");
+            String type = JsonlUtil.getStr(part, F_TYPE);
             if (type == null) continue;
 
             switch (type) {
-                case "text" -> writeAssistantTextItem(part, sb);
-                case "reasoning" -> writeReasoningItem(part, sb);
-                case "tool-invocation" -> writeToolItems(part, sb);
-                default -> {
-                }
+                case "text" -> writeAssistantTextItem(part, sb, timestamp);
+                case "reasoning" -> writeReasoningItem(part, sb, timestamp);
+                case "tool-invocation" -> writeToolItems(part, sb, timestamp);
+                default -> { /* skip unknown part types */ }
             }
         }
     }
 
-    private static void writeAssistantTextItem(@NotNull JsonObject part, @NotNull StringBuilder sb) {
+    private static void writeAssistantTextItem(@NotNull JsonObject part, @NotNull StringBuilder sb,
+                                               @NotNull String timestamp) {
         String text = JsonlUtil.getStr(part, "text");
         if (text == null || text.isEmpty()) return;
 
         JsonObject item = new JsonObject();
-        item.addProperty("type", "message");
+        item.addProperty(F_TYPE, "message");
         item.addProperty("role", "assistant");
         item.addProperty("id", "resp_" + UUID.randomUUID().toString().substring(0, 8));
         JsonArray content = new JsonArray();
         JsonObject outputText = new JsonObject();
-        outputText.addProperty("type", "output_text");
+        outputText.addProperty(F_TYPE, "output_text");
         outputText.addProperty("text", text);
         content.add(outputText);
-        item.add("content", content);
-        sb.append(GSON.toJson(item)).append('\n');
+        item.add(F_CONTENT, content);
+        writeResponseItem(sb, item, timestamp);
     }
 
-    private static void writeReasoningItem(@NotNull JsonObject part, @NotNull StringBuilder sb) {
+    private static void writeReasoningItem(@NotNull JsonObject part, @NotNull StringBuilder sb,
+                                           @NotNull String timestamp) {
         String text = JsonlUtil.getStr(part, "text");
         if (text == null || text.isEmpty()) return;
 
         JsonObject item = new JsonObject();
-        item.addProperty("type", "reasoning");
+        item.addProperty(F_TYPE, "reasoning");
         item.addProperty("id", "rs_" + UUID.randomUUID().toString().substring(0, 8));
         JsonArray content = new JsonArray();
         JsonObject reasoningText = new JsonObject();
-        reasoningText.addProperty("type", "reasoning_text");
+        reasoningText.addProperty(F_TYPE, "reasoning_text");
         reasoningText.addProperty("text", text);
         content.add(reasoningText);
-        item.add("content", content);
-        sb.append(GSON.toJson(item)).append('\n');
+        item.add(F_CONTENT, content);
+        writeResponseItem(sb, item, timestamp);
     }
 
-    private static void writeToolItems(@NotNull JsonObject part, @NotNull StringBuilder sb) {
+    private static void writeToolItems(@NotNull JsonObject part, @NotNull StringBuilder sb,
+                                       @NotNull String timestamp) {
         JsonObject invocation = part.getAsJsonObject("toolInvocation");
         if (invocation == null) return;
 
@@ -168,25 +246,25 @@ public final class CodexClientExporter {
         String toolName = JsonlUtil.getStr(invocation, "toolName");
         if (toolName == null) toolName = "unknown";
 
-        if ("call".equals(state) || "result".equals(state)) {
+        if ("call".equals(state) || F_RESULT.equals(state)) {
             JsonObject callItem = new JsonObject();
-            callItem.addProperty("type", "function_call");
+            callItem.addProperty(F_TYPE, "function_call");
             callItem.addProperty("call_id", callId);
             callItem.addProperty("name", toolName);
             callItem.addProperty("id", "fc_" + UUID.randomUUID().toString().substring(0, 8));
 
             JsonElement args = invocation.get("args");
             callItem.addProperty("arguments", args != null ? GSON.toJson(args) : "{}");
-            sb.append(GSON.toJson(callItem)).append('\n');
+            writeResponseItem(sb, callItem, timestamp);
         }
 
-        if ("result".equals(state)) {
-            String result = JsonlUtil.getStr(invocation, "result");
+        if (F_RESULT.equals(state)) {
+            String result = JsonlUtil.getStr(invocation, F_RESULT);
             JsonObject outputItem = new JsonObject();
-            outputItem.addProperty("type", "function_call_output");
+            outputItem.addProperty(F_TYPE, "function_call_output");
             outputItem.addProperty("call_id", callId);
             outputItem.addProperty("output", result != null ? result : "");
-            sb.append(GSON.toJson(outputItem)).append('\n');
+            writeResponseItem(sb, outputItem, timestamp);
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/CodexClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/CodexClientExporter.java
@@ -246,7 +246,7 @@ public final class CodexClientExporter {
         if (callId == null) callId = "call_" + UUID.randomUUID().toString().substring(0, 8);
 
         String rawToolName = JsonlUtil.getStr(invocation, "toolName");
-        String toolName = ExporterUtil.sanitizeToolName(rawToolName != null ? rawToolName : "unknown");
+        String toolName = ExporterUtil.normalizeToolNameForCodex(rawToolName != null ? rawToolName : "unknown");
 
         if ("call".equals(state) || F_RESULT.equals(state)) {
             JsonObject callItem = new JsonObject();

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/CodexClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/CodexClientExporter.java
@@ -245,8 +245,8 @@ public final class CodexClientExporter {
         String callId = JsonlUtil.getStr(invocation, "toolCallId");
         if (callId == null) callId = "call_" + UUID.randomUUID().toString().substring(0, 8);
 
-        String toolName = JsonlUtil.getStr(invocation, "toolName");
-        if (toolName == null) toolName = "unknown";
+        String rawToolName = JsonlUtil.getStr(invocation, "toolName");
+        String toolName = ExporterUtil.sanitizeToolName(rawToolName != null ? rawToolName : "unknown");
 
         if ("call".equals(state) || F_RESULT.equals(state)) {
             JsonObject callItem = new JsonObject();

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/CopilotClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/CopilotClientExporter.java
@@ -213,8 +213,8 @@ public final class CopilotClientExporter {
         String state = JsonlUtil.getStr(invocation, "state");
         String toolCallId = JsonlUtil.getStr(invocation, TOOL_CALL_ID_KEY);
         if (toolCallId == null) toolCallId = UUID.randomUUID().toString();
-        String toolName = JsonlUtil.getStr(invocation, "toolName");
-        if (toolName == null) toolName = "unknown";
+        String rawToolName = JsonlUtil.getStr(invocation, "toolName");
+        String toolName = ExporterUtil.sanitizeToolName(rawToolName != null ? rawToolName : "unknown");
         String argsStr = JsonlUtil.getStr(invocation, "args");
 
         if ("call".equals(state) || RESULT_KEY.equals(state)) {

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/ExporterUtil.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/ExporterUtil.java
@@ -12,6 +12,9 @@ public final class ExporterUtil {
     private static final int MAX_TOOL_NAME_LENGTH = 200;
     private static final Pattern INVALID_TOOL_NAME_CHARS = Pattern.compile("[^a-zA-Z0-9_-]");
     private static final Pattern CONSECUTIVE_UNDERSCORES = Pattern.compile("_{3,}");
+    private static final String AGENTBRIDGE_DASH = "agentbridge-";
+    private static final String AGENTBRIDGE_UNDERSCORE = "agentbridge_";
+    private static final String AGENTBRIDGE_KIRO = "@agentbridge/";
 
     private ExporterUtil() {
     }
@@ -33,5 +36,37 @@ public final class ExporterUtil {
         if (sanitized.endsWith("_")) sanitized = sanitized.substring(0, sanitized.length() - 1);
         if (sanitized.length() > MAX_TOOL_NAME_LENGTH) sanitized = sanitized.substring(0, MAX_TOOL_NAME_LENGTH);
         return sanitized.isEmpty() ? "unknown_tool" : sanitized;
+    }
+
+    /**
+     * Normalizes a tool name for Codex rollout export by ensuring it starts with
+     * {@code agentbridge_}.
+     *
+     * <p><b>Why extracted:</b> Codex presents MCP tools to the model with the server name
+     * as a prefix (e.g., {@code agentbridge_read_file}). The exported rollout must use the
+     * same names so the model recognizes them as the same tools after session restore.
+     * Different clients use different prefix conventions:</p>
+     * <ul>
+     *   <li>Copilot: {@code agentbridge-read_file} (dash separator)</li>
+     *   <li>Codex/OpenCode: {@code agentbridge_read_file} (underscore separator)</li>
+     *   <li>Kiro: {@code @agentbridge/read_file} (at-sign + slash)</li>
+     *   <li>Claude: {@code read_file} (no prefix)</li>
+     * </ul>
+     *
+     * <p>This method strips any existing prefix and adds the canonical
+     * {@code agentbridge_} prefix that Codex expects.</p>
+     */
+    @NotNull
+    public static String normalizeToolNameForCodex(@NotNull String rawName) {
+        String base = rawName;
+        if (base.startsWith(AGENTBRIDGE_DASH)) {
+            base = base.substring(AGENTBRIDGE_DASH.length());
+        } else if (base.startsWith(AGENTBRIDGE_UNDERSCORE)) {
+            base = base.substring(AGENTBRIDGE_UNDERSCORE.length());
+        } else if (base.startsWith(AGENTBRIDGE_KIRO)) {
+            base = base.substring(AGENTBRIDGE_KIRO.length());
+        }
+        String sanitized = sanitizeToolName(base);
+        return AGENTBRIDGE_UNDERSCORE + sanitized;
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/ExporterUtil.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/ExporterUtil.java
@@ -1,0 +1,37 @@
+package com.github.catatafishen.ideagentforcopilot.session.exporters;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Pattern;
+
+/**
+ * Shared utilities for session exporters.
+ */
+public final class ExporterUtil {
+
+    private static final int MAX_TOOL_NAME_LENGTH = 200;
+    private static final Pattern INVALID_TOOL_NAME_CHARS = Pattern.compile("[^a-zA-Z0-9_-]");
+    private static final Pattern CONSECUTIVE_UNDERSCORES = Pattern.compile("_{3,}");
+
+    private ExporterUtil() {
+    }
+
+    /**
+     * Sanitizes a tool name for APIs that require names to match {@code [a-zA-Z0-9_-]+}
+     * (OpenAI Responses API, Anthropic API, etc.).
+     *
+     * <p>Session data stores human-readable titles for tool calls (e.g., "git add src/Foo.java",
+     * "Check for public console APIs") which contain spaces and other invalid characters.
+     * This method replaces invalid characters with underscores, collapses runs of 3+
+     * underscores (preserving the {@code __} MCP separator convention), and truncates to fit.</p>
+     */
+    public static String sanitizeToolName(@NotNull String rawName) {
+        if (rawName.isEmpty()) return "unknown_tool";
+        String sanitized = INVALID_TOOL_NAME_CHARS.matcher(rawName).replaceAll("_");
+        sanitized = CONSECUTIVE_UNDERSCORES.matcher(sanitized).replaceAll("__");
+        if (sanitized.startsWith("_")) sanitized = sanitized.substring(1);
+        if (sanitized.endsWith("_")) sanitized = sanitized.substring(0, sanitized.length() - 1);
+        if (sanitized.length() > MAX_TOOL_NAME_LENGTH) sanitized = sanitized.substring(0, MAX_TOOL_NAME_LENGTH);
+        return sanitized.isEmpty() ? "unknown_tool" : sanitized;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/KiroClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/KiroClientExporter.java
@@ -392,7 +392,7 @@ public final class KiroClientExporter {
         if (!STATE_RESULT.equals(state)) return null;
 
         String toolCallId = inv.has("toolCallId") ? inv.get("toolCallId").getAsString() : UUID.randomUUID().toString();
-        String toolName = AnthropicClientExporter.sanitizeToolName(
+        String toolName = ExporterUtil.sanitizeToolName(
             inv.has(KEY_TOOL_NAME) ? inv.get(KEY_TOOL_NAME).getAsString() : "unknown");
         String argsStr = inv.has("args") ? inv.get("args").getAsString() : "{}";
         String resultStr = inv.has(STATE_RESULT) ? inv.get(STATE_RESULT).getAsString() : "";

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/OpenCodeClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/exporters/OpenCodeClientExporter.java
@@ -559,7 +559,8 @@ public final class OpenCodeClientExporter {
 
                 result.addProperty("type", "tool");
                 result.addProperty("callID", toolCallId != null ? toolCallId : "");
-                result.addProperty("tool", toolName != null ? toolName : "unknown");
+                result.addProperty("tool", ExporterUtil.sanitizeToolName(
+                    toolName != null ? toolName : "unknown"));
 
                 JsonObject stateObj = new JsonObject();
                 stateObj.addProperty("status",

--- a/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/importers/CodexClientImporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/ideagentforcopilot/session/importers/CodexClientImporter.java
@@ -13,8 +13,16 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.sql.*;
-import java.util.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 public final class CodexClientImporter {
 
@@ -58,7 +66,7 @@ public final class CodexClientImporter {
              Statement stmt = conn.createStatement()) {
             stmt.execute("PRAGMA journal_mode=WAL");
             try (ResultSet rs = stmt.executeQuery(
-                    "SELECT rollout_path FROM threads WHERE archived = 0 ORDER BY updated_at DESC LIMIT 1")) {
+                "SELECT rollout_path FROM threads WHERE archived = 0 ORDER BY updated_at DESC LIMIT 1")) {
                 if (rs.next()) {
                     return rs.getString("rollout_path");
                 }
@@ -104,11 +112,23 @@ public final class CodexClientImporter {
             String type = JsonlUtil.getStr(item, "type");
             if (type == null) continue;
 
+            // Unwrap response_item envelopes (native Codex format wraps items in these)
+            if ("response_item".equals(type)) {
+                JsonObject payload = item.getAsJsonObject("payload");
+                if (payload == null) continue;
+                item = payload;
+                type = JsonlUtil.getStr(item, "type");
+                if (type == null) continue;
+            }
+
             switch (type) {
                 case "message" -> handleMessage(item, messages, pendingAssistantParts, now);
                 case "function_call" -> handleFunctionCall(item, pendingAssistantParts, pendingCalls);
                 case "function_call_output" -> handleFunctionCallOutput(item, pendingAssistantParts, pendingCalls);
                 case "reasoning" -> handleReasoning(item, pendingAssistantParts);
+                // session_meta, event_msg, turn_context are metadata — skip silently
+                case "session_meta", "event_msg", "turn_context" -> {
+                }
                 default -> LOG.debug("Skipping unknown Codex rollout item type: " + type);
             }
         }
@@ -118,10 +138,10 @@ public final class CodexClientImporter {
     }
 
     private static void handleMessage(
-            @NotNull JsonObject item,
-            @NotNull List<SessionMessage> messages,
-            @NotNull List<JsonObject> pendingAssistantParts,
-            long now
+        @NotNull JsonObject item,
+        @NotNull List<SessionMessage> messages,
+        @NotNull List<JsonObject> pendingAssistantParts,
+        long now
     ) {
         String role = JsonlUtil.getStr(item, "role");
         if ("user".equals(role)) {
@@ -132,7 +152,7 @@ public final class CodexClientImporter {
             textPart.addProperty("type", "text");
             textPart.addProperty("text", text != null ? text : "");
             messages.add(new SessionMessage(
-                    UUID.randomUUID().toString(), "user", List.of(textPart), now, null, null));
+                UUID.randomUUID().toString(), "user", List.of(textPart), now, null, null));
         } else if ("assistant".equals(role)) {
             String text = extractContentText(item);
             if (text != null && !text.isEmpty()) {
@@ -145,9 +165,9 @@ public final class CodexClientImporter {
     }
 
     private static void handleFunctionCall(
-            @NotNull JsonObject item,
-            @NotNull List<JsonObject> pendingAssistantParts,
-            @NotNull Map<String, JsonObject> pendingCalls
+        @NotNull JsonObject item,
+        @NotNull List<JsonObject> pendingAssistantParts,
+        @NotNull Map<String, JsonObject> pendingCalls
     ) {
         String callId = JsonlUtil.getStr(item, "call_id");
         String name = JsonlUtil.getStr(item, "name");
@@ -178,9 +198,9 @@ public final class CodexClientImporter {
     }
 
     private static void handleFunctionCallOutput(
-            @NotNull JsonObject item,
-            @NotNull List<JsonObject> pendingAssistantParts,
-            @NotNull Map<String, JsonObject> pendingCalls
+        @NotNull JsonObject item,
+        @NotNull List<JsonObject> pendingAssistantParts,
+        @NotNull Map<String, JsonObject> pendingCalls
     ) {
         String callId = JsonlUtil.getStr(item, "call_id");
         String output = JsonlUtil.getStr(item, "output");
@@ -208,8 +228,8 @@ public final class CodexClientImporter {
     }
 
     private static void handleReasoning(
-            @NotNull JsonObject item,
-            @NotNull List<JsonObject> pendingAssistantParts
+        @NotNull JsonObject item,
+        @NotNull List<JsonObject> pendingAssistantParts
     ) {
         JsonArray content = item.getAsJsonArray("content");
         if (content == null) return;
@@ -233,13 +253,13 @@ public final class CodexClientImporter {
     }
 
     private static void flushAssistantParts(
-            @NotNull List<JsonObject> parts,
-            @NotNull List<SessionMessage> messages,
-            long now
+        @NotNull List<JsonObject> parts,
+        @NotNull List<SessionMessage> messages,
+        long now
     ) {
         if (parts.isEmpty()) return;
         messages.add(new SessionMessage(
-                UUID.randomUUID().toString(), "assistant", List.copyOf(parts), now, "Codex", null));
+            UUID.randomUUID().toString(), "assistant", List.copyOf(parts), now, "Codex", null));
         parts.clear();
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/ideagentforcopilot/session/AnthropicClientRoundTripTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/ideagentforcopilot/session/AnthropicClientRoundTripTest.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.ideagentforcopilot.session;
 
 import com.github.catatafishen.ideagentforcopilot.session.exporters.AnthropicClientExporter;
+import com.github.catatafishen.ideagentforcopilot.session.exporters.ExporterUtil;
 import com.github.catatafishen.ideagentforcopilot.session.importers.AnthropicClientImporter;
 import com.github.catatafishen.ideagentforcopilot.session.v2.SessionMessage;
 import com.google.gson.JsonObject;
@@ -650,7 +651,7 @@ class AnthropicClientRoundTripTest {
     @Test
     void sanitizeToolNameTruncatesLongNames() {
         String longName = "git add " + "a/".repeat(200) + "Foo.java";
-        String sanitized = AnthropicClientExporter.sanitizeToolName(longName);
+        String sanitized = ExporterUtil.sanitizeToolName(longName);
         assertTrue(sanitized.length() <= 200,
             "Sanitized name should be at most 200 chars, was " + sanitized.length());
         assertFalse(sanitized.contains(" "), "Sanitized name should not contain spaces");
@@ -658,24 +659,24 @@ class AnthropicClientRoundTripTest {
 
     @Test
     void sanitizeToolNamePreservesValidNames() {
-        assertEquals("read_file", AnthropicClientExporter.sanitizeToolName("read_file"));
+        assertEquals("read_file", ExporterUtil.sanitizeToolName("read_file"));
         assertEquals("mcp__agentbridge__read_file",
-            AnthropicClientExporter.sanitizeToolName("mcp__agentbridge__read_file"));
+            ExporterUtil.sanitizeToolName("mcp__agentbridge__read_file"));
     }
 
     @Test
     void sanitizeToolNameReplacesInvalidChars() {
         assertEquals("git_add_src_Foo-java",
-            AnthropicClientExporter.sanitizeToolName("git add src/Foo-java"));
+            ExporterUtil.sanitizeToolName("git add src/Foo-java"));
         assertEquals("Viewing__ChatConsolePanel_kt",
-            AnthropicClientExporter.sanitizeToolName("Viewing .../ChatConsolePanel.kt"));
+            ExporterUtil.sanitizeToolName("Viewing .../ChatConsolePanel.kt"));
     }
 
     @Test
     void sanitizeToolNameHandlesEdgeCases() {
-        assertEquals("unknown_tool", AnthropicClientExporter.sanitizeToolName(""));
-        assertEquals("unknown_tool", AnthropicClientExporter.sanitizeToolName("..."));
-        assertEquals("a", AnthropicClientExporter.sanitizeToolName("a"));
+        assertEquals("unknown_tool", ExporterUtil.sanitizeToolName(""));
+        assertEquals("unknown_tool", ExporterUtil.sanitizeToolName("..."));
+        assertEquals("a", ExporterUtil.sanitizeToolName("a"));
     }
 
     private static String extractText(SessionMessage msg) {

--- a/plugin-core/src/test/java/com/github/catatafishen/ideagentforcopilot/session/CodexClientRoundTripTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/ideagentforcopilot/session/CodexClientRoundTripTest.java
@@ -151,6 +151,8 @@ class CodexClientRoundTripTest {
         JsonObject payload = firstLine.getAsJsonObject("payload");
         assertEquals(threadId, payload.get("id").getAsString());
         assertEquals("/test/cwd", payload.get("cwd").getAsString());
+        assertEquals("intellij-copilot-plugin", payload.get("originator").getAsString());
+        assertEquals("0.0.0", payload.get("cli_version").getAsString());
 
         // Content lines must be wrapped in response_item envelopes
         JsonObject secondLine = new Gson().fromJson(lines.get(1), JsonObject.class);

--- a/plugin-core/src/test/java/com/github/catatafishen/ideagentforcopilot/session/CodexClientRoundTripTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/ideagentforcopilot/session/CodexClientRoundTripTest.java
@@ -18,7 +18,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -251,6 +250,8 @@ class CodexClientRoundTripTest {
         String content = Files.readString(sessionsDir.resolve(threadId).resolve("rollout.jsonl"));
         assertTrue(content.contains("\"type\":\"function_call\""));
         assertTrue(content.contains("\"call_id\":\"call_1\""));
+        assertTrue(content.contains("\"name\":\"agentbridge_read_file\""),
+            "Tool name should be prefixed with agentbridge_ for Codex: " + content);
         assertTrue(content.contains("\"type\":\"function_call_output\""));
     }
 
@@ -272,8 +273,8 @@ class CodexClientRoundTripTest {
         assertNotNull(threadId);
 
         String content = Files.readString(sessionsDir.resolve(threadId).resolve("rollout.jsonl"));
-        assertTrue(content.contains("\"name\":\"Check_for_public_console_APIs\""),
-            "Tool name should have spaces replaced with underscores: " + content);
+        assertTrue(content.contains("\"name\":\"agentbridge_Check_for_public_console_APIs\""),
+            "Tool name should be prefixed with agentbridge_ and have spaces replaced: " + content);
         assertFalse(content.contains("\"name\":\"Check for public console APIs\""),
             "Tool name should not contain raw spaces");
     }
@@ -296,9 +297,8 @@ class CodexClientRoundTripTest {
         String content = Files.readString(sessionsDir.resolve(threadId).resolve("rollout.jsonl"));
         assertFalse(content.contains("\"name\":\"Viewing .../ChatConsolePanel.kt\""),
             "Tool name should not contain raw dots/slashes");
-        Pattern validName = Pattern.compile("\"name\":\"[a-zA-Z0-9_-]+\"");
-        assertTrue(validName.matcher(content).find(),
-            "Function call name should match ^[a-zA-Z0-9_-]+$");
+        assertTrue(content.contains("\"name\":\"agentbridge_Viewing__ChatConsolePanel_kt\""),
+            "Tool name should be prefixed and sanitized: " + content);
     }
 
     @Test
@@ -411,7 +411,7 @@ class CodexClientRoundTripTest {
                 foundTool = true;
                 JsonObject inv = part.getAsJsonObject("toolInvocation");
                 assertEquals("result", inv.get("state").getAsString());
-                assertEquals("read_file", inv.get("toolName").getAsString());
+                assertEquals("agentbridge_read_file", inv.get("toolName").getAsString());
                 assertEquals("file data", inv.get("result").getAsString());
             }
         }

--- a/plugin-core/src/test/java/com/github/catatafishen/ideagentforcopilot/session/CodexClientRoundTripTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/ideagentforcopilot/session/CodexClientRoundTripTest.java
@@ -3,6 +3,7 @@ package com.github.catatafishen.ideagentforcopilot.session;
 import com.github.catatafishen.ideagentforcopilot.session.exporters.CodexClientExporter;
 import com.github.catatafishen.ideagentforcopilot.session.importers.CodexClientImporter;
 import com.github.catatafishen.ideagentforcopilot.session.v2.SessionMessage;
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -126,6 +127,57 @@ class CodexClientRoundTripTest {
     }
 
     @Test
+    void exportRolloutStartsWithSessionMeta() throws IOException, SQLException {
+        List<SessionMessage> messages = List.of(
+            userMessage("Hello"),
+            assistantMessage("World")
+        );
+
+        Path sessionsDir = tempDir.resolve("sessions-meta");
+        Path dbPath = tempDir.resolve("codex-meta.db");
+        createThreadsTable(dbPath);
+
+        String threadId = CodexClientExporter.exportSession(messages, sessionsDir, dbPath, "/test/cwd");
+        assertNotNull(threadId);
+
+        Path rolloutFile = sessionsDir.resolve(threadId).resolve("rollout.jsonl");
+        List<String> lines = Files.readAllLines(rolloutFile, StandardCharsets.UTF_8);
+        assertTrue(lines.size() >= 3, "Should have session_meta + at least 2 items");
+
+        // First line must be session_meta with the thread ID
+        JsonObject firstLine = new Gson().fromJson(lines.getFirst(), JsonObject.class);
+        assertEquals("session_meta", firstLine.get("type").getAsString());
+        assertTrue(firstLine.has("timestamp"), "session_meta must have timestamp");
+        JsonObject payload = firstLine.getAsJsonObject("payload");
+        assertEquals(threadId, payload.get("id").getAsString());
+        assertEquals("/test/cwd", payload.get("cwd").getAsString());
+
+        // Content lines must be wrapped in response_item envelopes
+        JsonObject secondLine = new Gson().fromJson(lines.get(1), JsonObject.class);
+        assertEquals("response_item", secondLine.get("type").getAsString());
+        assertTrue(secondLine.has("timestamp"), "response_item must have timestamp");
+        JsonObject itemPayload = secondLine.getAsJsonObject("payload");
+        assertEquals("message", itemPayload.get("type").getAsString());
+        assertEquals("user", itemPayload.get("role").getAsString());
+    }
+
+    @Test
+    void importHandlesResponseItemEnvelopes() throws IOException {
+        Path rollout = writeRollout(
+            "{\"timestamp\":\"2026-01-01T00:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"test-thread\"}}",
+            "{\"timestamp\":\"2026-01-01T00:00:00Z\",\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"Wrapped hello\"}]}}",
+            "{\"timestamp\":\"2026-01-01T00:00:00Z\",\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Wrapped response\"}]}}"
+        );
+
+        List<SessionMessage> messages = CodexClientImporter.importRolloutFile(rollout);
+        assertEquals(2, messages.size());
+        assertEquals("user", messages.get(0).role);
+        assertEquals("Wrapped hello", extractText(messages.get(0)));
+        assertEquals("assistant", messages.get(1).role);
+        assertEquals("Wrapped response", extractText(messages.get(1)));
+    }
+
+    @Test
     void importUnmatchedFunctionCallOutputCreatesOrphanPart() throws IOException {
         Path rollout = writeRollout(
             "{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"Go\"}]}",
@@ -233,7 +285,7 @@ class CodexClientRoundTripTest {
 
         List<SessionMessage> messages = CodexClientImporter.importLatestThread(dbPath);
         assertEquals(1, messages.size());
-        assertEquals("New", extractText(messages.get(0)));
+        assertEquals("New", extractText(messages.getFirst()));
     }
 
     @Test
@@ -259,7 +311,7 @@ class CodexClientRoundTripTest {
     // ── Round-trip tests ────────────────────────────────────────────
 
     @Test
-    void roundTripPreservesTextContent() throws IOException, SQLException {
+    void roundTripPreservesTextContent() throws SQLException {
         List<SessionMessage> original = List.of(
             userMessage("What is Rust?"),
             assistantMessage("A systems language.")
@@ -281,7 +333,7 @@ class CodexClientRoundTripTest {
     }
 
     @Test
-    void roundTripPreservesToolCalls() throws IOException, SQLException {
+    void roundTripPreservesToolCalls() throws SQLException {
         JsonObject textPart = textPart("Reading file");
         JsonObject toolPart = toolInvocationPart("call_1", "read_file", "{\"path\":\"/a\"}", "file data");
 
@@ -318,7 +370,7 @@ class CodexClientRoundTripTest {
     }
 
     @Test
-    void roundTripPreservesReasoning() throws IOException, SQLException {
+    void roundTripPreservesReasoning() throws SQLException {
         JsonObject reasoning = new JsonObject();
         reasoning.addProperty("type", "reasoning");
         reasoning.addProperty("text", "Let me think...");

--- a/plugin-core/src/test/java/com/github/catatafishen/ideagentforcopilot/session/CodexClientRoundTripTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/ideagentforcopilot/session/CodexClientRoundTripTest.java
@@ -18,8 +18,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -253,6 +255,51 @@ class CodexClientRoundTripTest {
     }
 
     // ── SQLite import tests ─────────────────────────────────────────
+
+    @Test
+    void exportSanitizesToolNamesWithSpaces() throws IOException, SQLException {
+        JsonObject toolPart = toolInvocationPart(
+            "call_1", "Check for public console APIs", "{}", "found it");
+        SessionMessage assistant = new SessionMessage(
+            "a1", "assistant", List.of(toolPart), System.currentTimeMillis(), null, null);
+
+        Path sessionsDir = tempDir.resolve("sessions");
+        Path dbPath = tempDir.resolve("codex.db");
+        createThreadsTable(dbPath);
+
+        String threadId = CodexClientExporter.exportSession(
+            List.of(userMessage("check"), assistant), sessionsDir, dbPath);
+        assertNotNull(threadId);
+
+        String content = Files.readString(sessionsDir.resolve(threadId).resolve("rollout.jsonl"));
+        assertTrue(content.contains("\"name\":\"Check_for_public_console_APIs\""),
+            "Tool name should have spaces replaced with underscores: " + content);
+        assertFalse(content.contains("\"name\":\"Check for public console APIs\""),
+            "Tool name should not contain raw spaces");
+    }
+
+    @Test
+    void exportSanitizesToolNamesWithSlashesAndDots() throws IOException, SQLException {
+        JsonObject toolPart = toolInvocationPart(
+            "call_1", "Viewing .../ChatConsolePanel.kt", "{}", "data");
+        SessionMessage assistant = new SessionMessage(
+            "a1", "assistant", List.of(toolPart), System.currentTimeMillis(), null, null);
+
+        Path sessionsDir = tempDir.resolve("sessions");
+        Path dbPath = tempDir.resolve("codex.db");
+        createThreadsTable(dbPath);
+
+        String threadId = CodexClientExporter.exportSession(
+            List.of(userMessage("view"), assistant), sessionsDir, dbPath);
+        assertNotNull(threadId);
+
+        String content = Files.readString(sessionsDir.resolve(threadId).resolve("rollout.jsonl"));
+        assertFalse(content.contains("\"name\":\"Viewing .../ChatConsolePanel.kt\""),
+            "Tool name should not contain raw dots/slashes");
+        Pattern validName = Pattern.compile("\"name\":\"[a-zA-Z0-9_-]+\"");
+        assertTrue(validName.matcher(content).find(),
+            "Function call name should match ^[a-zA-Z0-9_-]+$");
+    }
 
     @Test
     void importLatestThreadReadsFromDb() throws IOException, SQLException {


### PR DESCRIPTION
Fixes tool name matching for Codex rollout sessions:\n- Prefix Codex rollout tool names with agentbridge_ to match MCP registration\n- Sanitize tool names in all session exporters\n- Add required originator and cli_version to Codex rollout session_meta