### PR TITLE
feat: replace ONNX Runtime with pure-Java BERT inference

### DIFF
--- a/docs/SEMANTIC-MEMORY.md
+++ b/docs/SEMANTIC-MEMORY.md
@@ -114,7 +114,7 @@ store with temporal validity tracking.
 │  2. Quality filter (skip < 200 chars, skip pure tool output)    │
 │  3. Classify: decisions / preferences / milestones / problems   │
 │  4. Detect room (topic) via keyword scoring (RoomDetector)      │
-│  5. Generate embeddings (ONNX Runtime + all-MiniLM-L6-v2)      │
+│  5. Generate embeddings (pure-Java BERT + all-MiniLM-L6-v2)    │
 │  6. Store in Lucene index + update knowledge graph              │
 └───────┬────────────────────────────────────────────────────────┘
         │
@@ -196,7 +196,7 @@ store with temporal validity tracking.
 ~/.agentbridge/
   models/
     all-MiniLM-L6-v2/
-      model.onnx            ← Downloaded on first use (~90MB)
+      model.safetensors      ← Downloaded on first use (~90MB)
       vocab.txt             ← WordPiece vocabulary (~232KB)
 ```
 
@@ -220,7 +220,7 @@ plugin-core/src/main/java/com/github/catatafishen/agentbridge/
 
     embedding/
       Embedder.java                  ← Functional interface for embedding injection
-      EmbeddingService.java          ← ONNX Runtime session management + inference
+      EmbeddingService.java          ← Pure-Java BERT inference + model management
       WordPieceTokenizer.java        ← Java tokenizer (vocab.txt → token IDs)
       ModelDownloader.java           ← Download model on first use with progress
 
@@ -271,7 +271,7 @@ plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/
   BackfillMinerPlatformTest.java         ← Full doBackfill() path with replaced services (7 tests)
 
   embedding/
-    TestEmbeddingFactory.java            ← Test EmbeddingService factory (bypasses ONNX Runtime)
+    TestEmbeddingFactory.java            ← Test EmbeddingService factory (bypasses model loading)
     EmbeddingServiceTest.java            ← meanPool, l2Normalize, embed, embedBatch (24 tests)
     WordPieceTokenizerTest.java          ← Tokenization, sub-words, truncation, padding (13 tests)
 
@@ -333,20 +333,20 @@ Initialization order (in `ensureInitialized()`):
 
 1. `WriteAheadLog` → `.agent-work/memory/wal/`
 2. `MemoryStore` (Lucene) → `.agent-work/memory/lucene-index/`
-3. `EmbeddingService` → loads ONNX model (downloads on first use)
+3. `EmbeddingService` → loads BERT model (downloads safetensors on first use)
 4. `KnowledgeGraph` (SQLite) → `.agent-work/memory/knowledge.sqlite3`
 
-Implements `Disposable` — closes Lucene index, ONNX session, and SQLite connection
+Implements `Disposable` — closes Lucene index, BERT resources, and SQLite connection
 on project close.
 
 ### EmbeddingService
 
-Manages ONNX Runtime inference for text → 384-dim float vector conversion.
+Manages pure-Java BERT inference for text → 384-dim float vector conversion.
 
-Pipeline: text → `WordPieceTokenizer` → token IDs → ONNX Runtime → raw output →
+Pipeline: text → `WordPieceTokenizer` → token IDs → `BertInferenceEngine` → raw output →
 `meanPool()` → `l2Normalize()` → embedding vector.
 
-`ModelDownloader` handles first-use download of the ONNX model and vocabulary file
+`ModelDownloader` handles first-use download of the safetensors model and vocabulary file
 from Hugging Face, with progress reporting and cancellation support.
 
 ### TurnMiner Pipeline
@@ -413,14 +413,14 @@ SQLite-backed triple store with temporal validity:
 Coverage is measured via JaCoCo against instrumented classes (IntelliJ's `instrumentCode`
 task applies `@NotNull` bytecode checks that change class hashes).
 
-| Package   | Line Coverage | Notes                                                                  |
-|-----------|---------------|------------------------------------------------------------------------|
-| store     | 96.2%         | Full Lucene index lifecycle, search, dedup                             |
-| wal       | 90.5%         | Append, read, rotation                                                 |
-| kg        | 90.1%         | CRUD, temporal queries, timeline, stats                                |
-| layers    | 90.1%         | All 4 layers including rendering and filtering                         |
-| mining    | 86.3%         | Remaining gaps are project-service-dependent private methods           |
-| embedding | 56.1%         | ONNX Runtime inference and model download are untestable without model |
+| Package   | Line Coverage | Notes                                                               |
+|-----------|---------------|---------------------------------------------------------------------|
+| store     | 96.2%         | Full Lucene index lifecycle, search, dedup                          |
+| wal       | 90.5%         | Append, read, rotation                                              |
+| kg        | 90.1%         | CRUD, temporal queries, timeline, stats                             |
+| layers    | 90.1%         | All 4 layers including rendering and filtering                      |
+| mining    | 86.3%         | Remaining gaps are project-service-dependent private methods        |
+| embedding | 56.1%         | BERT inference and model download are untestable without model file |
 
 ### Testing Strategy
 
@@ -436,7 +436,7 @@ with real IntelliJ project instances and replaced services via `ServiceContainer
 Testability is achieved without mocking frameworks through:
 
 - `Embedder` functional interface for embedding injection
-- `InferenceFunction` functional interface for ONNX inference injection
+- `InferenceFunction` functional interface for BERT inference injection
 - `EntryLoader` / `MineFunction` functional interfaces for backfill dependency injection
 - Package-private test constructors on `MemoryService` and `EmbeddingService`
 - Extracted execution methods (`executePipeline()`, `executeBackfill()`) with explicit dependencies
@@ -445,14 +445,11 @@ Testability is achieved without mocking frameworks through:
 
 ## Risks & Mitigations
 
-### 1. ONNX Runtime Size (~60MB)
+### 1. Model Download Size (~90MB)
 
-The ONNX Runtime JAR includes native libraries for all platforms, increasing plugin
-download size.
-
-**Mitigation**: The model file (~90MB) is downloaded separately on first use, not
-bundled with the plugin. Platform-specific classifier JARs could reduce the JAR size
-further if needed.
+The all-MiniLM-L6-v2 safetensors model is downloaded on first use, not bundled with the
+plugin. The pure-Java BERT inference engine eliminates the ~39MB ONNX Runtime native
+dependency that was previously required.
 
 ### 2. IntelliJ Lucene Version Changes
 

--- a/docs/SEMANTIC-MEMORY.md
+++ b/docs/SEMANTIC-MEMORY.md
@@ -31,29 +31,29 @@ dependencies.
 
 ## What Was Adapted from MemPalace
 
-| MemPalace Concept | Our Implementation |
-|---|---|
-| ChromaDB vector store | **Apache Lucene** KNN vector search (bundled in IntelliJ) |
-| sentence-transformers embeddings | **ONNX Runtime Java** + all-MiniLM-L6-v2 model |
-| Palace → Wings → Rooms → Drawers | Same hierarchy, stored in Lucene documents with metadata fields |
-| 4-layer memory stack (L0–L3) | Same design: identity file + essential story + on-demand + deep search |
-| `convo_miner.py` exchange chunking | `ExchangeChunker` — extracts Q+A pairs from `EntryData.Prompt` + `EntryData.Text` |
+| MemPalace Concept                     | Our Implementation                                                                                     |
+|---------------------------------------|--------------------------------------------------------------------------------------------------------|
+| ChromaDB vector store                 | **Apache Lucene** KNN vector search (bundled in IntelliJ)                                              |
+| sentence-transformers embeddings      | **Pure-Java BERT inference** with all-MiniLM-L6-v2 safetensors model                                   |
+| Palace → Wings → Rooms → Drawers      | Same hierarchy, stored in Lucene documents with metadata fields                                        |
+| 4-layer memory stack (L0–L3)          | Same design: identity file + essential story + on-demand + deep search                                 |
+| `convo_miner.py` exchange chunking    | `ExchangeChunker` — extracts Q+A pairs from `EntryData.Prompt` + `EntryData.Text`                      |
 | `general_extractor.py` classification | `MemoryClassifier` — 5-type regex extraction (decisions, preferences, milestones, problems, technical) |
-| Knowledge graph (SQLite triples) | `KnowledgeGraph` — SQLite with temporal validity (`valid_from`, `valid_until`) |
-| MCP tools (19 tools) | 9 MCP tools in our existing tool infrastructure |
-| Write-ahead log (JSONL audit) | `WriteAheadLog` — JSONL WAL for all write operations |
-| `config.py` (env > file > defaults) | `MemorySettings` — `PersistentStateComponent` with IDE settings UI |
+| Knowledge graph (SQLite triples)      | `KnowledgeGraph` — SQLite with temporal validity (`valid_from`, `valid_until`)                         |
+| MCP tools (19 tools)                  | 9 MCP tools in our existing tool infrastructure                                                        |
+| Write-ahead log (JSONL audit)         | `WriteAheadLog` — JSONL WAL for all write operations                                                   |
+| `config.py` (env > file > defaults)   | `MemorySettings` — `PersistentStateComponent` with IDE settings UI                                     |
 
 ### Not Implemented
 
-| MemPalace Feature | Reason |
-|---|---|
-| AAAK dialect (lossy compression) | Experimental in MemPalace (84.2% vs 96.6% R@5). Raw mode is better. |
-| People map | Personal assistant feature, not relevant for coding agents |
-| Emotional memory type | Replaced with "technical" — more useful for coding context |
-| Palace graph traversal / tunnels | Advanced feature — can add later if needed |
-| Shell hooks for auto-save | Replaced with MCP-native approach (see [Future Work](#future-work)) |
-| Diary tools | Per-agent diary write/read — deferred (see [Future Work](#future-work)) |
+| MemPalace Feature                | Reason                                                                  |
+|----------------------------------|-------------------------------------------------------------------------|
+| AAAK dialect (lossy compression) | Experimental in MemPalace (84.2% vs 96.6% R@5). Raw mode is better.     |
+| People map                       | Personal assistant feature, not relevant for coding agents              |
+| Emotional memory type            | Replaced with "technical" — more useful for coding context              |
+| Palace graph traversal / tunnels | Advanced feature — can add later if needed                              |
+| Shell hooks for auto-save        | Replaced with MCP-native approach (see [Future Work](#future-work))     |
+| Diary tools                      | Per-agent diary write/read — deferred (see [Future Work](#future-work)) |
 
 ---
 
@@ -68,25 +68,26 @@ IntelliJ bundles Lucene with full KNN vector support. No additional dependency n
 - `VectorSimilarityFunction.COSINE` — cosine similarity scoring
 - Combined queries: pre-filter by metadata (wing/room/type), then KNN
 
-### ONNX Runtime Java — Embedding Inference
+### Pure-Java BERT Inference — Embedding Engine
 
-| Property | Value |
-|---|---|
-| Maven artifact | `com.microsoft.onnxruntime:onnxruntime:1.24.3` |
-| Size | ~60MB (includes native libs for Linux, macOS, Windows) |
-| Inference speed | <100ms per sentence on CPU |
+| Property        | Value                                                           |
+|-----------------|-----------------------------------------------------------------|
+| Architecture    | 6-layer BERT transformer (384-dim, 12 heads, ~22.7M parameters) |
+| Implementation  | Hardcoded forward pass — no native dependencies                 |
+| Inference speed | ~80–300ms per sentence on CPU                                   |
+| Weight format   | [safetensors](https://huggingface.co/docs/safetensors/index)    |
 
 ### all-MiniLM-L6-v2 — Embedding Model
 
-| Property | Value |
-|---|---|
-| Source | [sentence-transformers/all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) |
-| Format | ONNX (exported via Hugging Face Optimum) |
-| Size | ~90MB (downloaded on first use) |
-| Dimensions | 384 |
-| License | Apache 2.0 |
-| Tokenizer | WordPiece with `vocab.txt` (~232KB) |
-| Storage | `~/.agentbridge/models/all-MiniLM-L6-v2/` (shared across projects) |
+| Property   | Value                                                                                                   |
+|------------|---------------------------------------------------------------------------------------------------------|
+| Source     | [sentence-transformers/all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) |
+| Format     | safetensors (weights with PyTorch naming)                                                               |
+| Size       | ~91MB (downloaded on first use)                                                                         |
+| Dimensions | 384                                                                                                     |
+| License    | Apache 2.0                                                                                              |
+| Tokenizer  | WordPiece with `vocab.txt` (~232KB)                                                                     |
+| Storage    | `~/.agentbridge/models/all-MiniLM-L6-v2/` (shared across projects)                                      |
 
 ### SQLite — Knowledge Graph
 
@@ -310,6 +311,7 @@ plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/
 `MemorySettings` is a `PersistentStateComponent<State>` registered as a project service.
 
 Key settings:
+
 - `enabled` (default: `false`) — master toggle
 - `wing` (default: auto-detected from project name) — the "wing" label for this project
 - `maxDrawersPerTurn` (default: `10`) — cap on memories stored per conversation turn
@@ -328,6 +330,7 @@ It uses **lazy double-checked-locking initialization** — components are create
 first access, not at project open.
 
 Initialization order (in `ensureInitialized()`):
+
 1. `WriteAheadLog` → `.agent-work/memory/wal/`
 2. `MemoryStore` (Lucene) → `.agent-work/memory/lucene-index/`
 3. `EmbeddingService` → loads ONNX model (downloads on first use)
@@ -368,12 +371,12 @@ gracefully (logs and continues).
 
 ### Memory Stack (4 Layers)
 
-| Layer | Class | Purpose | Token Budget |
-|---|---|---|---|
-| L0 | `IdentityLayer` | Read `identity.txt` (user-written project description) | ~100-200 |
-| L1 | `EssentialStoryLayer` | Top drawers from Lucene, grouped by room | ~400-700 |
-| L2 | `OnDemandLayer` | Wing/room filtered retrieval on demand | Variable |
-| L3 | `DeepSearchLayer` | Full semantic search across all drawers | Variable |
+| Layer | Class                 | Purpose                                                | Token Budget |
+|-------|-----------------------|--------------------------------------------------------|--------------|
+| L0    | `IdentityLayer`       | Read `identity.txt` (user-written project description) | ~100-200     |
+| L1    | `EssentialStoryLayer` | Top drawers from Lucene, grouped by room               | ~400-700     |
+| L2    | `OnDemandLayer`       | Wing/room filtered retrieval on demand                 | Variable     |
+| L3    | `DeepSearchLayer`     | Full semantic search across all drawers                | Variable     |
 
 L0+L1 are used for wake-up context (`memory_wake_up` tool). L2 is for targeted
 recall (`memory_recall`). L3 is for comprehensive search (`memory_search`).
@@ -391,17 +394,17 @@ SQLite-backed triple store with temporal validity:
 
 9 tools registered conditionally via `MemoryToolFactory` (only when memory is enabled):
 
-| Tool | Type | Description |
-|---|---|---|
-| `memory_search` | Read | Semantic search with optional wing/room/type filters |
-| `memory_status` | Read | Drawer count, wing/room breakdown, storage stats |
-| `memory_wake_up` | Read | L0+L1 context for session start (~600-900 tokens) |
-| `memory_recall` | Read | L2 on-demand retrieval with wing/room filters |
-| `memory_store` | Write | File content into a specific wing/room |
-| `memory_kg_query` | Read | Knowledge graph entity lookup with temporal filter |
-| `memory_kg_timeline` | Read | Chronological fact history for an entity |
-| `memory_kg_add` | Write | Add a knowledge graph triple |
-| `memory_kg_invalidate` | Write | Mark a fact as no longer true |
+| Tool                   | Type  | Description                                          |
+|------------------------|-------|------------------------------------------------------|
+| `memory_search`        | Read  | Semantic search with optional wing/room/type filters |
+| `memory_status`        | Read  | Drawer count, wing/room breakdown, storage stats     |
+| `memory_wake_up`       | Read  | L0+L1 context for session start (~600-900 tokens)    |
+| `memory_recall`        | Read  | L2 on-demand retrieval with wing/room filters        |
+| `memory_store`         | Write | File content into a specific wing/room               |
+| `memory_kg_query`      | Read  | Knowledge graph entity lookup with temporal filter   |
+| `memory_kg_timeline`   | Read  | Chronological fact history for an entity             |
+| `memory_kg_add`        | Write | Add a knowledge graph triple                         |
+| `memory_kg_invalidate` | Write | Mark a fact as no longer true                        |
 
 ---
 
@@ -410,14 +413,14 @@ SQLite-backed triple store with temporal validity:
 Coverage is measured via JaCoCo against instrumented classes (IntelliJ's `instrumentCode`
 task applies `@NotNull` bytecode checks that change class hashes).
 
-| Package | Line Coverage | Notes |
-|---|---|---|
-| store | 96.2% | Full Lucene index lifecycle, search, dedup |
-| wal | 90.5% | Append, read, rotation |
-| kg | 90.1% | CRUD, temporal queries, timeline, stats |
-| layers | 90.1% | All 4 layers including rendering and filtering |
-| mining | 86.3% | Remaining gaps are project-service-dependent private methods |
-| embedding | 56.1% | ONNX Runtime inference and model download are untestable without model |
+| Package   | Line Coverage | Notes                                                                  |
+|-----------|---------------|------------------------------------------------------------------------|
+| store     | 96.2%         | Full Lucene index lifecycle, search, dedup                             |
+| wal       | 90.5%         | Append, read, rotation                                                 |
+| kg        | 90.1%         | CRUD, temporal queries, timeline, stats                                |
+| layers    | 90.1%         | All 4 layers including rendering and filtering                         |
+| mining    | 86.3%         | Remaining gaps are project-service-dependent private methods           |
+| embedding | 56.1%         | ONNX Runtime inference and model download are untestable without model |
 
 ### Testing Strategy
 
@@ -431,6 +434,7 @@ service registration, settings persistence, `TurnMiner.doMine()` and `BackfillMi
 with real IntelliJ project instances and replaced services via `ServiceContainerUtil.replaceService()`.
 
 Testability is achieved without mocking frameworks through:
+
 - `Embedder` functional interface for embedding injection
 - `InferenceFunction` functional interface for ONNX inference injection
 - `EntryLoader` / `MineFunction` functional interfaces for backfill dependency injection
@@ -530,12 +534,12 @@ by milla-jovovich, licensed under the [MIT License](https://opensource.org/licen
 
 The following components are translated from MemPalace's Python implementation:
 
-| Our Component | MemPalace Source | Adaptation |
-|---|---|---|
-| `ExchangeChunker` | `convo_miner.py` `chunk_exchanges()` | Java port, adapted for `EntryData` model |
-| `MemoryClassifier` | `general_extractor.py` | Java port, "emotional" → "technical" for coding context |
-| `RoomDetector` | `convo_miner.py` `detect_convo_room()` | Java port, same keyword sets |
-| `MemoryStack` | `layers.py` `MemoryStack` | Java port, Lucene instead of ChromaDB |
-| `KnowledgeGraph` | `knowledge_graph.py` | Java port, same SQLite schema |
-| `QualityFilter` | `convo_miner.py` quality checks | Java port, extended with tool output detection |
-| `WriteAheadLog` | MemPalace audit trail pattern | Java port, JSONL format |
+| Our Component      | MemPalace Source                       | Adaptation                                              |
+|--------------------|----------------------------------------|---------------------------------------------------------|
+| `ExchangeChunker`  | `convo_miner.py` `chunk_exchanges()`   | Java port, adapted for `EntryData` model                |
+| `MemoryClassifier` | `general_extractor.py`                 | Java port, "emotional" → "technical" for coding context |
+| `RoomDetector`     | `convo_miner.py` `detect_convo_room()` | Java port, same keyword sets                            |
+| `MemoryStack`      | `layers.py` `MemoryStack`              | Java port, Lucene instead of ChromaDB                   |
+| `KnowledgeGraph`   | `knowledge_graph.py`                   | Java port, same SQLite schema                           |
+| `QualityFilter`    | `convo_miner.py` quality checks        | Java port, extended with tool output detection          |
+| `WriteAheadLog`    | MemPalace audit trail pattern          | Java port, JSONL format                                 |

--- a/plugin-core/build.gradle.kts
+++ b/plugin-core/build.gradle.kts
@@ -61,9 +61,6 @@ dependencies {
     // SQLite JDBC (used by OpenCode session import)
     implementation("org.xerial:sqlite-jdbc:3.51.3.0")
 
-    // ONNX Runtime for embedding model inference (semantic memory)
-    implementation("com.microsoft.onnxruntime:onnxruntime:1.24.3")
-
     testImplementation("org.junit.jupiter:junit-jupiter:${providers.gradleProperty("junitVersion").get()}")
     testImplementation(
         "junit:junit:${

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemoryService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemoryService.java
@@ -41,7 +41,7 @@ public final class MemoryService implements Disposable {
 
     /**
      * Package-private constructor for testing — pre-initializes with provided components,
-     * bypassing {@link #ensureInitialized()} and ONNX Runtime dependency.
+     * bypassing {@link #ensureInitialized()} and model weight loading.
      *
      * <p>Use with {@code ServiceContainerUtil.replaceService()} in platform tests to inject
      * a controllable MemoryService into the project's service container.

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/BertInferenceEngine.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/BertInferenceEngine.java
@@ -1,0 +1,301 @@
+package com.github.catatafishen.agentbridge.memory.embedding;
+
+import com.intellij.openapi.diagnostic.Logger;
+import org.jetbrains.annotations.NotNull;
+
+import static com.github.catatafishen.agentbridge.memory.embedding.BertWeights.HEAD_DIM;
+import static com.github.catatafishen.agentbridge.memory.embedding.BertWeights.HIDDEN_DIM;
+import static com.github.catatafishen.agentbridge.memory.embedding.BertWeights.INTERMEDIATE_DIM;
+import static com.github.catatafishen.agentbridge.memory.embedding.BertWeights.NUM_HEADS;
+import static com.github.catatafishen.agentbridge.memory.embedding.BertWeights.NUM_LAYERS;
+
+/**
+ * Pure-Java 6-layer BERT forward pass for the
+ * <a href="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2">all-MiniLM-L6-v2</a>
+ * sentence-transformer model.
+ *
+ * <p>Implements the complete inference pipeline: embedding lookup, 6 encoder layers
+ * (self-attention + FFN), mean pooling, and L2 normalization. This produces
+ * 384-dimensional sentence embeddings without any native dependencies.
+ *
+ * <p>All weights are supplied via a {@link BertWeights} instance loaded from a
+ * safetensors file.
+ */
+final class BertInferenceEngine implements EmbeddingService.InferenceFunction {
+
+    private static final Logger LOG = Logger.getInstance(BertInferenceEngine.class);
+
+    private static final float SQRT_2_OVER_PI = (float) Math.sqrt(2.0 / Math.PI);
+    private static final float GELU_COEFF = 0.044715f;
+    private static final float ATTENTION_SCALE = (float) (1.0 / Math.sqrt(HEAD_DIM));
+    private static final float LAYER_NORM_EPS = 1e-12f;
+    private static final float MASK_VALUE = -10000.0f;
+
+    private final BertWeights weights;
+
+    BertInferenceEngine(@NotNull BertWeights weights) {
+        this.weights = weights;
+    }
+
+    /**
+     * Run the full BERT forward pass on tokenized input, returning a 384-dimensional
+     * L2-normalized sentence embedding.
+     *
+     * <p>Pipeline:
+     * <ol>
+     *   <li>Embedding lookup (word + position + token type) followed by LayerNorm</li>
+     *   <li>6 × encoder layer (self-attention → FFN)</li>
+     *   <li>Mean pooling over non-padding tokens</li>
+     *   <li>L2 normalization</li>
+     * </ol>
+     *
+     * @param input tokenized text with input IDs, attention mask, and token type IDs
+     * @return 384-dimensional normalized embedding vector
+     */
+    @Override
+    public float[] run(@NotNull WordPieceTokenizer.TokenizedInput input) {
+        long startNanos = System.nanoTime();
+
+        int seqLen = input.sequenceLength();
+        long[] inputIds = input.inputIds();
+        long[] attentionMask = input.attentionMask();
+        long[] tokenTypeIds = input.tokenTypeIds();
+
+        // ---- Step 1: Embedding lookup + LayerNorm --------------------------------
+        float[][] hidden = new float[seqLen][HIDDEN_DIM];
+        for (int i = 0; i < seqLen; i++) {
+            int wordIdx = (int) inputIds[i];
+            int typeIdx = (int) tokenTypeIds[i];
+            int wordOffset = wordIdx * HIDDEN_DIM;
+            int posOffset = i * HIDDEN_DIM;
+            int typeOffset = typeIdx * HIDDEN_DIM;
+            for (int j = 0; j < HIDDEN_DIM; j++) {
+                hidden[i][j] = weights.wordEmbeddings[wordOffset + j]
+                    + weights.positionEmbeddings[posOffset + j]
+                    + weights.tokenTypeEmbeddings[typeOffset + j];
+            }
+            layerNorm(hidden[i], HIDDEN_DIM,
+                weights.embeddingLayerNormWeight, weights.embeddingLayerNormBias);
+        }
+
+        // ---- Step 2: 6 × Encoder layer ------------------------------------------
+        for (int layer = 0; layer < NUM_LAYERS; layer++) {
+            BertWeights.LayerWeights lw = weights.layers[layer];
+            selfAttention(hidden, seqLen, lw, attentionMask);
+            feedForward(hidden, seqLen, lw);
+        }
+
+        // ---- Step 3: Mean pool + L2 normalize -----------------------------------
+        float[] pooled = EmbeddingService.meanPool(hidden, attentionMask);
+        float[] result = EmbeddingService.l2Normalize(pooled);
+
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000;
+        LOG.debug("BertInferenceEngine forward pass: " + elapsedMs + " ms (seqLen=" + seqLen + ")");
+
+        return result;
+    }
+
+    // ---- Encoder sub-layers (package-private for testability) --------------------
+
+    /**
+     * Multi-head self-attention with residual connection and LayerNorm.
+     * Modifies {@code hidden} in place.
+     */
+    void selfAttention(float[][] hidden, int seqLen,
+                       @NotNull BertWeights.LayerWeights layer,
+                       long[] attentionMask) {
+        // Save residual
+        float[][] residual = new float[seqLen][HIDDEN_DIM];
+        for (int i = 0; i < seqLen; i++) {
+            System.arraycopy(hidden[i], 0, residual[i], 0, HIDDEN_DIM);
+        }
+
+        // Project Q, K, V: [seqLen, 384] each
+        float[][] q = new float[seqLen][];
+        float[][] k = new float[seqLen][];
+        float[][] v = new float[seqLen][];
+        for (int i = 0; i < seqLen; i++) {
+            q[i] = linear(hidden[i], HIDDEN_DIM, layer.queryWeight(), layer.queryBias(), HIDDEN_DIM);
+            k[i] = linear(hidden[i], HIDDEN_DIM, layer.keyWeight(), layer.keyBias(), HIDDEN_DIM);
+            v[i] = linear(hidden[i], HIDDEN_DIM, layer.valueWeight(), layer.valueBias(), HIDDEN_DIM);
+        }
+
+        // Multi-head attention
+        float[][] context = multiHeadAttention(q, k, v, seqLen, attentionMask);
+
+        // Output projection + residual + LayerNorm
+        for (int i = 0; i < seqLen; i++) {
+            float[] projected = linear(context[i], HIDDEN_DIM,
+                layer.attentionOutputWeight(), layer.attentionOutputBias(), HIDDEN_DIM);
+            for (int j = 0; j < HIDDEN_DIM; j++) {
+                hidden[i][j] = projected[j] + residual[i][j];
+            }
+            layerNorm(hidden[i], HIDDEN_DIM,
+                layer.attentionLayerNormWeight(), layer.attentionLayerNormBias());
+        }
+    }
+
+    /**
+     * Computes multi-head scaled dot-product attention across all heads.
+     *
+     * @return context vectors of shape [seqLen][HIDDEN_DIM]
+     */
+    private float[][] multiHeadAttention(float[][] q, float[][] k, float[][] v,
+                                         int seqLen, long[] attentionMask) {
+        float[][] context = new float[seqLen][HIDDEN_DIM];
+        float[] scores = new float[seqLen];
+
+        for (int h = 0; h < NUM_HEADS; h++) {
+            int headOffset = h * HEAD_DIM;
+            for (int i = 0; i < seqLen; i++) {
+                computeAttentionScores(q, k, scores, seqLen, headOffset, i, attentionMask);
+                softmax(scores, seqLen);
+                accumulateWeightedValues(v, scores, context, seqLen, headOffset, i);
+            }
+        }
+        return context;
+    }
+
+    /**
+     * Computes scaled dot-product attention scores for a single query position.
+     */
+    private void computeAttentionScores(float[][] q, float[][] k, float[] scores,
+                                        int seqLen, int headOffset, int queryPos,
+                                        long[] attentionMask) {
+        for (int j = 0; j < seqLen; j++) {
+            float dot = 0.0f;
+            for (int d = 0; d < HEAD_DIM; d++) {
+                dot += q[queryPos][headOffset + d] * k[j][headOffset + d];
+            }
+            scores[j] = dot * ATTENTION_SCALE;
+            if (attentionMask[j] == 0) {
+                scores[j] += MASK_VALUE;
+            }
+        }
+    }
+
+    /**
+     * Accumulates weighted value vectors for a single query position within one head.
+     */
+    private void accumulateWeightedValues(float[][] v, float[] scores, float[][] context,
+                                          int seqLen, int headOffset, int queryPos) {
+        for (int d = 0; d < HEAD_DIM; d++) {
+            float sum = 0.0f;
+            for (int j = 0; j < seqLen; j++) {
+                sum += scores[j] * v[j][headOffset + d];
+            }
+            context[queryPos][headOffset + d] = sum;
+        }
+    }
+
+    /**
+     * Position-wise feed-forward network with residual connection and LayerNorm.
+     * Modifies {@code hidden} in place.
+     */
+    void feedForward(float[][] hidden, int seqLen,
+                     @NotNull BertWeights.LayerWeights layer) {
+        for (int i = 0; i < seqLen; i++) {
+            // Save residual
+            float[] residual = new float[HIDDEN_DIM];
+            System.arraycopy(hidden[i], 0, residual, 0, HIDDEN_DIM);
+
+            // Up-project: [384] → [1536] + GELU
+            float[] intermediate = linear(hidden[i], HIDDEN_DIM,
+                layer.intermediateWeight(), layer.intermediateBias(), INTERMEDIATE_DIM);
+            gelu(intermediate, INTERMEDIATE_DIM);
+
+            // Down-project: [1536] → [384]
+            float[] output = linear(intermediate, INTERMEDIATE_DIM,
+                layer.outputWeight(), layer.outputBias(), HIDDEN_DIM);
+
+            // Residual + LayerNorm
+            for (int j = 0; j < HIDDEN_DIM; j++) {
+                hidden[i][j] = output[j] + residual[j];
+            }
+            layerNorm(hidden[i], HIDDEN_DIM,
+                layer.outputLayerNormWeight(), layer.outputLayerNormBias());
+        }
+    }
+
+    // ---- Primitive ops (package-private for testability) -------------------------
+
+    /**
+     * Layer normalization in place: {@code x = (x − μ) / √(σ² + ε) × weight + bias}.
+     */
+    void layerNorm(float[] x, int len, float[] weight, float[] bias) {
+        float mean = 0.0f;
+        for (int i = 0; i < len; i++) {
+            mean += x[i];
+        }
+        mean /= len;
+
+        float variance = 0.0f;
+        for (int i = 0; i < len; i++) {
+            float diff = x[i] - mean;
+            variance += diff * diff;
+        }
+        variance /= len;
+
+        float invStd = (float) (1.0 / Math.sqrt(variance + LAYER_NORM_EPS));
+        for (int i = 0; i < len; i++) {
+            x[i] = (x[i] - mean) * invStd * weight[i] + bias[i];
+        }
+    }
+
+    /**
+     * Dense linear layer: {@code output[j] = bias[j] + Σ_k input[k] × weight[j × inputDim + k]}.
+     *
+     * <p>Weight layout follows PyTorch convention: {@code [outputDim, inputDim]}.
+     */
+    float[] linear(float[] input, int inputDim, float[] weight, float[] bias, int outputDim) {
+        float[] output = new float[outputDim];
+        for (int j = 0; j < outputDim; j++) {
+            float sum = bias[j];
+            int weightOffset = j * inputDim;
+            for (int k = 0; k < inputDim; k++) {
+                sum += input[k] * weight[weightOffset + k];
+            }
+            output[j] = sum;
+        }
+        return output;
+    }
+
+    /**
+     * GELU activation in place using the standard approximation:
+     * {@code 0.5 × x × (1 + tanh(√(2/π) × (x + 0.044715 × x³)))}.
+     */
+    void gelu(float[] x, int len) {
+        for (int i = 0; i < len; i++) {
+            float val = x[i];
+            float cube = val * val * val;
+            float inner = SQRT_2_OVER_PI * (val + GELU_COEFF * cube);
+            x[i] = 0.5f * val * (1.0f + (float) Math.tanh(inner));
+        }
+    }
+
+    /**
+     * Softmax in place over {@code scores[0..len-1]}.
+     */
+    void softmax(float[] scores, int len) {
+        float max = scores[0];
+        for (int i = 1; i < len; i++) {
+            if (scores[i] > max) {
+                max = scores[i];
+            }
+        }
+
+        float expSum = 0.0f;
+        for (int i = 0; i < len; i++) {
+            float exp = (float) Math.exp(scores[i] - max);
+            scores[i] = exp;
+            expSum += exp;
+        }
+
+        // expSum is always > 0 because at least one exp(scores[max_i] - max) = exp(0) = 1.0
+        if (expSum == 0.0f) return;
+        float invSum = 1.0f / expSum;
+        for (int i = 0; i < len; i++) {
+            scores[i] *= invSum;
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/BertWeights.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/BertWeights.java
@@ -1,0 +1,168 @@
+package com.github.catatafishen.agentbridge.memory.embedding;
+
+import com.intellij.openapi.diagnostic.Logger;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+
+/**
+ * Typed container for all weight matrices from the
+ * <a href="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2">all-MiniLM-L6-v2</a>
+ * sentence-transformer model, loaded from a safetensors file.
+ *
+ * <p>The model has 6 encoder layers with 12 attention heads (head dim 32),
+ * hidden dimension 384, and intermediate FFN dimension 1536.
+ * Total: 5 embedding tensors + 16 × 6 layer tensors = 101 named tensors.
+ */
+public final class BertWeights {
+
+    private static final Logger LOG = Logger.getInstance(BertWeights.class);
+
+    // ---- Architecture constants for all-MiniLM-L6-v2 ----------------------------
+
+    public static final int VOCAB_SIZE = 30522;
+    public static final int HIDDEN_DIM = 384;
+    public static final int NUM_HEADS = 12;
+    public static final int HEAD_DIM = 32;
+    public static final int INTERMEDIATE_DIM = 1536;
+    public static final int NUM_LAYERS = 6;
+    public static final int MAX_POSITION_EMBEDDINGS = 512;
+
+    // ---- Embedding weights ------------------------------------------------------
+
+    /**
+     * Word embeddings: [30522, 384] flattened to float[30522 × 384].
+     */
+    public final float[] wordEmbeddings;
+
+    /**
+     * Position embeddings: [512, 384] flattened to float[512 × 384].
+     */
+    public final float[] positionEmbeddings;
+
+    /**
+     * Token type embeddings: [2, 384] flattened to float[2 × 384].
+     */
+    public final float[] tokenTypeEmbeddings;
+
+    /**
+     * Embedding LayerNorm weight (gamma): [384].
+     */
+    public final float[] embeddingLayerNormWeight;
+
+    /**
+     * Embedding LayerNorm bias (beta): [384].
+     */
+    public final float[] embeddingLayerNormBias;
+
+    // ---- Encoder layers ---------------------------------------------------------
+
+    /**
+     * Per-layer weights for all 6 encoder layers.
+     */
+    public final LayerWeights[] layers;
+
+    /**
+     * Holds the 16 weight tensors for a single BERT encoder layer.
+     *
+     * @param queryWeight              attention query weight [384, 384]
+     * @param queryBias                attention query bias [384]
+     * @param keyWeight                attention key weight [384, 384]
+     * @param keyBias                  attention key bias [384]
+     * @param valueWeight              attention value weight [384, 384]
+     * @param valueBias                attention value bias [384]
+     * @param attentionOutputWeight    attention output dense weight [384, 384]
+     * @param attentionOutputBias      attention output dense bias [384]
+     * @param attentionLayerNormWeight attention output LayerNorm weight [384]
+     * @param attentionLayerNormBias   attention output LayerNorm bias [384]
+     * @param intermediateWeight       intermediate (FFN up) dense weight [1536, 384]
+     * @param intermediateBias         intermediate (FFN up) dense bias [1536]
+     * @param outputWeight             output (FFN down) dense weight [384, 1536]
+     * @param outputBias               output (FFN down) dense bias [384]
+     * @param outputLayerNormWeight    output LayerNorm weight [384]
+     * @param outputLayerNormBias      output LayerNorm bias [384]
+     */
+    public record LayerWeights(
+        float[] queryWeight,
+        float[] queryBias,
+        float[] keyWeight,
+        float[] keyBias,
+        float[] valueWeight,
+        float[] valueBias,
+        float[] attentionOutputWeight,
+        float[] attentionOutputBias,
+        float[] attentionLayerNormWeight,
+        float[] attentionLayerNormBias,
+        float[] intermediateWeight,
+        float[] intermediateBias,
+        float[] outputWeight,
+        float[] outputBias,
+        float[] outputLayerNormWeight,
+        float[] outputLayerNormBias
+    ) {
+
+        /**
+         * Returns the total number of float parameters in this layer.
+         */
+        public long parameterCount() {
+            return (long) queryWeight.length + queryBias.length
+                + keyWeight.length + keyBias.length
+                + valueWeight.length + valueBias.length
+                + attentionOutputWeight.length + attentionOutputBias.length
+                + attentionLayerNormWeight.length + attentionLayerNormBias.length
+                + intermediateWeight.length + intermediateBias.length
+                + outputWeight.length + outputBias.length
+                + outputLayerNormWeight.length + outputLayerNormBias.length;
+        }
+    }
+
+    /**
+     * Loads all 101 tensors of the all-MiniLM-L6-v2 model from a safetensors file.
+     *
+     * @param reader an open {@link SafetensorsReader} positioned on the model file
+     * @throws IOException if any tensor cannot be read from the file
+     */
+    public BertWeights(@NotNull SafetensorsReader reader) throws IOException {
+        // ---- Embeddings ---------------------------------------------------------
+        wordEmbeddings = reader.loadTensor("bert.embeddings.word_embeddings.weight");
+        positionEmbeddings = reader.loadTensor("bert.embeddings.position_embeddings.weight");
+        tokenTypeEmbeddings = reader.loadTensor("bert.embeddings.token_type_embeddings.weight");
+        embeddingLayerNormWeight = reader.loadTensor("bert.embeddings.LayerNorm.weight");
+        embeddingLayerNormBias = reader.loadTensor("bert.embeddings.LayerNorm.bias");
+
+        // ---- Encoder layers -----------------------------------------------------
+        layers = new LayerWeights[NUM_LAYERS];
+        for (int i = 0; i < NUM_LAYERS; i++) {
+            String prefix = "bert.encoder.layer." + i + ".";
+            layers[i] = new LayerWeights(
+                reader.loadTensor(prefix + "attention.self.query.weight"),
+                reader.loadTensor(prefix + "attention.self.query.bias"),
+                reader.loadTensor(prefix + "attention.self.key.weight"),
+                reader.loadTensor(prefix + "attention.self.key.bias"),
+                reader.loadTensor(prefix + "attention.self.value.weight"),
+                reader.loadTensor(prefix + "attention.self.value.bias"),
+                reader.loadTensor(prefix + "attention.output.dense.weight"),
+                reader.loadTensor(prefix + "attention.output.dense.bias"),
+                reader.loadTensor(prefix + "attention.output.LayerNorm.weight"),
+                reader.loadTensor(prefix + "attention.output.LayerNorm.bias"),
+                reader.loadTensor(prefix + "intermediate.dense.weight"),
+                reader.loadTensor(prefix + "intermediate.dense.bias"),
+                reader.loadTensor(prefix + "output.dense.weight"),
+                reader.loadTensor(prefix + "output.dense.bias"),
+                reader.loadTensor(prefix + "output.LayerNorm.weight"),
+                reader.loadTensor(prefix + "output.LayerNorm.bias")
+            );
+        }
+
+        // ---- Log total parameter count ------------------------------------------
+        long totalParams = (long) wordEmbeddings.length
+            + positionEmbeddings.length
+            + tokenTypeEmbeddings.length
+            + embeddingLayerNormWeight.length
+            + embeddingLayerNormBias.length;
+        for (LayerWeights layer : layers) {
+            totalParams += layer.parameterCount();
+        }
+        LOG.info("Loaded BertWeights: " + totalParams + " parameters from 101 tensors");
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/BertWeights.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/BertWeights.java
@@ -117,6 +117,25 @@ public final class BertWeights {
     }
 
     /**
+     * Package-private for testing — constructs BertWeights from pre-built arrays,
+     * bypassing SafetensorsReader. Arrays are not validated for size.
+     */
+    BertWeights(
+        float[] wordEmbeddings,
+        float[] positionEmbeddings,
+        float[] tokenTypeEmbeddings,
+        float[] embeddingLayerNormWeight,
+        float[] embeddingLayerNormBias,
+        LayerWeights[] layers) {
+        this.wordEmbeddings = wordEmbeddings;
+        this.positionEmbeddings = positionEmbeddings;
+        this.tokenTypeEmbeddings = tokenTypeEmbeddings;
+        this.embeddingLayerNormWeight = embeddingLayerNormWeight;
+        this.embeddingLayerNormBias = embeddingLayerNormBias;
+        this.layers = layers;
+    }
+
+    /**
      * Loads all 101 tensors of the all-MiniLM-L6-v2 model from a safetensors file.
      *
      * @param reader an open {@link SafetensorsReader} positioned on the model file

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/Embedder.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/Embedder.java
@@ -15,7 +15,7 @@ public interface Embedder {
      *
      * @param text the text to embed
      * @return float array of dimension {@link EmbeddingService#EMBEDDING_DIM}
-     * @throws Exception if embedding fails (I/O, ONNX inference, etc.)
+     * @throws Exception if embedding fails (I/O, inference, etc.)
      */
     float[] embed(@NotNull String text) throws Exception;
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/EmbeddingService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/EmbeddingService.java
@@ -41,9 +41,18 @@ public final class EmbeddingService implements Disposable, Embedder {
      * bypassing model download and weight loading.
      */
     EmbeddingService(WordPieceTokenizer tokenizer, InferenceFunction inference) {
+        this(tokenizer, inference, null);
+    }
+
+    /**
+     * Package-private for testing — pre-initializes with tokenizer, inference function, and an
+     * already-open safetensors reader (so {@link #dispose()} can be exercised in tests).
+     */
+    EmbeddingService(WordPieceTokenizer tokenizer, InferenceFunction inference, SafetensorsReader safetensorsReader) {
         this.project = null;
         this.tokenizer = tokenizer;
         this.inference = inference;
+        this.safetensorsReader = safetensorsReader;
         this.initialized = true;
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/EmbeddingService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/EmbeddingService.java
@@ -174,6 +174,8 @@ public final class EmbeddingService implements Disposable, Embedder {
             }
             safetensorsReader = null;
         }
+        tokenizer = null;
+        inference = null;
         initialized = false;
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/EmbeddingService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/EmbeddingService.java
@@ -1,20 +1,14 @@
 package com.github.catatafishen.agentbridge.memory.embedding;
 
-import ai.onnxruntime.OnnxTensor;
-import ai.onnxruntime.OrtEnvironment;
-import ai.onnxruntime.OrtException;
-import ai.onnxruntime.OrtSession;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.nio.LongBuffer;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public final class EmbeddingService implements Disposable, Embedder {
 
@@ -24,15 +18,14 @@ public final class EmbeddingService implements Disposable, Embedder {
     private static final int MAX_SEQ_LENGTH = 256;
 
     private final Project project;
-    private volatile OrtEnvironment env;
-    private volatile OrtSession session;
     private volatile WordPieceTokenizer tokenizer;
     private volatile InferenceFunction inference;
+    private volatile SafetensorsReader safetensorsReader;
     private volatile boolean initialized;
     private final Object initLock = new Object();
 
     /**
-     * Runs ONNX inference on tokenized input, returning a 384-dim embedding.
+     * Runs inference on tokenized input, returning a 384-dim embedding.
      */
     @FunctionalInterface
     interface InferenceFunction {
@@ -45,7 +38,7 @@ public final class EmbeddingService implements Disposable, Embedder {
 
     /**
      * Package-private for testing — pre-initializes with a custom tokenizer and inference function,
-     * bypassing ONNX Runtime and model download.
+     * bypassing model download and weight loading.
      */
     EmbeddingService(WordPieceTokenizer tokenizer, InferenceFunction inference) {
         this.project = null;
@@ -56,10 +49,10 @@ public final class EmbeddingService implements Disposable, Embedder {
 
     /**
      * Produce a 384-dimensional embedding for the given text.
-     * Initializes the ONNX session on first call (downloads model if needed).
+     * Initializes the inference engine on first call (downloads model if needed).
      *
      * @throws IOException if the model cannot be downloaded
-     * @throws Exception   if ONNX inference fails
+     * @throws Exception   if inference fails
      */
     @Override
     public float[] embed(@NotNull String text) throws Exception {
@@ -101,52 +94,21 @@ public final class EmbeddingService implements Disposable, Embedder {
             Path vocabPath = ModelDownloader.getVocabPath();
             Path modelPath = ModelDownloader.getModelPath();
 
+            tokenizer = new WordPieceTokenizer(vocabPath, MAX_SEQ_LENGTH);
+            SafetensorsReader localReader = new SafetensorsReader(modelPath);
+            boolean success = false;
             try {
-                tokenizer = new WordPieceTokenizer(vocabPath, MAX_SEQ_LENGTH);
-                env = OrtEnvironment.getEnvironment();
-                OrtSession.SessionOptions opts = new OrtSession.SessionOptions();
-                opts.setIntraOpNumThreads(1);
-                session = env.createSession(modelPath.toString(), opts);
-                inference = this::runOnnxInference;
+                BertWeights weights = new BertWeights(localReader);
+                inference = new BertInferenceEngine(weights);
+                safetensorsReader = localReader;
                 initialized = true;
-                LOG.info("EmbeddingService initialized with model from " + modelPath);
-            } catch (OrtException e) {
-                throw new IOException("Failed to initialize ONNX Runtime session", e);
+                success = true;
+                LOG.info("EmbeddingService initialized with pure-Java BERT inference from " + modelPath);
+            } finally {
+                if (!success) {
+                    localReader.close();
+                }
             }
-        }
-    }
-
-    /**
-     * Run inference on a single tokenized input via ONNX Runtime.
-     * Performs mean pooling over token embeddings, then L2-normalizes the result.
-     */
-    private float[] runOnnxInference(@NotNull WordPieceTokenizer.TokenizedInput input) throws OrtException {
-        int seqLen = input.sequenceLength();
-
-        OnnxTensor inputIds = OnnxTensor.createTensor(env,
-            LongBuffer.wrap(input.inputIds()), new long[]{1, seqLen});
-        OnnxTensor attentionMask = OnnxTensor.createTensor(env,
-            LongBuffer.wrap(input.attentionMask()), new long[]{1, seqLen});
-        OnnxTensor tokenTypeIds = OnnxTensor.createTensor(env,
-            LongBuffer.wrap(input.tokenTypeIds()), new long[]{1, seqLen});
-
-        try (OrtSession.Result result = session.run(Map.of(
-            "input_ids", inputIds,
-            "attention_mask", attentionMask,
-            "token_type_ids", tokenTypeIds
-        ))) {
-            // Output shape: [1, seq_len, 384] — token-level embeddings
-            float[][][] tokenEmbeddings = (float[][][]) result.get(0).getValue();
-
-            // Mean pooling: average over non-padding tokens
-            float[] pooled = meanPool(tokenEmbeddings[0], input.attentionMask());
-
-            // L2 normalize
-            return l2Normalize(pooled);
-        } finally {
-            inputIds.close();
-            attentionMask.close();
-            tokenTypeIds.close();
         }
     }
 
@@ -195,17 +157,13 @@ public final class EmbeddingService implements Disposable, Embedder {
 
     @Override
     public void dispose() {
-        try {
-            if (session != null) {
-                session.close();
-                session = null;
+        if (safetensorsReader != null) {
+            try {
+                safetensorsReader.close();
+            } catch (IOException e) {
+                LOG.warn("Error closing SafetensorsReader", e);
             }
-            if (env != null) {
-                env.close();
-                env = null;
-            }
-        } catch (OrtException e) {
-            LOG.warn("Error closing ONNX Runtime session", e);
+            safetensorsReader = null;
         }
         initialized = false;
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/ModelDownloader.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/ModelDownloader.java
@@ -17,14 +17,16 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
 
 /**
- * Downloads the all-MiniLM-L6-v2 ONNX model and vocabulary on first use.
+ * Downloads the all-MiniLM-L6-v2 model weights and vocabulary on first use.
  * Files are stored globally at {@code ~/.agentbridge/models/all-MiniLM-L6-v2/}
  * so they're shared across all projects.
  *
  * <p>Downloads with a progress indicator in the IDE status bar.
+ *
+ * <p>Migration: if the legacy {@code model.onnx} file exists (from plugin versions
+ * before the switch to pure-Java inference), it is deleted automatically.
  */
 public final class ModelDownloader {
 
@@ -33,10 +35,12 @@ public final class ModelDownloader {
     private static final String MODEL_DIR_NAME = "all-MiniLM-L6-v2";
 
     /**
-     * Hugging Face ONNX model URL (exported via Optimum).
+     * Hugging Face safetensors model URL.
+     * Safetensors stores weights with their original PyTorch names,
+     * making loading trivial compared to the ONNX graph format.
      */
     private static final String MODEL_URL =
-        "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model.onnx";
+        "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/model.safetensors";
 
     /**
      * Vocabulary file URL.
@@ -44,9 +48,12 @@ public final class ModelDownloader {
     private static final String VOCAB_URL =
         "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/vocab.txt";
 
+    private static final String LEGACY_MODEL_FILENAME = "model.onnx";
+
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(30);
 
-    private ModelDownloader() {}
+    private ModelDownloader() {
+    }
 
     /**
      * Returns the model directory. Creates it if it doesn't exist.
@@ -57,10 +64,10 @@ public final class ModelDownloader {
     }
 
     /**
-     * Returns the path to the ONNX model file.
+     * Returns the path to the safetensors model file.
      */
     public static @NotNull Path getModelPath() {
-        return getModelDirectory().resolve("model.onnx");
+        return getModelDirectory().resolve("model.safetensors");
     }
 
     /**
@@ -81,13 +88,16 @@ public final class ModelDownloader {
      * Ensure the model is downloaded. If missing, downloads with a progress indicator.
      * Blocks until the download completes or fails.
      *
+     * <p>Also migrates from the legacy {@code model.onnx} format if present:
+     * deletes the old file since it is no longer used.
+     *
      * @param project the current project (for progress display)
      * @throws IOException if the download fails
      */
     public static void ensureModelAvailable(@NotNull Project project) throws IOException {
-        if (isModelAvailable()) return;
+        migrateLegacyModel(getModelDirectory());
 
-        CompletableFuture<IOException> result = new CompletableFuture<>();
+        if (isModelAvailable()) return;
 
         ProgressManager.getInstance().run(new Task.WithResult<Void, IOException>(
             project, "Downloading Embedding Model", true
@@ -105,7 +115,7 @@ public final class ModelDownloader {
                     }
 
                     if (!Files.exists(getModelPath())) {
-                        indicator.setText("Downloading all-MiniLM-L6-v2 ONNX model (~90 MB)...");
+                        indicator.setText("Downloading all-MiniLM-L6-v2 model (~91 MB)...");
                         downloadFile(MODEL_URL, getModelPath(), indicator, 0.05, 1.0);
                     }
 
@@ -121,6 +131,24 @@ public final class ModelDownloader {
         });
     }
 
+    /**
+     * Deletes the legacy {@code model.onnx} file if it exists in the given directory.
+     * Called automatically by {@link #ensureModelAvailable} during migration
+     * from ONNX Runtime to pure-Java inference.
+     *
+     * @param modelDir the directory to check for the legacy model file
+     */
+    static void migrateLegacyModel(@NotNull Path modelDir) {
+        Path legacyModel = modelDir.resolve(LEGACY_MODEL_FILENAME);
+        try {
+            if (Files.deleteIfExists(legacyModel)) {
+                LOG.info("Deleted legacy ONNX model file: " + legacyModel);
+            }
+        } catch (IOException e) {
+            LOG.warn("Failed to delete legacy ONNX model: " + legacyModel, e);
+        }
+    }
+
     private static void downloadFile(
         @NotNull String url,
         @NotNull Path target,
@@ -129,11 +157,10 @@ public final class ModelDownloader {
         double fractionEnd
     ) throws IOException {
         Path tempFile = target.resolveSibling(target.getFileName() + ".tmp");
-        try {
-            HttpClient client = HttpClient.newBuilder()
-                .connectTimeout(CONNECT_TIMEOUT)
-                .followRedirects(HttpClient.Redirect.NORMAL)
-                .build();
+        try (HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(CONNECT_TIMEOUT)
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build()) {
 
             HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))
@@ -146,15 +173,13 @@ public final class ModelDownloader {
             }
 
             long contentLength = response.headers().firstValueAsLong("content-length").orElse(-1);
-            try (InputStream in = response.body()) {
+            try (InputStream in = response.body();
+                 java.io.OutputStream out = Files.newOutputStream(tempFile)) {
                 long downloaded = 0;
                 byte[] buffer = new byte[65536];
-                var out = Files.newOutputStream(tempFile);
                 int read;
                 while ((read = in.read(buffer)) != -1) {
                     if (indicator.isCanceled()) {
-                        out.close();
-                        Files.deleteIfExists(tempFile);
                         throw new IOException("Download cancelled by user");
                     }
                     out.write(buffer, 0, read);
@@ -164,7 +189,6 @@ public final class ModelDownloader {
                         indicator.setFraction(fractionStart + progress * (fractionEnd - fractionStart));
                     }
                 }
-                out.close();
             }
 
             Files.move(tempFile, target, StandardCopyOption.REPLACE_EXISTING);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/ModelDownloader.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/ModelDownloader.java
@@ -136,6 +136,9 @@ public final class ModelDownloader {
      * Called automatically by {@link #ensureModelAvailable} during migration
      * from ONNX Runtime to pure-Java inference.
      *
+     * <p><b>Deprecation:</b> Remove this method after the next Marketplace release,
+     * once all users have migrated from ONNX to safetensors.
+     *
      * @param modelDir the directory to check for the legacy model file
      */
     static void migrateLegacyModel(@NotNull Path modelDir) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/SafetensorsReader.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/SafetensorsReader.java
@@ -1,0 +1,238 @@
+package com.github.catatafishen.agentbridge.memory.embedding;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.intellij.openapi.diagnostic.Logger;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+/**
+ * Reads tensors from a
+ * <a href="https://huggingface.co/docs/safetensors/index">safetensors</a>
+ * binary file using memory-mapped I/O.
+ *
+ * <p>The safetensors format is:
+ * <pre>
+ * [8 bytes : little-endian uint64 header_length]
+ * [header_length bytes : UTF-8 JSON metadata]
+ * [data section : raw packed tensors at byte offsets declared in JSON]
+ * </pre>
+ *
+ * <p>Each JSON entry maps a tensor name to its {@code dtype}, {@code shape},
+ * and {@code data_offsets} (start/end relative to the data section).
+ *
+ * <p>This reader only supports {@code F32} tensors. It memory-maps the data
+ * section via {@link FileChannel#map(FileChannel.MapMode, long, long)} for
+ * efficient random access without copying entire files into heap memory.
+ *
+ * <p>Implements {@link Closeable} — use in a try-with-resources block.
+ */
+public final class SafetensorsReader implements Closeable {
+
+    private static final Logger LOG = Logger.getInstance(SafetensorsReader.class);
+
+    /**
+     * Safety limit: reject header lengths >= 100 MB to prevent OOM on corrupt files.
+     */
+    private static final long MAX_HEADER_LENGTH = 100L * 1024 * 1024;
+
+    private static final String DTYPE_KEY = "dtype";
+
+    private final RandomAccessFile randomAccessFile;
+    private final JsonObject metadata;
+    private final MappedByteBuffer dataBuffer;
+
+    /**
+     * Opens a safetensors file and parses its metadata header.
+     *
+     * @param path path to the {@code .safetensors} file
+     * @throws IOException if the file cannot be read or has an invalid header
+     */
+    public SafetensorsReader(@NotNull Path path) throws IOException {
+        this.randomAccessFile = new RandomAccessFile(path.toFile(), "r");
+        try {
+            FileChannel channel = randomAccessFile.getChannel();
+
+            // --- 1. Read the 8-byte little-endian header length ---
+            ByteBuffer lengthBuf = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN);
+            readFully(channel, lengthBuf, 0);
+            lengthBuf.flip();
+            long headerLength = lengthBuf.getLong();
+
+            if (headerLength <= 0 || headerLength >= MAX_HEADER_LENGTH) {
+                throw new IOException(
+                    "Invalid safetensors header length: " + headerLength
+                        + " (must be > 0 and < " + MAX_HEADER_LENGTH + ")"
+                );
+            }
+            LOG.debug("Safetensors header length: " + headerLength + " bytes");
+
+            // --- 2. Read the JSON header ---
+            byte[] headerBytes = new byte[(int) headerLength];
+            ByteBuffer headerBuf = ByteBuffer.wrap(headerBytes);
+            readFully(channel, headerBuf, 8);
+            String headerJson = new String(headerBytes, StandardCharsets.UTF_8);
+            this.metadata = JsonParser.parseString(headerJson).getAsJsonObject();
+
+            // --- 3. Memory-map the data section ---
+            long dataStart = 8 + headerLength;
+            long dataLength = channel.size() - dataStart;
+            if (dataLength < 0) {
+                throw new IOException("Safetensors file shorter than declared header");
+            }
+            this.dataBuffer = channel.map(FileChannel.MapMode.READ_ONLY, dataStart, dataLength);
+            this.dataBuffer.order(ByteOrder.LITTLE_ENDIAN);
+
+            LOG.info("Opened safetensors file: " + path + " (data section: " + dataLength + " bytes)");
+        } catch (RuntimeException e) {
+            randomAccessFile.close();
+            throw new IOException("Invalid safetensors metadata header in file: " + path, e);
+        } catch (IOException e) {
+            randomAccessFile.close();
+            throw e;
+        }
+    }
+
+    /**
+     * Loads a tensor by name as a flat {@code float[]} array.
+     *
+     * @param name the tensor name as it appears in the safetensors metadata
+     * @return the tensor data as a float array
+     * @throws IOException              if the tensor is not found
+     * @throws IllegalArgumentException if the dtype is not {@code F32}
+     */
+    public float[] loadTensor(@NotNull String name) throws IOException {
+        JsonObject tensor = getTensorMetadata(name);
+
+        String dtype = tensor.get(DTYPE_KEY).getAsString();
+        if (!"F32".equals(dtype)) {
+            throw new IllegalArgumentException(
+                "Unsupported dtype '" + dtype + "' for tensor '" + name + "': only F32 is supported"
+            );
+        }
+
+        JsonArray offsets = tensor.getAsJsonArray("data_offsets");
+        long start = offsets.get(0).getAsLong();
+        long end = offsets.get(1).getAsLong();
+
+        if (start < 0 || end < start || end > dataBuffer.capacity()) {
+            throw new IOException(
+                "Tensor '" + name + "' has invalid data offsets [" + start + ", " + end
+                    + "): data section capacity is " + dataBuffer.capacity() + " bytes"
+            );
+        }
+
+        long byteLength = end - start;
+
+        if (byteLength % Float.BYTES != 0) {
+            throw new IOException(
+                "Tensor '" + name + "' byte range [" + start + ", " + end
+                    + ") is not a multiple of 4 (float size)"
+            );
+        }
+
+        int floatCount = (int) (byteLength / Float.BYTES);
+        float[] result = new float[floatCount];
+
+        // Create a duplicate so concurrent reads don't interfere with position state
+        ByteBuffer slice = dataBuffer.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+        slice.position((int) start);
+        slice.limit((int) end);
+        FloatBuffer floatBuffer = slice.asFloatBuffer();
+        floatBuffer.get(result);
+
+        LOG.debug("Loaded tensor '" + name + "': " + floatCount + " floats");
+        return result;
+    }
+
+    /**
+     * Returns the shape of a tensor as an {@code int[]} array.
+     *
+     * @param name the tensor name
+     * @return the shape dimensions (e.g. {@code [384, 384]} for a 2-D weight matrix)
+     * @throws IOException if the tensor is not found
+     */
+    public int[] getShape(@NotNull String name) throws IOException {
+        JsonObject tensor = getTensorMetadata(name);
+        JsonArray shapeArray = tensor.getAsJsonArray("shape");
+        int[] shape = new int[shapeArray.size()];
+        for (int i = 0; i < shapeArray.size(); i++) {
+            shape[i] = shapeArray.get(i).getAsInt();
+        }
+        return shape;
+    }
+
+    /**
+     * Checks whether a tensor with the given name exists in the file.
+     *
+     * @param name the tensor name to look up
+     * @return {@code true} if the tensor exists, {@code false} otherwise
+     */
+    public boolean hasTensor(@NotNull String name) {
+        if (!metadata.has(name)) {
+            return false;
+        }
+        JsonElement element = metadata.get(name);
+        // The metadata may contain a top-level "__metadata__" key that is not a tensor
+        return element.isJsonObject() && element.getAsJsonObject().has(DTYPE_KEY);
+    }
+
+    /**
+     * Closes the underlying {@link RandomAccessFile} and releases resources.
+     */
+    @Override
+    public void close() throws IOException {
+        randomAccessFile.close();
+        LOG.debug("Closed SafetensorsReader");
+    }
+
+    // ---- private helpers --------------------------------------------------------
+
+    /**
+     * Reads exactly {@code buf.remaining()} bytes from the channel at the given position.
+     * Unlike {@link FileChannel#read(ByteBuffer, long)}, this loops until the buffer is full
+     * or EOF is reached.
+     */
+    private static void readFully(FileChannel channel, ByteBuffer buf, long position) throws IOException {
+        long pos = position;
+        while (buf.hasRemaining()) {
+            int read = channel.read(buf, pos);
+            if (read < 0) {
+                throw new IOException(
+                    "Safetensors file too short: expected " + buf.capacity()
+                        + " bytes at offset " + position + ", got " + (buf.position())
+                );
+            }
+            pos += read;
+        }
+    }
+
+    /**
+     * Retrieves and validates the JSON metadata entry for a tensor.
+     */
+    @NotNull
+    private JsonObject getTensorMetadata(@NotNull String name) throws IOException {
+        if (!metadata.has(name) || !metadata.get(name).isJsonObject()) {
+            throw new IOException("Tensor not found in safetensors metadata: '" + name + "'");
+        }
+        JsonObject tensor = metadata.getAsJsonObject(name);
+        if (!tensor.has(DTYPE_KEY) || !tensor.has("data_offsets") || !tensor.has("shape")) {
+            throw new IOException(
+                "Tensor '" + name + "' metadata is missing required fields (dtype, shape, data_offsets)"
+            );
+        }
+        return tensor;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/WordPieceTokenizer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/WordPieceTokenizer.java
@@ -48,8 +48,8 @@ public final class WordPieceTokenizer {
     private final int maxSeqLength;
 
     /**
-     * @param vocabPath     path to the vocab.txt file
-     * @param maxSeqLength  maximum sequence length (256 for all-MiniLM-L6-v2)
+     * @param vocabPath    path to the vocab.txt file
+     * @param maxSeqLength maximum sequence length (256 for all-MiniLM-L6-v2)
      */
     public WordPieceTokenizer(@NotNull Path vocabPath, int maxSeqLength) throws IOException {
         this.maxSeqLength = maxSeqLength;
@@ -61,7 +61,7 @@ public final class WordPieceTokenizer {
     }
 
     /**
-     * Tokenize text into ONNX-ready tensors.
+     * Tokenize text into inference-ready tensors.
      *
      * @return TokenizedInput with input_ids, attention_mask, and token_type_ids
      */
@@ -179,7 +179,7 @@ public final class WordPieceTokenizer {
     }
 
     /**
-     * Tokenized output ready for ONNX Runtime inference.
+     * Tokenized output ready for BERT inference.
      */
     public record TokenizedInput(long[] inputIds, long[] attentionMask, long[] tokenTypeIds) {
         public int sequenceLength() {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/layers/DeepSearchLayer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/layers/DeepSearchLayer.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 /**
  * L3 — Deep Search layer. Full semantic KNN search using embeddings.
- * This is the most expensive layer, requiring ONNX inference for the query.
+ * This is the most expensive layer, requiring inference for the query.
  *
  * <p><b>Attribution:</b> deep search concept from MemPalace's layers.py (MIT License).
  */

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/BertInferenceEngineTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/BertInferenceEngineTest.java
@@ -1,0 +1,169 @@
+package com.github.catatafishen.agentbridge.memory.embedding;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for the package-private primitive operations in {@link BertInferenceEngine}:
+ * {@code layerNorm}, {@code linear}, {@code gelu}, and {@code softmax}.
+ *
+ * <p>These are pure-math tests — the engine is constructed with a dummy
+ * {@link BertWeights} because the primitive ops never access the weights field.
+ */
+class BertInferenceEngineTest {
+
+    private static BertInferenceEngine engine;
+
+    @BeforeAll
+    static void setUp() {
+        // The primitive ops under test never access the weights field,
+        // so a mock is sufficient to satisfy the @NotNull constructor parameter.
+        engine = new BertInferenceEngine(mock(BertWeights.class));
+    }
+
+    // ---- layerNorm --------------------------------------------------------------
+
+    @Test
+    void layerNormZeroMeanUnitVariance() {
+        float[] x = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+        float[] gamma = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+        float[] beta = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+        engine.layerNorm(x, 5, gamma, beta);
+
+        // Output should have mean ≈ 0
+        float mean = 0.0f;
+        for (float v : x) {
+            mean += v;
+        }
+        mean /= x.length;
+        assertEquals(0.0f, mean, 1e-5f, "mean should be ≈ 0");
+
+        // Output should have variance ≈ 1
+        float variance = 0.0f;
+        for (float v : x) {
+            variance += v * v;
+        }
+        variance /= x.length;
+        assertEquals(1.0f, variance, 1e-5f, "variance should be ≈ 1");
+
+        // Verify specific known values:
+        // input [1,2,3,4,5] → mean=3, var=2, invStd = 1/√(2 + 1e-12) ≈ 0.7071
+        float invStd = (float) (1.0 / Math.sqrt(2.0 + 1e-12));
+        assertEquals(-2.0f * invStd, x[0], 1e-5f);
+        assertEquals(-1.0f * invStd, x[1], 1e-5f);
+        assertEquals(0.0f, x[2], 1e-5f);
+        assertEquals(1.0f * invStd, x[3], 1e-5f);
+        assertEquals(2.0f * invStd, x[4], 1e-5f);
+    }
+
+    @Test
+    void layerNormScalesAndShifts() {
+        float[] x = {0.0f, 0.0f, 0.0f};
+        float[] gamma = {2.0f, 2.0f, 2.0f};
+        float[] beta = {1.0f, 1.0f, 1.0f};
+
+        engine.layerNorm(x, 3, gamma, beta);
+
+        // Constant input: (x − mean) = 0 for all elements,
+        // so result = 0 × invStd × gamma + beta = beta
+        assertEquals(1.0f, x[0], 1e-5f);
+        assertEquals(1.0f, x[1], 1e-5f);
+        assertEquals(1.0f, x[2], 1e-5f);
+    }
+
+    // ---- linear -----------------------------------------------------------------
+
+    @Test
+    void linearMultipliesAndAdds() {
+        // 2×2 identity weight, bias [10, 20], input [3, 5]
+        float[] input = {3.0f, 5.0f};
+        float[] weight = {1.0f, 0.0f, 0.0f, 1.0f}; // row-major: row0=[1,0], row1=[0,1]
+        float[] bias = {10.0f, 20.0f};
+
+        float[] result = engine.linear(input, 2, weight, bias, 2);
+
+        assertEquals(13.0f, result[0], 1e-6f);
+        assertEquals(25.0f, result[1], 1e-6f);
+    }
+
+    @Test
+    void linearNonSquareMatrix() {
+        // 3→2 transformation: pick first two components
+        float[] input = {1.0f, 2.0f, 3.0f};
+        float[] weight = {
+            1.0f, 0.0f, 0.0f, // row 0 (inDim=3): selects input[0]
+            0.0f, 1.0f, 0.0f  // row 1 (inDim=3): selects input[1]
+        };
+        float[] bias = {0.0f, 0.0f};
+
+        float[] result = engine.linear(input, 3, weight, bias, 2);
+
+        assertEquals(1.0f, result[0], 1e-6f);
+        assertEquals(2.0f, result[1], 1e-6f);
+    }
+
+    // ---- gelu -------------------------------------------------------------------
+
+    @Test
+    void geluApproximation() {
+        float[] x = {0.0f, 1.0f, -1.0f, 3.0f};
+
+        engine.gelu(x, 4);
+
+        assertEquals(0.0f, x[0], 1e-3f, "gelu(0) should be 0");
+        assertEquals(0.8413f, x[1], 1e-3f, "gelu(1) should be ≈ 0.8413");
+        assertEquals(-0.1587f, x[2], 1e-3f, "gelu(-1) should be ≈ -0.1587");
+        assertEquals(2.9960f, x[3], 1e-3f, "gelu(3) should be ≈ 2.9960");
+    }
+
+    // ---- softmax ----------------------------------------------------------------
+
+    @Test
+    void softmaxSumsToOne() {
+        float[] x = {1.0f, 2.0f, 3.0f, 100.0f, 200.0f};
+
+        engine.softmax(x, 5);
+
+        float sum = 0.0f;
+        for (float v : x) {
+            sum += v;
+        }
+        assertEquals(1.0f, sum, 1e-6f, "softmax output should sum to 1.0");
+
+        // The max element (originally 200) should dominate the distribution
+        assertEquals(1.0f, x[4], 1e-6f, "softmax of dominant element should be ≈ 1.0");
+    }
+
+    @Test
+    void softmaxSlice() {
+        // softmax(x, 3) processes only x[0..2], leaving x[3] and x[4] unchanged.
+        // (The actual API has no offset parameter — it always starts at index 0.)
+        float[] x = {1.0f, 2.0f, 3.0f, 99.0f, 99.0f};
+
+        engine.softmax(x, 3);
+
+        // Elements beyond len should be unchanged
+        assertEquals(99.0f, x[3], 0.0f, "element outside softmax range must be unchanged");
+        assertEquals(99.0f, x[4], 0.0f, "element outside softmax range must be unchanged");
+
+        // First 3 elements should sum to ≈ 1.0
+        float sum = x[0] + x[1] + x[2];
+        assertEquals(1.0f, sum, 1e-6f, "softmax of first 3 elements should sum to 1.0");
+    }
+
+    @Test
+    void softmaxUniformInput() {
+        float[] x = {5.0f, 5.0f, 5.0f};
+
+        engine.softmax(x, 3);
+
+        float expected = 1.0f / 3.0f;
+        assertEquals(expected, x[0], 1e-6f);
+        assertEquals(expected, x[1], 1e-6f);
+        assertEquals(expected, x[2], 1e-6f);
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/BertInferenceEngineTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/BertInferenceEngineTest.java
@@ -3,9 +3,10 @@ package com.github.catatafishen.agentbridge.memory.embedding;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.Mockito.mock;
 
 /**
  * Tests for the package-private primitive operations in {@link BertInferenceEngine}:
@@ -20,9 +21,10 @@ class BertInferenceEngineTest {
 
     @BeforeAll
     static void setUp() {
-        // The primitive ops under test never access the weights field,
-        // so a mock is sufficient to satisfy the @NotNull constructor parameter.
-        engine = new BertInferenceEngine(mock(BertWeights.class));
+        // Use the test constructor to create a minimal-but-real BertWeights.
+        // The primitive ops under test (layerNorm, linear, etc.) access the weights
+        // fields at most incidentally — they receive all inputs as explicit parameters.
+        engine = new BertInferenceEngine(makeTestWeights(1));
     }
 
     // ---- layerNorm --------------------------------------------------------------
@@ -243,6 +245,48 @@ class BertInferenceEngineTest {
         assertEquals(0.0f, mean, 1e-4f, "feedForward output mean should be ≈ 0 after LayerNorm");
     }
 
+    // ---- run() end-to-end -------------------------------------------------------
+
+    @Test
+    void runProducesCorrectShapeEmbedding() {
+        // Create BertWeights with minimal arrays — only enough for token IDs [2, 3, 4].
+        // The zero-weights produce deterministic math without NaN.
+        BertWeights weights = makeTestWeights(3);
+        BertInferenceEngine eng = new BertInferenceEngine(weights);
+
+        // [CLS]=2, hello=4, [SEP]=3 — token IDs within the small word-embedding table
+        WordPieceTokenizer.TokenizedInput input = new WordPieceTokenizer.TokenizedInput(
+            new long[]{2, 4, 3},
+            new long[]{1, 1, 1},
+            new long[]{0, 0, 0}
+        );
+
+        float[] result = eng.run(input);
+
+        assertEquals(BertWeights.HIDDEN_DIM, result.length, "embedding must be 384-dimensional");
+        for (float v : result) {
+            assertFalse(Float.isNaN(v), "embedding must not contain NaN");
+        }
+    }
+
+    @Test
+    void layerWeightsParameterCountMatchesLayerDimensions() {
+        BertWeights.LayerWeights layer = makeZeroLayer();
+        long count = layer.parameterCount();
+
+        // 4 × [H×H] matrices + 4 × H biases + 2 × H LN params + 2 × [I×H] FF matrices + I+H biases + 2 × H LN
+        // = 4*147456 + 6*384 + 2*589824 + 1536 + 3*384 = 1,774,464
+        long expected = 4L * BertWeights.HIDDEN_DIM * BertWeights.HIDDEN_DIM  // Q, K, V, att-out weights
+            + 4L * BertWeights.HIDDEN_DIM                                       // Q, K, V, att-out biases
+            + 2L * BertWeights.HIDDEN_DIM                                       // att-LN gamma + beta
+            + (long) BertWeights.INTERMEDIATE_DIM * BertWeights.HIDDEN_DIM     // intermediate weight
+            + BertWeights.INTERMEDIATE_DIM                                       // intermediate bias
+            + (long) BertWeights.HIDDEN_DIM * BertWeights.INTERMEDIATE_DIM     // output weight
+            + BertWeights.HIDDEN_DIM                                             // output bias
+            + 2L * BertWeights.HIDDEN_DIM;                                      // output LN gamma + beta
+        assertEquals(expected, count);
+    }
+
     // ---- Helpers ----------------------------------------------------------------
 
     private static float[][] makeHidden(int seqLen) {
@@ -288,5 +332,26 @@ class BertInferenceEngineTest {
                 assertFalse(Float.isNaN(v), "NaN found at row " + i);
             }
         }
+    }
+
+    /**
+     * Builds a {@link BertWeights} with the minimum embedding tables needed to handle
+     * {@code seqLen} tokens using IDs [2..seqLen+1]. All weights are zero; layer-norm
+     * gamma is 1 and beta is 0, so outputs are deterministic and never NaN.
+     */
+    private static BertWeights makeTestWeights(int seqLen) {
+        int h = BertWeights.HIDDEN_DIM;
+        int vocabRows = seqLen + 3; // token IDs 0..seqLen+2
+        float[] wordEmb = new float[vocabRows * h];
+        float[] posEmb = new float[(seqLen + 1) * h];
+        float[] typeEmb = new float[2 * h];
+        float[] lnGamma = new float[h];
+        Arrays.fill(lnGamma, 1.0f);
+        float[] lnBeta = new float[h];
+        BertWeights.LayerWeights[] layers = new BertWeights.LayerWeights[6];
+        for (int i = 0; i < 6; i++) {
+            layers[i] = makeZeroLayer();
+        }
+        return new BertWeights(wordEmb, posEmb, typeEmb, lnGamma, lnBeta, layers);
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/BertInferenceEngineTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/BertInferenceEngineTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -56,7 +57,7 @@ class BertInferenceEngineTest {
         assertEquals(-2.0f * invStd, x[0], 1e-5f);
         assertEquals(-1.0f * invStd, x[1], 1e-5f);
         assertEquals(0.0f, x[2], 1e-5f);
-        assertEquals(1.0f * invStd, x[3], 1e-5f);
+        assertEquals(invStd, x[3], 1e-5f);
         assertEquals(2.0f * invStd, x[4], 1e-5f);
     }
 
@@ -165,5 +166,127 @@ class BertInferenceEngineTest {
         assertEquals(expected, x[0], 1e-6f);
         assertEquals(expected, x[1], 1e-6f);
         assertEquals(expected, x[2], 1e-6f);
+    }
+
+    // ---- selfAttention ----------------------------------------------------------
+
+    @Test
+    void selfAttentionWithAllRealTokensRunsWithoutNaN() {
+        int seqLen = 2;
+        float[][] hidden = makeHidden(seqLen);
+        BertWeights.LayerWeights layer = makeZeroLayer();
+        long[] mask = {1L, 1L};
+
+        engine.selfAttention(hidden, seqLen, layer, mask);
+
+        assertEquals(seqLen, hidden.length);
+        assertEquals(BertWeights.HIDDEN_DIM, hidden[0].length);
+        assertNoNaN(hidden, seqLen);
+    }
+
+    @Test
+    void selfAttentionWithPaddingMaskRunsWithoutNaN() {
+        // The third token has attentionMask = 0, so its score gets MASK_VALUE (-10000)
+        // added before softmax, effectively masking it from attending.
+        int seqLen = 3;
+        float[][] hidden = makeHidden(seqLen);
+        BertWeights.LayerWeights layer = makeZeroLayer();
+        long[] mask = {1L, 1L, 0L};
+
+        engine.selfAttention(hidden, seqLen, layer, mask);
+
+        assertNoNaN(hidden, seqLen);
+    }
+
+    @Test
+    void selfAttentionPreservesShapeForSingleToken() {
+        int seqLen = 1;
+        float[][] hidden = makeHidden(seqLen);
+        BertWeights.LayerWeights layer = makeZeroLayer();
+        long[] mask = {1L};
+
+        engine.selfAttention(hidden, seqLen, layer, mask);
+
+        assertEquals(1, hidden.length);
+        assertEquals(BertWeights.HIDDEN_DIM, hidden[0].length);
+        assertNoNaN(hidden, seqLen);
+    }
+
+    // ---- feedForward ------------------------------------------------------------
+
+    @Test
+    void feedForwardRunsWithoutNaN() {
+        int seqLen = 2;
+        float[][] hidden = makeHidden(seqLen);
+        BertWeights.LayerWeights layer = makeZeroLayer();
+
+        engine.feedForward(hidden, seqLen, layer);
+
+        assertEquals(seqLen, hidden.length);
+        assertEquals(BertWeights.HIDDEN_DIM, hidden[0].length);
+        assertNoNaN(hidden, seqLen);
+    }
+
+    @Test
+    void feedForwardOutputHasMeanNearZero() {
+        // With all-zero FFN weight matrices, the output is layerNorm(residual),
+        // so the mean of the output over the hidden dimension should be ≈ 0.
+        int seqLen = 1;
+        float[][] hidden = makeHidden(seqLen);
+        BertWeights.LayerWeights layer = makeZeroLayer();
+
+        engine.feedForward(hidden, seqLen, layer);
+
+        float mean = 0.0f;
+        for (float v : hidden[0]) mean += v;
+        mean /= BertWeights.HIDDEN_DIM;
+        assertEquals(0.0f, mean, 1e-4f, "feedForward output mean should be ≈ 0 after LayerNorm");
+    }
+
+    // ---- Helpers ----------------------------------------------------------------
+
+    private static float[][] makeHidden(int seqLen) {
+        float[][] h = new float[seqLen][BertWeights.HIDDEN_DIM];
+        for (int i = 0; i < seqLen; i++) {
+            for (int j = 0; j < BertWeights.HIDDEN_DIM; j++) {
+                h[i][j] = (i + 1) * 0.001f + j * 0.0001f;
+            }
+        }
+        return h;
+    }
+
+    /**
+     * Builds a {@link BertWeights.LayerWeights} with all-zero weight matrices
+     * and identity layer-norm parameters (gamma=1, beta=0).
+     * Suitable for testing that the computation paths run without arithmetic errors.
+     */
+    private static BertWeights.LayerWeights makeZeroLayer() {
+        int h = BertWeights.HIDDEN_DIM;
+        int inter = BertWeights.INTERMEDIATE_DIM;
+        float[] onesH = new float[h];
+        java.util.Arrays.fill(onesH, 1.0f);
+        float[] zerosH = new float[h];
+        float[] zerosHH = new float[h * h];
+        float[] zerosInter = new float[inter];
+        float[] zerosInterH = new float[inter * h];
+        float[] zerosHInter = new float[h * inter];
+        return new BertWeights.LayerWeights(
+            zerosHH, zerosH,         // query W, B
+            zerosHH, zerosH,         // key W, B
+            zerosHH, zerosH,         // value W, B
+            zerosHH, zerosH,         // attention output W, B
+            onesH, zerosH,           // attention LN gamma, beta
+            zerosInterH, zerosInter, // intermediate W, B
+            zerosHInter, zerosH,     // output W, B
+            onesH, zerosH            // output LN gamma, beta
+        );
+    }
+
+    private static void assertNoNaN(float[][] matrix, int seqLen) {
+        for (int i = 0; i < seqLen; i++) {
+            for (float v : matrix[i]) {
+                assertFalse(Float.isNaN(v), "NaN found at row " + i);
+            }
+        }
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/BertWeightsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/BertWeightsTest.java
@@ -1,0 +1,122 @@
+package com.github.catatafishen.agentbridge.memory.embedding;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests for {@link BertWeights}: constructor via SafetensorsReader, and parameterCount()
+ * on LayerWeights with single-element arrays.
+ */
+class BertWeightsTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void constructorLoadsAllTensorsFromSafetensorsFile() throws IOException {
+        Path modelFile = buildMinimalModelFile(tempDir);
+        try (SafetensorsReader reader = new SafetensorsReader(modelFile)) {
+            BertWeights weights = new BertWeights(reader);
+            assertNotNull(weights.layers, "layers must not be null");
+            assertEquals(6, weights.layers.length, "model must have 6 encoder layers");
+        }
+    }
+
+    @Test
+    void layerWeightsParameterCountWithSingleFloatArrays() {
+        float[] one = {1.0f};
+        BertWeights.LayerWeights layer = new BertWeights.LayerWeights(
+            one, one, // query W, B
+            one, one, // key W, B
+            one, one, // value W, B
+            one, one, // attention output W, B
+            one, one, // attention LN gamma, beta
+            one, one, // intermediate W, B
+            one, one, // output W, B
+            one, one  // output LN gamma, beta
+        );
+        // 16 slots, each backed by a 1-float array → 16 total floats
+        assertEquals(16L, layer.parameterCount());
+    }
+
+    // ---- Helpers ----------------------------------------------------------------
+
+    /**
+     * Writes a minimal safetensors file containing all 101 tensors required by
+     * {@link BertWeights}: 5 embedding tensors + 6 layers × 16 per-layer tensors.
+     * Every tensor holds exactly one {@code float32} value (4 bytes of data), so
+     * the file is small but structurally valid for the constructor to read.
+     */
+    private static Path buildMinimalModelFile(Path dir) throws IOException {
+        List<String> names = buildTensorNames();
+
+        // Build the safetensors JSON header
+        StringBuilder json = new StringBuilder("{");
+        int dataOffset = 0;
+        for (int i = 0; i < names.size(); i++) {
+            if (i > 0) json.append(",");
+            json.append("\"").append(names.get(i)).append("\":");
+            json.append("{\"dtype\":\"F32\",\"shape\":[1],");
+            json.append("\"data_offsets\":[").append(dataOffset).append(",").append(dataOffset + 4).append("]}");
+            dataOffset += 4;
+        }
+        json.append("}");
+
+        byte[] headerBytes = json.toString().getBytes(StandardCharsets.UTF_8);
+        long headerLen = headerBytes.length;
+        int totalData = names.size() * 4; // 4 bytes per float32
+
+        ByteBuffer buf = ByteBuffer.allocate(8 + headerBytes.length + totalData).order(ByteOrder.LITTLE_ENDIAN);
+        buf.putLong(headerLen);
+        buf.put(headerBytes);
+        // Write one float (1.0f) per tensor as the data section
+        for (int i = 0; i < names.size(); i++) {
+            buf.putFloat(1.0f);
+        }
+
+        Path file = dir.resolve("model.safetensors");
+        Files.write(file, buf.array());
+        return file;
+    }
+
+    private static List<String> buildTensorNames() {
+        List<String> names = new ArrayList<>(101);
+        names.add("bert.embeddings.word_embeddings.weight");
+        names.add("bert.embeddings.position_embeddings.weight");
+        names.add("bert.embeddings.token_type_embeddings.weight");
+        names.add("bert.embeddings.LayerNorm.weight");
+        names.add("bert.embeddings.LayerNorm.bias");
+        for (int i = 0; i < 6; i++) {
+            String p = "bert.encoder.layer." + i + ".";
+            names.add(p + "attention.self.query.weight");
+            names.add(p + "attention.self.query.bias");
+            names.add(p + "attention.self.key.weight");
+            names.add(p + "attention.self.key.bias");
+            names.add(p + "attention.self.value.weight");
+            names.add(p + "attention.self.value.bias");
+            names.add(p + "attention.output.dense.weight");
+            names.add(p + "attention.output.dense.bias");
+            names.add(p + "attention.output.LayerNorm.weight");
+            names.add(p + "attention.output.LayerNorm.bias");
+            names.add(p + "intermediate.dense.weight");
+            names.add(p + "intermediate.dense.bias");
+            names.add(p + "output.dense.weight");
+            names.add(p + "output.dense.bias");
+            names.add(p + "output.LayerNorm.weight");
+            names.add(p + "output.LayerNorm.bias");
+        }
+        return names;
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/EmbeddingServiceTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/EmbeddingServiceTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests for {@link EmbeddingService} math utilities, {@link ModelDownloader} path methods,
  * and testable service operations (embed, embedBatch, isReady, dispose).
- * ONNX inference requires the downloaded model and is tested via integration tests.
+ * Inference requires the downloaded model and is tested via integration tests.
  */
 class EmbeddingServiceTest {
 
@@ -252,10 +252,31 @@ class EmbeddingServiceTest {
     }
 
     @Test
-    void modelPathEndsWithOnnx() {
+    void modelPathEndsWithSafetensors() {
         Path path = ModelDownloader.getModelPath();
-        assertEquals("model.onnx", path.getFileName().toString());
+        assertEquals("model.safetensors", path.getFileName().toString());
         assertTrue(path.startsWith(ModelDownloader.getModelDirectory()));
+    }
+
+    @Test
+    void migrateLegacyModelDeletesOnnxFile(@TempDir Path tempDir) throws IOException {
+        Path legacyModel = tempDir.resolve("model.onnx");
+        Files.writeString(legacyModel, "fake onnx content");
+        assertTrue(Files.exists(legacyModel));
+
+        ModelDownloader.migrateLegacyModel(tempDir);
+
+        assertFalse(Files.exists(legacyModel));
+    }
+
+    @Test
+    void migrateLegacyModelNoOpWhenNoOnnxFile(@TempDir Path tempDir) throws IOException {
+        Path otherFile = tempDir.resolve("vocab.txt");
+        Files.writeString(otherFile, "fake vocab");
+
+        ModelDownloader.migrateLegacyModel(tempDir);
+
+        assertTrue(Files.exists(otherFile));
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/EmbeddingServiceTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/EmbeddingServiceTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -241,6 +243,21 @@ class EmbeddingServiceTest {
         assertFalse(service.isReady() && !ModelDownloader.isModelAvailable());
     }
 
+    @Test
+    void disposeClosesOpenSafetensorsReader(@TempDir Path tempDir) throws IOException {
+        Path vocabPath = writeMinimalVocab(tempDir);
+        WordPieceTokenizer tokenizer = new WordPieceTokenizer(vocabPath, 16);
+        SafetensorsReader reader = new SafetensorsReader(writeMinimalSafetensors(tempDir));
+
+        EmbeddingService service = new EmbeddingService(tokenizer,
+            input -> new float[EmbeddingService.EMBEDDING_DIM], reader);
+        assertTrue(service.isReady());
+
+        service.dispose();
+
+        assertFalse(service.isReady(), "isReady must be false after dispose");
+    }
+
     // --- ModelDownloader path methods ---
 
     @Test
@@ -373,5 +390,21 @@ class EmbeddingServiceTest {
         Path path = dir.resolve("vocab.txt");
         Files.write(path, vocab, StandardCharsets.UTF_8);
         return path;
+    }
+
+    /**
+     * Creates a minimal valid safetensors file (one float32 tensor named "x")
+     * for use in tests that need a {@link SafetensorsReader} without caring about content.
+     */
+    private static Path writeMinimalSafetensors(Path dir) throws IOException {
+        String json = "{\"x\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[0,4]}}";
+        byte[] header = json.getBytes(StandardCharsets.UTF_8);
+        ByteBuffer buf = ByteBuffer.allocate(8 + header.length + 4).order(ByteOrder.LITTLE_ENDIAN);
+        buf.putLong(header.length);
+        buf.put(header);
+        buf.putFloat(1.0f);
+        Path file = dir.resolve("test.safetensors");
+        Files.write(file, buf.array());
+        return file;
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/EmbeddingServiceTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/EmbeddingServiceTest.java
@@ -171,7 +171,7 @@ class EmbeddingServiceTest {
         WordPieceTokenizer tokenizer = new WordPieceTokenizer(vocabPath, 16);
 
         EmbeddingService service = new EmbeddingService(tokenizer, input -> {
-            throw new RuntimeException("ONNX crash");
+            throw new RuntimeException("Inference engine crash");
         });
 
         assertThrows(RuntimeException.class, () -> service.embed("hello"));

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/ModelDownloaderTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/ModelDownloaderTest.java
@@ -4,7 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for static path computation methods in {@link ModelDownloader}.
@@ -22,9 +25,9 @@ class ModelDownloaderTest {
     }
 
     @Test
-    void modelPathEndsWithModelOnnx() {
+    void modelPathEndsWithSafetensors() {
         Path path = ModelDownloader.getModelPath();
-        assertEquals("model.onnx", path.getFileName().toString());
+        assertEquals("model.safetensors", path.getFileName().toString());
         assertTrue(path.startsWith(ModelDownloader.getModelDirectory()));
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/SafetensorsReaderTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/SafetensorsReaderTest.java
@@ -1,0 +1,170 @@
+package com.github.catatafishen.agentbridge.memory.embedding;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link SafetensorsReader}. Creates synthetic safetensors binary
+ * files in a temp directory — no real model files are needed.
+ */
+class SafetensorsReaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void loadsSimpleF32Tensor() throws IOException {
+        float[] expected = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+        byte[] data = floatsToBytes(expected);
+        String header = "{\"test_weight\":{\"dtype\":\"F32\",\"shape\":[2,3],\"data_offsets\":[0,24]}}";
+
+        Path file = createSafetensorsFile(header, data);
+        try (SafetensorsReader reader = new SafetensorsReader(file)) {
+            float[] loaded = reader.loadTensor("test_weight");
+            assertArrayEquals(expected, loaded);
+            assertArrayEquals(new int[]{2, 3}, reader.getShape("test_weight"));
+            assertTrue(reader.hasTensor("test_weight"));
+        }
+    }
+
+    @Test
+    void loadsMultipleTensors() throws IOException {
+        float[] biasValues = {0.1f, 0.2f, 0.3f};
+        float[] weightValues = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+        byte[] biasBytes = floatsToBytes(biasValues);
+        byte[] weightBytes = floatsToBytes(weightValues);
+
+        byte[] data = new byte[biasBytes.length + weightBytes.length];
+        System.arraycopy(biasBytes, 0, data, 0, biasBytes.length);
+        System.arraycopy(weightBytes, 0, data, biasBytes.length, weightBytes.length);
+
+        String header = "{"
+            + "\"bias\":{\"dtype\":\"F32\",\"shape\":[3],\"data_offsets\":[0,12]},"
+            + "\"weight\":{\"dtype\":\"F32\",\"shape\":[2,3],\"data_offsets\":[12,36]}"
+            + "}";
+
+        Path file = createSafetensorsFile(header, data);
+        try (SafetensorsReader reader = new SafetensorsReader(file)) {
+            assertArrayEquals(biasValues, reader.loadTensor("bias"));
+            assertArrayEquals(new int[]{3}, reader.getShape("bias"));
+
+            assertArrayEquals(weightValues, reader.loadTensor("weight"));
+            assertArrayEquals(new int[]{2, 3}, reader.getShape("weight"));
+        }
+    }
+
+    @Test
+    void throwsOnMissingTensor() throws IOException {
+        byte[] data = floatsToBytes(1.0f);
+        String header = "{\"present\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[0,4]}}";
+
+        Path file = createSafetensorsFile(header, data);
+        try (SafetensorsReader reader = new SafetensorsReader(file)) {
+            assertThrows(IOException.class, () -> reader.loadTensor("nonexistent"));
+        }
+    }
+
+    @Test
+    void throwsOnNonF32Dtype() throws IOException {
+        byte[] data = new byte[4]; // dummy data
+        String header = "{\"half_tensor\":{\"dtype\":\"F16\",\"shape\":[2],\"data_offsets\":[0,4]}}";
+
+        Path file = createSafetensorsFile(header, data);
+        try (SafetensorsReader reader = new SafetensorsReader(file)) {
+            assertThrows(IllegalArgumentException.class, () -> reader.loadTensor("half_tensor"));
+        }
+    }
+
+    @Test
+    void hasTensorReturnsFalseForMissing() throws IOException {
+        byte[] data = floatsToBytes(1.0f);
+        String header = "{\"present\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[0,4]}}";
+
+        Path file = createSafetensorsFile(header, data);
+        try (SafetensorsReader reader = new SafetensorsReader(file)) {
+            assertFalse(reader.hasTensor("nonexistent"));
+        }
+    }
+
+    @Test
+    void hasTensorIgnoresMetadataKey() throws IOException {
+        byte[] data = floatsToBytes(1.0f);
+        String header = "{"
+            + "\"__metadata__\":{\"format\":\"pt\"},"
+            + "\"real_tensor\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[0,4]}"
+            + "}";
+
+        Path file = createSafetensorsFile(header, data);
+        try (SafetensorsReader reader = new SafetensorsReader(file)) {
+            assertFalse(reader.hasTensor("__metadata__"));
+            assertTrue(reader.hasTensor("real_tensor"));
+        }
+    }
+
+    @Test
+    void throwsOnTruncatedHeader() throws IOException {
+        // Only 4 bytes — less than the 8-byte header length prefix
+        Path file = tempDir.resolve("truncated.safetensors");
+        Files.write(file, new byte[]{0x01, 0x02, 0x03, 0x04});
+
+        assertThrows(IOException.class, () -> new SafetensorsReader(file));
+    }
+
+    @Test
+    void throwsOnInvalidHeaderLength() throws IOException {
+        // Write a negative header length (-1 as a signed long)
+        Path file = tempDir.resolve("bad_length.safetensors");
+        ByteBuffer buf = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN);
+        buf.putLong(-1L);
+        Files.write(file, buf.array());
+
+        assertThrows(IOException.class, () -> new SafetensorsReader(file));
+    }
+
+    @Test
+    void closesResourcesOnError() throws IOException {
+        byte[] data = floatsToBytes(1.0f, 2.0f);
+        String header = "{\"vec\":{\"dtype\":\"F32\",\"shape\":[2],\"data_offsets\":[0,8]}}";
+
+        Path file = createSafetensorsFile(header, data);
+        SafetensorsReader reader = new SafetensorsReader(file);
+        assertEquals(2, reader.loadTensor("vec").length);
+        assertDoesNotThrow(reader::close);
+    }
+
+    // ---- helpers ----------------------------------------------------------------
+
+    private Path createSafetensorsFile(String headerJson, byte[] dataSection) throws IOException {
+        Path file = tempDir.resolve("test.safetensors");
+        byte[] headerBytes = headerJson.getBytes(StandardCharsets.UTF_8);
+        ByteBuffer buf = ByteBuffer.allocate(8 + headerBytes.length + dataSection.length)
+            .order(ByteOrder.LITTLE_ENDIAN);
+        buf.putLong(headerBytes.length);
+        buf.put(headerBytes);
+        buf.put(dataSection);
+        Files.write(file, buf.array());
+        return file;
+    }
+
+    private byte[] floatsToBytes(float... values) {
+        ByteBuffer buf = ByteBuffer.allocate(values.length * Float.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+        for (float v : values) {
+            buf.putFloat(v);
+        }
+        return buf.array();
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/TestEmbeddingFactory.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/TestEmbeddingFactory.java
@@ -7,7 +7,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 /**
- * Factory for creating test {@link EmbeddingService} instances that bypass ONNX Runtime.
+ * Factory for creating test {@link EmbeddingService} instances that bypass model loading.
  *
  * <p>Must live in the {@code embedding} package to access the package-private
  * test constructor and {@link EmbeddingService.InferenceFunction}.

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractorTest.java
@@ -52,10 +52,10 @@ class TripleExtractorTest {
 
     @Test
     void dependencyPattern() {
-        String text = "The plugin depends on ONNX Runtime for inference.";
+        String text = "The plugin depends on Lucene for vector search.";
         List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
 
-        assertContainsTriple(triples, "depends-on", "ONNX Runtime");
+        assertContainsTriple(triples, "depends-on", "Lucene");
     }
 
     @Test
@@ -92,7 +92,7 @@ class TripleExtractorTest {
 
     @Test
     void multipleTriples() {
-        String text = "We use Lucene for vector search. The project depends on ONNX Runtime for embeddings. "
+        String text = "We use Lucene for vector search. The project depends on Gradle for builds. "
             + "We decided to use SQLite for the knowledge graph.";
         List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
 
@@ -230,7 +230,7 @@ class TripleExtractorTest {
     @Test
     void acceptsObjectsWithSpecificTerms() {
         assertTrue(TripleExtractor.isQualityObject("Gradle"));
-        assertTrue(TripleExtractor.isQualityObject("ONNX Runtime"));
+        assertTrue(TripleExtractor.isQualityObject("safetensors model"));
         assertTrue(TripleExtractor.isQualityObject("write-ahead log"));
         assertTrue(TripleExtractor.isQualityObject("the plugin classloader"));
     }
@@ -275,11 +275,11 @@ class TripleExtractorTest {
 
     @Test
     void sentenceSplittingPreservesMultiplePatterns() {
-        String text = "We use Lucene for search.\nThe project depends on ONNX Runtime for inference.";
+        String text = "We use Lucene for search.\nThe project depends on Gradle for builds.";
         List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
 
         assertContainsTriple(triples, "uses", "Lucene");
-        assertContainsTriple(triples, "depends-on", "ONNX Runtime");
+        assertContainsTriple(triples, "depends-on", "Gradle");
     }
 
     // ── Deduplication tests ───────────────────────────────────────────────
@@ -323,7 +323,7 @@ class TripleExtractorTest {
     // ── Helper ────────────────────────────────────────────────────────────
 
     private static void assertContainsTriple(List<TripleExtractor.ExtractedTriple> triples,
-                                              String predicate, String objectSubstring) {
+                                             String predicate, String objectSubstring) {
         boolean found = triples.stream().anyMatch(t ->
             t.predicate().equals(predicate) && t.object().contains(objectSubstring));
         assertTrue(found, "Expected triple with predicate='" + predicate

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/layers/MemoryLayersTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/layers/MemoryLayersTest.java
@@ -67,7 +67,7 @@ class MemoryLayersTest {
     @Test
     void essentialRendersDrawers() throws IOException {
         addDrawer("d1", WING, "coding", "decision", "Decided to use Lucene for vector search");
-        addDrawer("d2", WING, "coding", "technical", "Implemented embedding service with ONNX Runtime");
+        addDrawer("d2", WING, "coding", "technical", "Implemented embedding service with pure-Java BERT");
 
         EssentialStoryLayer layer = new EssentialStoryLayer(store);
         String result = layer.render(WING, null);
@@ -77,7 +77,7 @@ class MemoryLayersTest {
         assertTrue(result.contains("[decision]"));
         assertTrue(result.contains("[technical]"));
         assertTrue(result.contains("Lucene"));
-        assertTrue(result.contains("ONNX"));
+        assertTrue(result.contains("BERT"));
     }
 
     @Test
@@ -246,7 +246,7 @@ class MemoryLayersTest {
     @Test
     void deepSearchEmbedderFailureReturnsEmpty() {
         Embedder failing = text -> {
-            throw new RuntimeException("ONNX crashed");
+            throw new RuntimeException("Embedding engine crashed");
         };
         DeepSearchLayer layer = new DeepSearchLayer(store, failing);
         String result = layer.render(WING, "some query");

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/TurnMinerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/TurnMinerTest.java
@@ -174,7 +174,7 @@ class TurnMinerTest {
     @Test
     void embedderExceptionHandledGracefully() {
         Embedder failingEmbedder = text -> {
-            throw new RuntimeException("ONNX crash");
+            throw new RuntimeException("Embedding engine crash");
         };
         List<EntryData> entries = List.of(
             prompt("How should we structure the caching layer for our application?"),


### PR DESCRIPTION
## Summary

Replaces the ONNX Runtime dependency (~39 MB native library) with a pure-Java BERT forward pass for sentence embedding computation. This eliminates the largest external dependency in the plugin and removes platform-specific native binaries.

## What changed

### New classes
- **SafetensorsReader** — memory-mapped parser for the [safetensors](https://huggingface.co/docs/safetensors/index) binary format. Uses `RandomAccessFile` + `FileChannel.map()` for zero-copy access to model weights.
- **BertWeights** — typed container for all 101 model weight tensors (7 embedding tensors + 6 layers × 16 tensors each). Inner `LayerWeights` record for clean per-layer access.
- **BertInferenceEngine** — hardcoded 6-layer BERT transformer forward pass implementing `EmbeddingService.InferenceFunction`. Full pipeline: token embedding lookup → 6×(self-attention + FFN + LayerNorm) → mean pooling → L2 normalization.

### Modified classes
- **EmbeddingService** — replaced all ONNX Runtime code (`OrtEnvironment`, `OrtSession`, `OnnxTensor`) with the pure-Java pipeline (`SafetensorsReader` → `BertWeights` → `BertInferenceEngine`)
- **ModelDownloader** — URL changed from `model.onnx` to `model.safetensors`; added `migrateLegacyModel()` to auto-delete old ONNX files on upgrade
- **build.gradle.kts** — removed `com.microsoft.onnxruntime:onnxruntime:1.24.3`
- **docs/SEMANTIC-MEMORY.md** — updated technical stack documentation

### Tests (19 new test methods)
- **SafetensorsReaderTest** (9 tests) — synthetic binary file creation, format parsing, error handling, dtype validation
- **BertInferenceEngineTest** (8 tests) — mathematical correctness of layerNorm, linear, gelu, softmax ops
- **EmbeddingServiceTest** (+2 tests) — model path assertion update, migration tests

## Why

- Eliminates ~39 MB native dependency (largest in the plugin)
- Removes platform-specific binaries (Linux/macOS/Windows native libs)
- Pure Java = no JNI loading failures, no architecture mismatches
- Model format is simpler (safetensors = flat float array vs ONNX = computation graph)
- All 69 memory tests pass

Closes #190