### PR TITLE
fix: enable V8 coverage tracking for chat-ui TypeScript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,15 +133,11 @@ jobs:
         with:
           cache-disabled: true
 
-      - name: Build chat-ui with sourcemaps (for coverage)
-        run: BUILD_SOURCEMAPS=1 npm run build
-        working-directory: plugin-core/chat-ui
-
       - name: Run chat-ui tests with coverage
         run: npm run test:coverage
         working-directory: plugin-core/js-tests
 
-      - name: Build chat-ui (production, no sourcemaps)
+      - name: Build chat-ui
         run: npm run build
         working-directory: plugin-core/chat-ui
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
         with:
           files: mcp-server/build/reports/jacoco/test/jacocoTestReport.xml
           flags: mcp-server
+          disable_search: true
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -132,11 +133,15 @@ jobs:
         with:
           cache-disabled: true
 
+      - name: Build chat-ui with sourcemaps (for coverage)
+        run: BUILD_SOURCEMAPS=1 npm run build
+        working-directory: plugin-core/chat-ui
+
       - name: Run chat-ui tests with coverage
         run: npm run test:coverage
         working-directory: plugin-core/js-tests
 
-      - name: Build chat-ui
+      - name: Build chat-ui (production, no sourcemaps)
         run: npm run build
         working-directory: plugin-core/chat-ui
 
@@ -152,6 +157,7 @@ jobs:
         with:
           files: plugin-core/js-tests/coverage/lcov.info
           flags: chat-ui
+          disable_search: true
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -162,6 +168,7 @@ jobs:
         with:
           files: plugin-core/build/reports/jacoco/test/jacocoTestReport.xml
           flags: plugin-core
+          disable_search: true
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/plugin-core/chat-ui/build.js
+++ b/plugin-core/chat-ui/build.js
@@ -1,5 +1,4 @@
 import * as esbuild from 'esbuild';
-import * as fs from 'fs';
 
 const banner = `/*
  * ⚠️  AUTO-GENERATED FILE - DO NOT EDIT DIRECTLY!
@@ -12,13 +11,14 @@ const banner = `/*
  *   3. The changes will be compiled into this file
  *
  * See plugin-core/chat-ui/README.md for more information.
- */
-
-`;
+ */`;
 
 const sourcemaps = process.env.BUILD_SOURCEMAPS === '1';
 
 async function build() {
+    // Use esbuild's banner option so sourcemaps account for banner line offsets.
+    const jsBanner = {js: banner};
+
     // 1. Chat components — custom elements + ChatController (loaded first)
     await esbuild.build({
         entryPoints: ['src/index.ts'],
@@ -28,6 +28,7 @@ async function build() {
         outfile: 'dist/chat-components.js',
         target: 'es2022',
         sourcemap: sourcemaps ? 'inline' : false,
+        banner: jsBanner,
     });
 
     // 2. Web app — PWA page logic (loaded after chat-components)
@@ -39,6 +40,7 @@ async function build() {
         outfile: 'dist/web-app.js',
         target: 'es2022',
         sourcemap: sourcemaps ? 'inline' : false,
+        banner: jsBanner,
     });
 
     // 3. Service worker — runs in SW context, no DOM
@@ -49,13 +51,8 @@ async function build() {
         outfile: 'dist/sw.js',
         target: 'es2022',
         sourcemap: sourcemaps ? 'inline' : false,
+        banner: jsBanner,
     });
-
-    // Prepend banner to JS output files
-    for (const file of ['dist/chat-components.js', 'dist/web-app.js', 'dist/sw.js']) {
-        const content = fs.readFileSync(file, 'utf8');
-        fs.writeFileSync(file, banner + content);
-    }
 
     console.log('✓ Built: chat-components.js, web-app.js, sw.js');
 }

--- a/plugin-core/js-tests/package-lock.json
+++ b/plugin-core/js-tests/package-lock.json
@@ -16,6 +16,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -25,6 +26,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -34,6 +36,7 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
       },
@@ -49,6 +52,7 @@
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
@@ -62,6 +66,7 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -105,6 +110,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -121,6 +127,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -463,25 +470,28 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
       "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -491,6 +501,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -644,6 +655,7 @@
       "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
       "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
@@ -682,6 +694,7 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -711,6 +724,7 @@
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -771,6 +785,7 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -779,13 +794,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
       }
@@ -795,6 +812,7 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
         "make-dir": "^4.0.0",
@@ -809,6 +827,7 @@
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
@@ -821,7 +840,8 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1099,6 +1119,7 @@
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
       "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -1110,6 +1131,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
       },
@@ -1245,6 +1267,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1256,7 +1279,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1272,7 +1296,8 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "4.0.0",
@@ -1286,6 +1311,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -1297,7 +1323,8 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.1.1",
@@ -1345,10 +1372,11 @@
       "optional": true
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.8",
@@ -1523,6 +1551,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -1532,6 +1561,7 @@
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"
@@ -1548,6 +1578,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/plugin-core/js-tests/setup.js
+++ b/plugin-core/js-tests/setup.js
@@ -1,12 +1,11 @@
-// Setup: load the web components into the happy-dom environment
-import {readFileSync} from 'node:fs';
-import {resolve} from 'node:path';
-import vm from 'node:vm';
+// Setup: load the web components into the happy-dom environment.
+//
+// Import the TypeScript source directly through Vitest's module system
+// so V8 coverage can attribute lines to individual .ts files.
+// (The previous approach — new Function(bundleCode)() — produced 0/0 coverage
+//  because V8 can't map anonymous eval'd code back to source files.)
 
-const bundlePath = resolve(__dirname, '../chat-ui/dist/chat-components.js');
-const code = readFileSync(bundlePath, 'utf-8');
-
-// Provide a minimal _bridge stub
+// Provide a minimal _bridge stub before components register
 globalThis._bridge = {
     openFile: () => {
     },
@@ -24,11 +23,5 @@ globalThis._bridge = {
     },
 };
 
-// Use vm.Script with a filename so V8 coverage can associate the code with a URL
-// and follow the inline sourcemaps back to the TypeScript sources.
-// The filename must point to the dist/ directory because esbuild generates
-// sourcemap source paths relative to the output file location.
-const script = new vm.Script(code, {
-    filename: resolve(__dirname, '../chat-ui/dist/chat-components.js'),
-});
-script.runInThisContext();
+// Import the chat-ui entry point — registers custom elements + exposes ChatController
+import '../chat-ui/src/index.ts';

--- a/plugin-core/js-tests/setup.js
+++ b/plugin-core/js-tests/setup.js
@@ -1,11 +1,12 @@
-// Setup: load the web components into the happy-dom environment.
-//
-// Import the TypeScript source directly through Vitest's module system
-// so V8 coverage can attribute lines to individual .ts files.
-// (The previous approach — new Function(bundleCode)() — produced 0/0 coverage
-//  because V8 can't map anonymous eval'd code back to source files.)
+// Setup: load the web components into the happy-dom environment
+import {readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+import vm from 'node:vm';
 
-// Provide a minimal _bridge stub before components register
+const bundlePath = resolve(__dirname, '../chat-ui/dist/chat-components.js');
+const code = readFileSync(bundlePath, 'utf-8');
+
+// Provide a minimal _bridge stub
 globalThis._bridge = {
     openFile: () => {
     },
@@ -23,5 +24,11 @@ globalThis._bridge = {
     },
 };
 
-// Import the chat-ui entry point — registers custom elements + exposes ChatController
-import '../chat-ui/src/index.ts';
+// Use vm.Script with a filename so V8 coverage can associate the code with a URL
+// and follow the inline sourcemaps back to the TypeScript sources.
+// The filename must point to the dist/ directory because esbuild generates
+// sourcemap source paths relative to the output file location.
+const script = new vm.Script(code, {
+    filename: resolve(__dirname, '../chat-ui/dist/chat-components.js'),
+});
+script.runInThisContext();

--- a/plugin-core/js-tests/vitest.config.js
+++ b/plugin-core/js-tests/vitest.config.js
@@ -10,12 +10,15 @@ export default defineConfig({
             // lcov for Codecov upload; text-summary for CI log
             reporter: ['lcov', 'text-summary'],
             reportsDirectory: './coverage',
-            // The tests load a pre-built bundle via vm.Script, so coverage is
-            // attributed at the bundle level. With BUILD_SOURCEMAPS=1, esbuild embeds
-            // inline sourcemaps, and V8 maps coverage back to the TypeScript source.
-            // Without sourcemaps the report covers the bundle; still useful for CI gating.
-            include: ['../chat-ui/src/**/*.ts'],
+            // Tests import TypeScript source directly (via setup.js → index.ts).
+            // V8 tracks coverage per-file through Vitest's module transforms.
+            // Use **/ prefix because V8 reports absolute paths and picomatch
+            // needs a pattern that matches anywhere in the path (with contains: true).
+            include: ['**/chat-ui/src/**/*.ts'],
             exclude: ['**/*.d.ts'],
+            // chat-ui source lives outside the Vitest root (js-tests/),
+            // so we must allow external files for V8 to report their coverage.
+            allowExternal: true,
         },
     },
 });

--- a/plugin-core/js-tests/vitest.config.js
+++ b/plugin-core/js-tests/vitest.config.js
@@ -10,8 +10,10 @@ export default defineConfig({
             // lcov for Codecov upload; text-summary for CI log
             reporter: ['lcov', 'text-summary'],
             reportsDirectory: './coverage',
-            // Tests import TypeScript source directly (via setup.js → index.ts).
-            // V8 tracks coverage per-file through Vitest's module transforms.
+            // The tests load a pre-built bundle via vm.Script, so coverage is
+            // attributed at the bundle level. With BUILD_SOURCEMAPS=1, esbuild embeds
+            // inline sourcemaps, and V8 maps coverage back to the TypeScript source.
+            // Without sourcemaps the report covers the bundle; still useful for CI gating.
             include: ['../chat-ui/src/**/*.ts'],
             exclude: ['**/*.d.ts'],
         },


### PR DESCRIPTION
## Problem

Codecov chat-ui coverage uploads were producing "Unusable report" errors with `Statements: Unknown% (0/0)` — zero coverage collected.

## Root Causes

1. **`setup.js` used `new Function(code)()`** — V8 coverage can't track anonymous scripts because there's no script URL to associate sourcemaps with
2. **`build.js` manually prepended a banner AFTER esbuild build** — this shifted all line numbers, breaking sourcemap mappings
3. **Codecov auto-discovery was enabled** — each upload step discovered and uploaded ALL 3 coverage files (lcov + JaCoCo + test XML), creating duplicate/confused reports

## Fixes

- **`setup.js`**: Switch to `vm.Script` with `filename` pointing to `chat-ui/dist/chat-components.js` so V8 coverage can follow inline sourcemaps back to TypeScript sources
- **`build.js`**: Use esbuild's `banner` option (which adjusts sourcemaps automatically) instead of manual file prepend
- **`ci.yml`**: Add `disable_search: true` to all 3 Codecov upload steps. Reorder steps to build chat-ui with `BUILD_SOURCEMAPS=1` before running tests
- **`vitest.config.js`**: Update comment to reflect vm.Script approach

Closes #195