### PR TITLE
fix: port Codex session format fixes to master

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
@@ -34,7 +34,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.intellij.ide.util.PropertiesComponent;
-import com.intellij.notification.NotificationGroupManager;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -569,18 +568,16 @@ public abstract class AcpClient extends AbstractAgentClient {
         }
 
         com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater(() ->
-            NotificationGroupManager.getInstance()
-                .getNotificationGroup("AgentBridge Notifications")
-                .createNotification(
-                    displayName() + " session resume not available",
-                    "Session load was requested but " + displayName() + " could not resume session "
-                        + requestedId + ". "
-                        + "Conversation history injection has been enabled as a fallback — "
-                        + "a compressed summary of the previous session will be prepended to "
-                        + "your first prompt. You can configure this in "
-                        + "Settings → AgentBridge → Chat History.",
-                    NotificationType.INFORMATION)
-                .notify(project));
+            com.github.catatafishen.agentbridge.psi.PlatformApiCompat.showNotification(
+                project,
+                displayName() + " session resume not available",
+                "Session load was requested but " + displayName() + " could not resume session "
+                    + requestedId + ". "
+                    + "Conversation history injection has been enabled as a fallback — "
+                    + "a compressed summary of the previous session will be prepended to "
+                    + "your first prompt. You can configure this in "
+                    + "Settings → AgentBridge → Chat History.",
+                NotificationType.INFORMATION));
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/codex/CodexAppServerClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/codex/CodexAppServerClient.java
@@ -634,6 +634,13 @@ public final class CodexAppServerClient extends AbstractAgentClient {
             } catch (AgentException e) {
                 LOG.warn("thread/resume failed (thread may be expired), starting new thread: " + e.getMessage());
                 persistCodexThreadId(null);
+                com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater(() ->
+                    com.github.catatafishen.agentbridge.psi.PlatformApiCompat.showNotification(
+                        project,
+                        "Codex session resume failed",
+                        "Could not resume the previous Codex thread (it may have expired). "
+                            + "A new thread will be started. Previous conversation context will not be restored.",
+                        com.intellij.notification.NotificationType.WARNING));
             }
         }
         return startThread(sessionId, model);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
@@ -325,7 +325,34 @@ public final class PlatformApiCompat {
     }
 
     /**
-     * Creates a JCEF load handler that calls the given callback when the main frame finishes loading.
+     * Shows an IDE balloon notification in the "AgentBridge Notifications" group.
+     *
+     * <p><b>Why extracted:</b> {@code NotificationGroup.createNotification(String, String, NotificationType)}
+     * — the 3-argument overload with a content string — is not resolved by the IDE daemon when the
+     * development IDE version differs from the target SDK. The method exists in both the minimum and
+     * maximum supported IDE versions (2024.3–2025.2) and the Gradle build compiles cleanly; the error
+     * is a false positive in the editor. Centralising all notification creation here eliminates the
+     * daemon error from every caller.</p>
+     *
+     * <p>Must be called on the EDT. Wrap with {@code invokeLater} if calling from a background thread.</p>
+     *
+     * @param project the project to scope the notification to (may be null for app-level notifications)
+     * @param title   notification balloon title
+     * @param content notification body text (HTML is supported)
+     * @param type    notification type (INFO, WARNING, or ERROR)
+     */
+    public static void showNotification(
+        @Nullable Project project,
+        @NotNull String title,
+        @NotNull String content,
+        @NotNull com.intellij.notification.NotificationType type) {
+        com.intellij.notification.NotificationGroupManager.getInstance()
+            .getNotificationGroup("AgentBridge Notifications")
+            .createNotification(title, content, type)
+            .notify(project);
+    }
+
+    /**
      *
      * <p><b>Why extracted:</b> {@code CefLoadHandlerAdapter} provides default implementations for all
      * {@code CefLoadHandler} methods, but the JCEF version bundled with the dev IDE may declare

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/SessionSwitchService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/SessionSwitchService.java
@@ -354,7 +354,7 @@ public final class SessionSwitchService implements Disposable {
     private void exportToCodex(@NotNull List<EntryData> entries, @Nullable String basePath) {
         Path sessionsDir = CodexClientExporter.defaultSessionsDir();
         Path dbPath = CodexClientExporter.defaultDbPath();
-        String threadId = CodexClientExporter.exportSession(entries, sessionsDir, dbPath);
+        String threadId = CodexClientExporter.exportSession(entries, sessionsDir, dbPath, basePath);
         if (threadId != null) {
             // Set the thread ID so CodexAppServerClient will try thread/resume on next startup
             PropertiesComponent.getInstance(project)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/CodexClientExporter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/CodexClientExporter.java
@@ -28,6 +28,10 @@ public final class CodexClientExporter {
     private static final Logger LOG = Logger.getInstance(CodexClientExporter.class);
     private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
 
+    private static final String F_TYPE = "type";
+    private static final String F_CONTENT = "content";
+    private static final String F_TIMESTAMP = "timestamp";
+
     private CodexClientExporter() {
     }
 
@@ -46,6 +50,15 @@ public final class CodexClientExporter {
         @NotNull List<EntryData> entries,
         @NotNull Path sessionsDir,
         @NotNull Path dbPath) {
+        return exportSession(entries, sessionsDir, dbPath, null);
+    }
+
+    @Nullable
+    public static String exportSession(
+        @NotNull List<EntryData> entries,
+        @NotNull Path sessionsDir,
+        @NotNull Path dbPath,
+        @Nullable String cwd) {
         if (entries.isEmpty() || entries.stream().noneMatch(e -> e instanceof EntryData.Prompt)) return null;
 
         try {
@@ -54,7 +67,7 @@ public final class CodexClientExporter {
             Files.createDirectories(sessionDir);
 
             Path rolloutFile = sessionDir.resolve("rollout.jsonl");
-            writeRolloutFile(entries, rolloutFile);
+            writeRolloutFile(entries, rolloutFile, threadId, cwd);
 
             long createdAt = System.currentTimeMillis() / 1000;
             for (EntryData entry : entries) {
@@ -81,67 +94,134 @@ public final class CodexClientExporter {
         }
     }
 
+    /**
+     * Writes a rollout JSONL file for testing. A random thread ID is generated and cwd is null.
+     * Use {@link #writeRolloutFile(List, Path, String, String)} when the thread ID and cwd are known.
+     */
     static void writeRolloutFile(@NotNull List<EntryData> entries, @NotNull Path rolloutFile) throws IOException {
+        writeRolloutFile(entries, rolloutFile, UUID.randomUUID().toString(), null);
+    }
+
+    /**
+     * Writes a native Codex rollout JSONL file.
+     *
+     * <p>Format: a {@code session_meta} header line, followed by each content item wrapped in a
+     * {@code response_item} envelope. This matches the format expected by {@code codex thread/resume}.</p>
+     */
+    static void writeRolloutFile(
+        @NotNull List<EntryData> entries,
+        @NotNull Path rolloutFile,
+        @NotNull String threadId,
+        @Nullable String cwd) throws IOException {
         StringBuilder sb = new StringBuilder();
+        String timestamp = Instant.now().toString();
+
+        writeSessionMeta(sb, threadId, timestamp, cwd);
+
         for (EntryData entry : entries) {
-            if (entry instanceof EntryData.Prompt prompt) {
-                JsonObject item = new JsonObject();
-                item.addProperty("type", "message");
-                item.addProperty("role", "user");
-                JsonArray content = new JsonArray();
-                JsonObject inputText = new JsonObject();
-                inputText.addProperty("type", "input_text");
-                inputText.addProperty("text", prompt.getText());
-                content.add(inputText);
-                item.add("content", content);
-                sb.append(GSON.toJson(item)).append('\n');
-            } else if (entry instanceof EntryData.Text text) {
-                String raw = text.getRaw();
-                if (!raw.isEmpty()) {
-                    JsonObject item = new JsonObject();
-                    item.addProperty("type", "message");
-                    item.addProperty("role", "assistant");
-                    JsonArray content = new JsonArray();
-                    JsonObject outputText = new JsonObject();
-                    outputText.addProperty("type", "output_text");
-                    outputText.addProperty("text", raw);
-                    content.add(outputText);
-                    item.add("content", content);
-                    sb.append(GSON.toJson(item)).append('\n');
-                }
-            } else if (entry instanceof EntryData.Thinking thinking) {
-                String raw = thinking.getRaw();
-                if (!raw.isEmpty()) {
-                    JsonObject item = new JsonObject();
-                    item.addProperty("type", "reasoning");
-                    JsonArray content = new JsonArray();
-                    JsonObject reasoningText = new JsonObject();
-                    reasoningText.addProperty("type", "reasoning_text");
-                    reasoningText.addProperty("text", raw);
-                    content.add(reasoningText);
-                    item.add("content", content);
-                    sb.append(GSON.toJson(item)).append('\n');
-                }
-            } else if (entry instanceof EntryData.ToolCall toolCall) {
-                String callId = UUID.randomUUID().toString();
-
-                JsonObject callItem = new JsonObject();
-                callItem.addProperty("type", "function_call");
-                callItem.addProperty("call_id", callId);
-                callItem.addProperty("name", toolCall.getTitle());
-                callItem.addProperty("arguments", toolCall.getArguments() != null ? toolCall.getArguments() : "{}");
-                sb.append(GSON.toJson(callItem)).append('\n');
-
-                JsonObject outputItem = new JsonObject();
-                outputItem.addProperty("type", "function_call_output");
-                outputItem.addProperty("call_id", callId);
-                outputItem.addProperty("output", toolCall.getResult() != null ? toolCall.getResult() : "");
-                sb.append(GSON.toJson(outputItem)).append('\n');
-            }
-            // Skip SubAgent, Status, TurnStats, ContextFiles, SessionSeparator
+            writeEntryItem(entry, sb, timestamp);
         }
         Files.writeString(rolloutFile, sb.toString(), StandardCharsets.UTF_8,
             StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    private static void writeEntryItem(
+        @NotNull EntryData entry,
+        @NotNull StringBuilder sb,
+        @NotNull String timestamp) {
+        switch (entry) {
+            case EntryData.Prompt prompt -> {
+                JsonObject item = new JsonObject();
+                item.addProperty(F_TYPE, "message");
+                item.addProperty("role", "user");
+                JsonArray content = new JsonArray();
+                JsonObject inputText = new JsonObject();
+                inputText.addProperty(F_TYPE, "input_text");
+                inputText.addProperty("text", prompt.getText());
+                content.add(inputText);
+                item.add(F_CONTENT, content);
+                writeResponseItem(sb, item, timestamp);
+            }
+            case EntryData.Text text -> {
+                String raw = text.getRaw();
+                if (!raw.isEmpty()) {
+                    JsonObject item = new JsonObject();
+                    item.addProperty(F_TYPE, "message");
+                    item.addProperty("role", "assistant");
+                    JsonArray content = new JsonArray();
+                    JsonObject outputText = new JsonObject();
+                    outputText.addProperty(F_TYPE, "output_text");
+                    outputText.addProperty("text", raw);
+                    content.add(outputText);
+                    item.add(F_CONTENT, content);
+                    writeResponseItem(sb, item, timestamp);
+                }
+            }
+            case EntryData.Thinking thinking -> {
+                String raw = thinking.getRaw();
+                if (!raw.isEmpty()) {
+                    JsonObject item = new JsonObject();
+                    item.addProperty(F_TYPE, "reasoning");
+                    JsonArray content = new JsonArray();
+                    JsonObject reasoningText = new JsonObject();
+                    reasoningText.addProperty(F_TYPE, "reasoning_text");
+                    reasoningText.addProperty("text", raw);
+                    content.add(reasoningText);
+                    item.add(F_CONTENT, content);
+                    writeResponseItem(sb, item, timestamp);
+                }
+            }
+            case EntryData.ToolCall toolCall -> {
+                String callId = UUID.randomUUID().toString();
+                String toolName = ExportUtils.normalizeToolNameForCodex(toolCall.getTitle());
+
+                JsonObject callItem = new JsonObject();
+                callItem.addProperty(F_TYPE, "function_call");
+                callItem.addProperty("call_id", callId);
+                callItem.addProperty("name", toolName);
+                callItem.addProperty("arguments", toolCall.getArguments() != null ? toolCall.getArguments() : "{}");
+                writeResponseItem(sb, callItem, timestamp);
+
+                JsonObject outputItem = new JsonObject();
+                outputItem.addProperty(F_TYPE, "function_call_output");
+                outputItem.addProperty("call_id", callId);
+                outputItem.addProperty("output", toolCall.getResult() != null ? toolCall.getResult() : "");
+                writeResponseItem(sb, outputItem, timestamp);
+            }
+            default -> {
+                // Skip SubAgent, Status, TurnStats, ContextFiles, SessionSeparator
+            }
+        }
+    }
+
+    private static void writeSessionMeta(
+        @NotNull StringBuilder sb,
+        @NotNull String threadId,
+        @NotNull String timestamp,
+        @Nullable String cwd) {
+        JsonObject meta = new JsonObject();
+        meta.addProperty(F_TYPE, "session_meta");
+        meta.addProperty("id", threadId);
+        meta.addProperty(F_TIMESTAMP, timestamp);
+        if (cwd != null) {
+            meta.addProperty("cwd", cwd);
+        }
+        meta.addProperty("originator", "intellij-copilot-plugin");
+        meta.addProperty("cli_version", "0.0.0");
+        meta.addProperty("source", "vscode");
+        meta.addProperty("model_provider", "openai");
+        sb.append(GSON.toJson(meta)).append('\n');
+    }
+
+    private static void writeResponseItem(
+        @NotNull StringBuilder sb,
+        @NotNull JsonObject payload,
+        @NotNull String timestamp) {
+        JsonObject envelope = new JsonObject();
+        envelope.addProperty(F_TYPE, "response_item");
+        envelope.addProperty(F_TIMESTAMP, timestamp);
+        envelope.add("payload", payload);
+        sb.append(GSON.toJson(envelope)).append('\n');
     }
 
     private static void insertThread(@NotNull Path dbPath, @NotNull String threadId,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/ExportUtils.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/exporters/ExportUtils.java
@@ -14,6 +14,9 @@ public final class ExportUtils {
     private static final int MAX_TOOL_NAME_LENGTH = 200;
     private static final Pattern INVALID_TOOL_NAME_CHARS = Pattern.compile("[^a-zA-Z0-9_-]");
     private static final Pattern CONSECUTIVE_UNDERSCORES = Pattern.compile("_{3,}");
+    private static final String AGENTBRIDGE_DASH = "agentbridge-";
+    private static final String AGENTBRIDGE_UNDERSCORE = "agentbridge_";
+    private static final String AGENTBRIDGE_KIRO = "@agentbridge/";
 
     private ExportUtils() {
     }
@@ -35,6 +38,38 @@ public final class ExportUtils {
         if (sanitized.endsWith("_")) sanitized = sanitized.substring(0, sanitized.length() - 1);
         if (sanitized.length() > MAX_TOOL_NAME_LENGTH) sanitized = sanitized.substring(0, MAX_TOOL_NAME_LENGTH);
         return sanitized.isEmpty() ? "unknown_tool" : sanitized;
+    }
+
+    /**
+     * Normalizes a tool name for Codex rollout export by ensuring it starts with
+     * {@code agentbridge_}.
+     *
+     * <p>Codex presents MCP tools to the model with the server name as a prefix
+     * (e.g., {@code agentbridge_read_file}). The exported rollout must use the same
+     * names so the model recognizes them as the same tools after session restore.
+     * Different clients use different prefix conventions:</p>
+     * <ul>
+     *   <li>Copilot: {@code agentbridge-read_file} (dash separator)</li>
+     *   <li>Codex/OpenCode: {@code agentbridge_read_file} (underscore separator)</li>
+     *   <li>Kiro: {@code @agentbridge/read_file} (at-sign + slash)</li>
+     *   <li>Claude: {@code read_file} (no prefix)</li>
+     * </ul>
+     *
+     * <p>This method strips any existing prefix and adds the canonical
+     * {@code agentbridge_} prefix that Codex expects.</p>
+     */
+    @NotNull
+    public static String normalizeToolNameForCodex(@NotNull String rawName) {
+        String base = rawName;
+        if (base.startsWith(AGENTBRIDGE_DASH)) {
+            base = base.substring(AGENTBRIDGE_DASH.length());
+        } else if (base.startsWith(AGENTBRIDGE_UNDERSCORE)) {
+            base = base.substring(AGENTBRIDGE_UNDERSCORE.length());
+        } else if (base.startsWith(AGENTBRIDGE_KIRO)) {
+            base = base.substring(AGENTBRIDGE_KIRO.length());
+        }
+        String sanitized = sanitizeToolName(base);
+        return AGENTBRIDGE_UNDERSCORE + sanitized;
     }
 
     /**

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/exporters/CodexClientExporterTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/exporters/CodexClientExporterTest.java
@@ -146,7 +146,8 @@ class CodexClientExporterTest {
 
         JsonObject fcLine = lines.get(1);
         assertEquals("function_call", fcLine.get("type").getAsString());
-        assertEquals("read_file", fcLine.get("name").getAsString());
+        assertEquals("agentbridge_read_file", fcLine.get("name").getAsString(),
+            "Tool name must be prefixed with agentbridge_ for Codex MCP tool matching");
         assertEquals("{\"path\":\"/etc/hosts\"}", fcLine.get("arguments").getAsString());
     }
 
@@ -279,14 +280,71 @@ class CodexClientExporterTest {
             "Second write with more entries must produce a larger file");
     }
 
+    // ── Native format structure tests ─────────────────────────────────────────
+
+    @Test
+    void exportedRolloutHasSessionMetaFirstLine() throws IOException {
+        Path rollout = tempDir.resolve("rollout-meta.jsonl");
+        CodexClientExporter.writeRolloutFile(List.of(prompt("Hi")), rollout);
+
+        List<String> rawLines = Files.readAllLines(rollout, StandardCharsets.UTF_8).stream()
+            .filter(l -> !l.isBlank())
+            .toList();
+        assertFalse(rawLines.isEmpty(), "Rollout file must not be empty");
+
+        JsonObject firstLine = GSON.fromJson(rawLines.getFirst(), JsonObject.class);
+        assertEquals("session_meta", firstLine.get("type").getAsString(),
+            "First line must be session_meta");
+        assertTrue(firstLine.has("originator"), "session_meta must have originator field");
+        assertTrue(firstLine.has("cli_version"), "session_meta must have cli_version field");
+    }
+
+    @Test
+    void contentItemsAreWrappedInResponseItemEnvelopes() throws IOException {
+        Path rollout = tempDir.resolve("rollout-envelopes.jsonl");
+        CodexClientExporter.writeRolloutFile(List.of(prompt("Hi"), text("Hello")), rollout);
+
+        List<JsonObject> rawLines = Files.readAllLines(rollout, StandardCharsets.UTF_8).stream()
+            .filter(l -> !l.isBlank())
+            .map(l -> GSON.fromJson(l, JsonObject.class))
+            .toList();
+
+        // Line 0 = session_meta, lines 1+ = response_item envelopes
+        for (int i = 1; i < rawLines.size(); i++) {
+            JsonObject line = rawLines.get(i);
+            assertEquals("response_item", line.get("type").getAsString(),
+                "Content line " + i + " must be wrapped in response_item envelope");
+            assertTrue(line.has("payload"),
+                "response_item at line " + i + " must have a payload field");
+            assertTrue(line.has("timestamp"),
+                "response_item at line " + i + " must have a timestamp field");
+        }
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
+    /**
+     * Writes a rollout file and parses the content lines.
+     * Skips the {@code session_meta} header line and unwraps {@code response_item} envelopes
+     * so tests can assert on the inner payload items directly.
+     */
     private List<JsonObject> writeAndParse(List<EntryData> entries) throws IOException {
         Path rollout = tempDir.resolve("rollout-" + System.nanoTime() + ".jsonl");
         CodexClientExporter.writeRolloutFile(entries, rollout);
         return Files.readAllLines(rollout, StandardCharsets.UTF_8).stream()
             .filter(l -> !l.isBlank())
             .map(l -> GSON.fromJson(l, JsonObject.class))
+            .filter(obj -> {
+                String type = obj.has("type") ? obj.get("type").getAsString() : "";
+                return !"session_meta".equals(type);
+            })
+            .map(obj -> {
+                String type = obj.has("type") ? obj.get("type").getAsString() : "";
+                if ("response_item".equals(type) && obj.has("payload")) {
+                    return obj.getAsJsonObject("payload");
+                }
+                return obj;
+            })
             .collect(Collectors.toList());
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/importers/CodexClientImporter.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/importers/CodexClientImporter.java
@@ -110,6 +110,18 @@ public final class CodexClientImporter {
             String type = JsonlUtil.getStr(item, "type");
             if (type == null) continue;
 
+            // Skip metadata lines produced by the exporter
+            if ("session_meta".equals(type) || "event_msg".equals(type) || "turn_context".equals(type)) continue;
+
+            // Unwrap response_item envelopes
+            if ("response_item".equals(type)) {
+                JsonObject payload = item.getAsJsonObject("payload");
+                if (payload == null) continue;
+                item = payload;
+                type = JsonlUtil.getStr(item, "type");
+                if (type == null) continue;
+            }
+
             switch (type) {
                 case "message" -> handleMessage(item, entries, pendingAssistantParts);
                 case "function_call" -> handleFunctionCall(item, pendingAssistantParts, pendingCalls);
@@ -148,12 +160,16 @@ public final class CodexClientImporter {
         @NotNull Map<String, EntryData.ToolCall> pendingCalls
     ) {
         String callId = JsonlUtil.getStr(item, "call_id");
-        String name = JsonlUtil.getStr(item, "name");
+        String rawName = JsonlUtil.getStr(item, "name");
         String arguments = JsonlUtil.getStr(item, "arguments");
 
-        EntryData.ToolCall toolCall = new EntryData.ToolCall(
-            name != null ? name : "unknown",
-            arguments);
+        // Strip the agentbridge_ prefix added during export for Codex tool name matching
+        String name = rawName != null ? rawName : "unknown";
+        if (name.startsWith("agentbridge_")) {
+            name = name.substring("agentbridge_".length());
+        }
+
+        EntryData.ToolCall toolCall = new EntryData.ToolCall(name, arguments);
 
         pendingAssistantParts.add(toolCall);
 


### PR DESCRIPTION
## What & Why

Codex session restore was broken — every time you switched back to Codex, it silently started a fresh thread instead of resuming the previous conversation. This PR fixes the root cause by producing the correct native rollout format that Codex's Rust parser expects.

### Root Cause

Codex's session restore works by writing a `.jsonl` rollout file that `codex thread/resume` reads on startup. The file format is strictly defined by Codex's Rust `serde` deserializer. Our exporter was writing a simplified format that failed silently in three ways:

1. **Missing `session_meta` header** — Codex's `SessionMeta` struct requires `originator` and `cli_version` as non-optional fields. Without them, serde deserialization fails and the thread ID is never extracted → every startup creates a new thread.

2. **Missing `response_item` envelopes** — Each content item must be wrapped as `{"type":"response_item","timestamp":"...","payload":{...item...}}`. Without this wrapping, Codex can't parse the rollout file at all.

3. **Wrong tool names** — Codex presents MCP tools with an `agentbridge_` prefix (e.g. `agentbridge_read_file`). The rollout must use these same names for tool calls to be matched on restore. We were writing bare names like `read_file`.

## Changes

### `CodexClientExporter` (main fix)
- First line is now a `session_meta` JSON object with `id`, `originator`, `cli_version`, `cwd`, `timestamp`
- Every subsequent content item is wrapped in a `response_item` envelope: `{type, timestamp, payload}`
- Tool names normalized with `agentbridge_` prefix via `ExportUtils.normalizeToolNameForCodex()`
- Added 4-arg `exportSession(entries, sessionsDir, dbPath, cwd)` overload so the working directory is written into `session_meta.cwd`
- Extracted `writeEntryItem()` private helper to keep `writeRolloutFile` within cognitive complexity limits

### `ExportUtils` (new utility method)
- `normalizeToolNameForCodex(rawName)` strips any existing prefix variant (`agentbridge-`, `agentbridge_`, `@agentbridge/`) and re-adds `agentbridge_` + sanitized base name
- Ensures consistent tool naming regardless of how the tool call was originally recorded

### `CodexClientImporter` (test-side importer)
- Now skips metadata lines: `session_meta`, `event_msg`, `turn_context`
- Unwraps `response_item` envelopes before processing the inner payload
- Strips `agentbridge_` prefix from tool names on import (so round-trip tests and chat history display bare names like `read_file`)

### `SessionSwitchService`
- Passes `basePath` (the project root) as `cwd` to the new 4-arg `exportSession` — Codex uses this to resolve relative paths in the session

### `CodexAppServerClient`
- When `thread/resume` fails (e.g. thread expired on the Codex server), now shows a user-visible WARNING balloon notification explaining what happened and that a new thread will be started
- Previously it only logged a warning internally — the user had no idea their context was lost

### `PlatformApiCompat` + `AcpClient`
- Added `showNotification(project, title, content, type)` wrapper
- `NotificationGroup.createNotification(String, String, NotificationType)` is a known false-positive in the IDE daemon (the 3-arg overload isn't resolved when the dev IDE version differs from the target SDK). Previously this caused an ERROR highlight in `AcpClient`. The wrapper centralises the call in `PlatformApiCompat` where all such cross-version API issues live, and eliminates the editor error from all callers.

### `CodexClientExporterTest`
- `writeAndParse` helper updated to skip `session_meta` lines and unwrap `response_item` envelopes so existing tests still work
- `functionCallLineHasNameAndArguments` updated to expect `agentbridge_read_file` (not `read_file`)
- New: `exportedRolloutHasSessionMetaFirstLine` — verifies first line is `session_meta` with `originator` and `cli_version`
- New: `contentItemsAreWrappedInResponseItemEnvelopes` — verifies every non-meta line is a `response_item` with `payload` and `timestamp`

## Porting Note

This is a port of PR #174 which implemented these fixes on a stale branch (276 commits behind master, old `ideagentforcopilot` package). That branch could not be rebased because the data model also differed (`SessionMessage` vs `EntryData`). All changes were adapted to the current package structure and data model.
