### PR TITLE
fix: use checkout -b instead of switch -c in git_branch create

### DIFF
--- a/.idea/ideAgentScratchTracker.xml
+++ b/.idea/ideAgentScratchTracker.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AgentScratchTracker">
+    <option name="trackedFiles">
+      <map>
+        <entry key="$APPLICATION_CONFIG_DIR$/scratches/pr183-body.md" value="1776020641976" />
+      </map>
+    </option>
+  </component>
+</project>


### PR DESCRIPTION
## What

Fixes the `git_branch create` MCP tool which was crashing with `unknown switch 'c'`.

## Why

IntelliJ's `PlatformApiCompat.IDE_GIT_COMMAND_MAP` maps the string `"switch"` → `GitCommand.CHECKOUT`. This means `runGit("switch", "-c", name)` ultimately runs `git checkout -c name` — but `-c` is not a valid flag for `git checkout`. The correct flag is `-b`.

The fix changes the `create` case to use `runGit("checkout", "-b", name)` and also accepts `"checkout"` as an alias in the switch action, so both calling conventions work.

## Changes
- `GitBranchTool.java`: `create` now uses `CMD_CHECKOUT` + `-b` flag
- Added `CMD_CHECKOUT = "checkout"` constant
- `switch` case also accepts `"checkout"` alias via `case CMD_SWITCH, CMD_CHECKOUT`