### PR TITLE
fix: resolve stale tool statistics and chart client/model mixing

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentIdMapper.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/AgentIdMapper.java
@@ -1,0 +1,37 @@
+package com.github.catatafishen.agentbridge.services;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Maps agent display names (e.g. "GitHub Copilot") to canonical profile IDs
+ * (e.g. "copilot") that match {@link AgentProfileManager} identifiers.
+ *
+ * <p>Used by both chart statistics and tool-call backfill to normalize
+ * session-level agent names into consistent client IDs.</p>
+ */
+public final class AgentIdMapper {
+
+    private AgentIdMapper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Converts an agent display name to a canonical profile ID.
+     *
+     * @param agentDisplayName the display name from session metadata (e.g. "GitHub Copilot", "Claude Code")
+     * @return the canonical profile ID (e.g. "copilot", "claude-cli")
+     */
+    @NotNull
+    public static String toAgentId(@Nullable String agentDisplayName) {
+        if (agentDisplayName == null || agentDisplayName.isEmpty()) return "unknown";
+        String lower = agentDisplayName.toLowerCase();
+        if (lower.contains("copilot")) return "copilot";
+        if (lower.contains("claude")) return "claude-cli";
+        if (lower.contains("opencode")) return "opencode";
+        if (lower.contains("junie")) return "junie";
+        if (lower.contains("kiro")) return "kiro";
+        if (lower.contains("codex")) return "codex";
+        return lower.replaceAll("[^a-z0-9]", "-");
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsBackfill.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsBackfill.java
@@ -106,7 +106,7 @@ public final class ToolCallStatisticsBackfill {
         int skipped = 0;
         int errors = 0;
 
-        try (BufferedReader reader = Files.newBufferedReader(jsonlPath)) {
+        try (BufferedReader reader = Files.newBufferedReader(jsonlPath, StandardCharsets.UTF_8)) {
             String line;
             while ((line = reader.readLine()) != null) {
                 if (!line.contains("\"type\":\"tool\"")) continue;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsBackfill.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsBackfill.java
@@ -1,0 +1,195 @@
+package com.github.catatafishen.agentbridge.services;
+
+import com.github.catatafishen.agentbridge.session.exporters.ExportUtils;
+import com.github.catatafishen.agentbridge.session.v2.SessionStoreV2;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.intellij.openapi.diagnostic.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Backfills tool call statistics from session JSONL files into the SQLite database.
+ *
+ * <p>Session files contain {@code "type":"tool"} entries with tool name, arguments,
+ * result, status, timestamp, and agent. This class scans those entries and inserts
+ * them as {@link ToolCallRecord}s, recovering statistics that were lost when
+ * {@code ToolCallStatisticsService} failed to initialize or record calls.</p>
+ *
+ * <p>Backfill is idempotent: it skips entries whose timestamp already exists in the
+ * database (uses the timestamp + tool name for deduplication).</p>
+ */
+public final class ToolCallStatisticsBackfill {
+
+    private static final Logger LOG = Logger.getInstance(ToolCallStatisticsBackfill.class);
+
+    private ToolCallStatisticsBackfill() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Result of a backfill operation, reporting how many records were inserted
+     * and how many were skipped (already present).
+     */
+    public record BackfillResult(int inserted, int skipped, int errors) {
+        @NotNull
+        @Override
+        public String toString() {
+            return "BackfillResult{inserted=" + inserted + ", skipped=" + skipped
+                + ", errors=" + errors + "}";
+        }
+    }
+
+    /**
+     * Scans all session JSONL files and backfills tool call records into the
+     * given service. Skips entries that already exist (by timestamp + tool name).
+     *
+     * @param service  the statistics service to insert records into
+     * @param basePath the project base path (for locating session files)
+     * @return the backfill result with counts
+     */
+    public static BackfillResult backfill(@NotNull ToolCallStatisticsService service,
+                                          @NotNull String basePath) {
+        SessionStoreV2 store = new SessionStoreV2();
+        List<SessionStoreV2.SessionRecord> sessions = store.listSessions(basePath);
+        if (sessions.isEmpty()) {
+            LOG.info("Backfill: no sessions found");
+            return new BackfillResult(0, 0, 0);
+        }
+
+        Map<String, String> sessionToClient = buildSessionClientMap(sessions);
+        File sessionsDir = ExportUtils.sessionsDir(basePath);
+        int inserted = 0;
+        int skipped = 0;
+        int errors = 0;
+
+        for (SessionStoreV2.SessionRecord session : sessions) {
+            Path jsonlPath = sessionsDir.toPath().resolve(session.id() + ".jsonl");
+            if (!Files.exists(jsonlPath)) continue;
+
+            String clientId = sessionToClient.get(session.id());
+            BackfillResult sessionResult = backfillSession(service, jsonlPath, clientId);
+            inserted += sessionResult.inserted();
+            skipped += sessionResult.skipped();
+            errors += sessionResult.errors();
+        }
+
+        LOG.info("Backfill complete: " + inserted + " inserted, "
+            + skipped + " skipped, " + errors + " errors");
+        return new BackfillResult(inserted, skipped, errors);
+    }
+
+    private static Map<String, String> buildSessionClientMap(
+        @NotNull List<SessionStoreV2.SessionRecord> sessions) {
+        Map<String, String> map = new HashMap<>();
+        for (SessionStoreV2.SessionRecord session : sessions) {
+            map.put(session.id(), AgentIdMapper.toAgentId(session.agent()));
+        }
+        return map;
+    }
+
+    private static BackfillResult backfillSession(@NotNull ToolCallStatisticsService service,
+                                                  @NotNull Path jsonlPath,
+                                                  @NotNull String clientId) {
+        int inserted = 0;
+        int skipped = 0;
+        int errors = 0;
+
+        try (BufferedReader reader = Files.newBufferedReader(jsonlPath)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (!line.contains("\"type\":\"tool\"")) continue;
+                EntryResult entryResult = processToolEntry(service, line, clientId);
+                switch (entryResult) {
+                    case INSERTED -> inserted++;
+                    case SKIPPED -> skipped++;
+                    case ERROR -> errors++;
+                    case IGNORED -> { /* not a valid tool entry */ }
+                }
+            }
+        } catch (IOException e) {
+            LOG.warn("Backfill: failed to read " + jsonlPath.getFileName(), e);
+        }
+
+        return new BackfillResult(inserted, skipped, errors);
+    }
+
+    private enum EntryResult {INSERTED, SKIPPED, ERROR, IGNORED}
+
+    private static EntryResult processToolEntry(@NotNull ToolCallStatisticsService service,
+                                                @NotNull String line,
+                                                @NotNull String clientId) {
+        ToolCallRecord toolRecord;
+        try {
+            toolRecord = parseToolEntry(line, clientId);
+        } catch (Exception e) {
+            LOG.debug("Backfill: malformed tool entry: " + e.getMessage());
+            return EntryResult.ERROR;
+        }
+
+        if (toolRecord == null) return EntryResult.IGNORED;
+
+        if (service.hasRecordAt(toolRecord.timestamp(), toolRecord.toolName())) {
+            return EntryResult.SKIPPED;
+        }
+        service.recordCall(toolRecord);
+        return EntryResult.INSERTED;
+    }
+
+    @Nullable
+    private static ToolCallRecord parseToolEntry(@NotNull String line,
+                                                 @NotNull String clientId) {
+        JsonObject obj = JsonParser.parseString(line).getAsJsonObject();
+
+        String type = getStr(obj, "type");
+        if (!"tool".equals(type)) return null;
+
+        String toolName = getStr(obj, "title");
+        if (toolName.isEmpty()) return null;
+
+        String timestampStr = getStr(obj, "timestamp");
+        if (timestampStr.isEmpty()) return null;
+
+        Instant timestamp = Instant.parse(timestampStr);
+
+        String status = getStr(obj, "status");
+        boolean success = "completed".equals(status);
+
+        String arguments = getStr(obj, "arguments");
+        String result = getStr(obj, "result");
+        long inputSize = arguments.getBytes(StandardCharsets.UTF_8).length;
+        long outputSize = result.getBytes(StandardCharsets.UTF_8).length;
+
+        String kind = getStr(obj, "kind");
+        String category = kind.isEmpty() ? null : kind;
+
+        String errorMessage = null;
+        if (!success && !result.isEmpty()) {
+            errorMessage = result.length() > 500 ? result.substring(0, 500) : result;
+        }
+
+        return new ToolCallRecord(
+            toolName, category, inputSize, outputSize,
+            0, // durationMs not available in JSONL entries
+            success, errorMessage, clientId, timestamp);
+    }
+
+    @NotNull
+    private static String getStr(@NotNull JsonObject obj, @NotNull String key) {
+        if (obj.has(key) && !obj.get(key).isJsonNull()) {
+            return obj.get(key).getAsString();
+        }
+        return "";
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -43,7 +43,8 @@ public final class ToolCallStatisticsService implements Disposable {
     private Connection connection;
     private Runnable disconnectHandle;
 
-    private volatile boolean initialized;
+    private volatile boolean initAttempted;
+    private volatile boolean warnedConnectionNull;
 
     public ToolCallStatisticsService(@NotNull Project project) {
         this.project = project;
@@ -62,9 +63,10 @@ public final class ToolCallStatisticsService implements Disposable {
      * Called lazily on first access via {@code getInstance()}.
      *
      * @throws RuntimeException if initialization fails (JDBC driver not found,
-     *                          database cannot be created, or subscription fails). The caller
-     *                          must not set {@code initialized = true} unless this method
-     *                          completes without exception.
+     *                          database cannot be created, or subscription fails).
+     *                          The caller sets {@code initAttempted = true} regardless of
+     *                          success/failure to prevent retry loops — the service stays
+     *                          inert (connection == null) until the IDE is restarted.
      */
     public void initialize() {
         try {
@@ -145,8 +147,12 @@ public final class ToolCallStatisticsService implements Disposable {
 
     public synchronized void recordCall(@NotNull ToolCallRecord callRecord) {
         if (connection == null) {
-            LOG.warn("ToolCallStatisticsService: dropping tool call '" + callRecord.toolName()
-                + "' — database connection is not available (initialization may have failed)");
+            if (!warnedConnectionNull) {
+                warnedConnectionNull = true;
+                LOG.warn("ToolCallStatisticsService: dropping tool call '" + callRecord.toolName()
+                    + "' — database connection is not available (initialization may have failed). "
+                    + "Subsequent dropped calls will not be logged.");
+            }
             return;
         }
         try {
@@ -452,17 +458,16 @@ public final class ToolCallStatisticsService implements Disposable {
 
     public static ToolCallStatisticsService getInstance(@NotNull Project project) {
         ToolCallStatisticsService service = PlatformApiCompat.getService(project, ToolCallStatisticsService.class);
-        if (!service.initialized) {
+        if (!service.initAttempted) {
             synchronized (service) {
-                if (!service.initialized) {
+                if (!service.initAttempted) {
+                    service.initAttempted = true;
                     try {
                         service.initialize();
-                        service.initialized = true;
                         triggerBackfillIfNeeded(service, project);
                     } catch (RuntimeException e) {
                         LOG.error("ToolCallStatisticsService initialization failed — "
                             + "tool call recording will be disabled until restart", e);
-                        service.initialized = true;
                     }
                 }
             }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -59,23 +59,32 @@ public final class ToolCallStatisticsService implements Disposable {
     /**
      * Initialize the SQLite database and subscribe to tool call events.
      * Called lazily on first access via {@code getInstance()}.
+     *
+     * @throws RuntimeException if initialization fails (JDBC driver not found,
+     *                          database cannot be created, or subscription fails). The caller
+     *                          must not set {@code initialized = true} unless this method
+     *                          completes without exception.
      */
     public void initialize() {
         try {
             Class.forName("org.sqlite.JDBC");
-            String basePath = project.getBasePath();
-            if (basePath == null) {
-                LOG.warn("Cannot initialize ToolCallStatisticsService: project has no base path");
-                return;
-            }
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("SQLite JDBC driver not found on classpath", e);
+        }
+        String basePath = project.getBasePath();
+        if (basePath == null) {
+            throw new IllegalStateException(
+                "Cannot initialize ToolCallStatisticsService: project has no base path");
+        }
+        try {
             Path dbDir = Path.of(basePath, ".agentbridge");
             Files.createDirectories(dbDir);
             Path dbPath = dbDir.resolve(DB_FILENAME);
             initializeWithConnection(DriverManager.getConnection("jdbc:sqlite:" + dbPath));
             subscribeToToolCallEvents();
             LOG.info("ToolCallStatisticsService initialized at " + dbPath);
-        } catch (ClassNotFoundException | SQLException | IOException e) {
-            LOG.error("Failed to initialize ToolCallStatisticsService", e);
+        } catch (SQLException | IOException e) {
+            throw new IllegalStateException("Failed to initialize ToolCallStatisticsService", e);
         }
     }
 
@@ -134,7 +143,11 @@ public final class ToolCallStatisticsService implements Disposable {
     }
 
     public synchronized void recordCall(@NotNull ToolCallRecord callRecord) {
-        if (connection == null) return;
+        if (connection == null) {
+            LOG.warn("ToolCallStatisticsService: dropping tool call '" + callRecord.toolName()
+                + "' — database connection is not available (initialization may have failed)");
+            return;
+        }
         try {
             insertRecord(callRecord);
         } catch (SQLException e) {
@@ -381,8 +394,14 @@ public final class ToolCallStatisticsService implements Disposable {
         if (!service.initialized) {
             synchronized (service) {
                 if (!service.initialized) {
-                    service.initialize();
-                    service.initialized = true;
+                    try {
+                        service.initialize();
+                        service.initialized = true;
+                    } catch (RuntimeException e) {
+                        LOG.error("ToolCallStatisticsService initialization failed — "
+                            + "tool call recording will be disabled until restart", e);
+                        service.initialized = true;
+                    }
                 }
             }
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -3,6 +3,7 @@ package com.github.catatafishen.agentbridge.services;
 import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
 import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -179,6 +180,40 @@ public final class ToolCallStatisticsService implements Disposable {
             stmt.setString(8, callRecord.clientId());
             stmt.setString(9, callRecord.timestamp().toString());
             stmt.executeUpdate();
+        }
+    }
+
+    /**
+     * Checks whether a tool call record already exists at the given timestamp
+     * and tool name. Used by {@link ToolCallStatisticsBackfill} for deduplication.
+     */
+    public synchronized boolean hasRecordAt(@NotNull Instant timestamp, @NotNull String toolName) {
+        if (connection == null) return false;
+        String sql = "SELECT COUNT(*) FROM tool_calls WHERE timestamp = ? AND tool_name = ?";
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, timestamp.toString());
+            stmt.setString(2, toolName);
+            try (ResultSet rs = stmt.executeQuery()) {
+                return rs.next() && rs.getInt(1) > 0;
+            }
+        } catch (SQLException e) {
+            LOG.warn("Failed to check for existing record", e);
+            return false;
+        }
+    }
+
+    /**
+     * Returns the total number of tool call records in the database.
+     * Used to determine whether a backfill is needed.
+     */
+    public synchronized int getRecordCount() {
+        if (connection == null) return 0;
+        try (PreparedStatement stmt = connection.prepareStatement("SELECT COUNT(*) FROM tool_calls");
+             ResultSet rs = stmt.executeQuery()) {
+            return rs.next() ? rs.getInt(1) : 0;
+        } catch (SQLException e) {
+            LOG.warn("Failed to count records", e);
+            return 0;
         }
     }
 
@@ -389,6 +424,32 @@ public final class ToolCallStatisticsService implements Disposable {
         return results;
     }
 
+    /**
+     * Threshold below which the database is considered empty enough to warrant backfill.
+     * If the DB has fewer records than this, session JSONL files are scanned.
+     */
+    private static final int BACKFILL_THRESHOLD = 10;
+
+    private static void triggerBackfillIfNeeded(@NotNull ToolCallStatisticsService service,
+                                                @NotNull Project project) {
+        String basePath = project.getBasePath();
+        if (basePath == null) return;
+
+        if (service.getRecordCount() >= BACKFILL_THRESHOLD) return;
+
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                ToolCallStatisticsBackfill.BackfillResult result =
+                    ToolCallStatisticsBackfill.backfill(service, basePath);
+                if (result.inserted() > 0) {
+                    LOG.info("Tool statistics backfill: " + result);
+                }
+            } catch (Exception e) {
+                LOG.warn("Tool statistics backfill failed", e);
+            }
+        });
+    }
+
     public static ToolCallStatisticsService getInstance(@NotNull Project project) {
         ToolCallStatisticsService service = PlatformApiCompat.getService(project, ToolCallStatisticsService.class);
         if (!service.initialized) {
@@ -397,6 +458,7 @@ public final class ToolCallStatisticsService implements Disposable {
                     try {
                         service.initialize();
                         service.initialized = true;
+                        triggerBackfillIfNeeded(service, project);
                     } catch (RuntimeException e) {
                         LOG.error("ToolCallStatisticsService initialization failed — "
                             + "tool call recording will be disabled until restart", e);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -113,7 +114,7 @@ final class UsageStatisticsLoader {
     private static void collectTurnStats(Path jsonlPath, String sessionAgentId,
                                          LocalDate startDate, LocalDate endDate,
                                          Map<DayAgentKey, Accumulator> accumulators) {
-        try (BufferedReader reader = Files.newBufferedReader(jsonlPath)) {
+        try (BufferedReader reader = Files.newBufferedReader(jsonlPath, StandardCharsets.UTF_8)) {
             String lastSeenTimestamp = null;
             String line;
             while ((line = reader.readLine()) != null) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
@@ -1,5 +1,6 @@
 package com.github.catatafishen.agentbridge.ui.statistics;
 
+import com.github.catatafishen.agentbridge.services.AgentIdMapper;
 import com.github.catatafishen.agentbridge.session.exporters.ExportUtils;
 import com.github.catatafishen.agentbridge.session.v2.EntryDataJsonAdapter;
 import com.github.catatafishen.agentbridge.session.v2.SessionStoreV2;
@@ -193,15 +194,7 @@ final class UsageStatisticsLoader {
      * for color lookup via {@code ChatTheme.agentColorIndex()}.
      */
     static String toAgentId(String agentDisplayName) {
-        if (agentDisplayName == null || agentDisplayName.isEmpty()) return "unknown";
-        String lower = agentDisplayName.toLowerCase();
-        if (lower.contains("copilot")) return "copilot";
-        if (lower.contains("claude")) return "claude-cli";
-        if (lower.contains("opencode")) return "opencode";
-        if (lower.contains("junie")) return "junie";
-        if (lower.contains("kiro")) return "kiro";
-        if (lower.contains("codex")) return "codex";
-        return lower.replaceAll("[^a-z0-9]", "-");
+        return AgentIdMapper.toAgentId(agentDisplayName);
     }
 
     private static double parsePremiumMultiplier(String multiplier) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
@@ -70,7 +70,7 @@ final class UsageStatisticsLoader {
             }
 
             collectTurnStats(jsonlPath, fallbackAgentId, startDate, endDate,
-                accumulators, agentIds, agentDisplayNames);
+                accumulators);
         }
 
         List<UsageStatisticsData.DailyAgentStats> dailyStats = buildDailyStats(accumulators);
@@ -109,14 +109,11 @@ final class UsageStatisticsLoader {
         return result;
     }
 
-    private static void collectTurnStats(Path jsonlPath, String fallbackAgentId,
+    private static void collectTurnStats(Path jsonlPath, String sessionAgentId,
                                          LocalDate startDate, LocalDate endDate,
-                                         Map<DayAgentKey, Accumulator> accumulators,
-                                         Set<String> agentIds,
-                                         Map<String, String> agentDisplayNames) {
+                                         Map<DayAgentKey, Accumulator> accumulators) {
         try (BufferedReader reader = Files.newBufferedReader(jsonlPath)) {
             String lastSeenTimestamp = null;
-            String currentAgentId = fallbackAgentId;
             String line;
             while ((line = reader.readLine()) != null) {
                 // Track timestamps from all entries for date attribution.
@@ -134,22 +131,9 @@ final class UsageStatisticsLoader {
                     }
                 }
 
-                int agentIdx = line.indexOf("\"agent\":\"");
-                if (agentIdx >= 0) {
-                    try {
-                        JsonObject obj = JsonParser.parseString(line).getAsJsonObject();
-                        if (obj.has("agent")) {
-                            String agentDisplay = obj.get("agent").getAsString();
-                            if (!agentDisplay.isEmpty()) {
-                                currentAgentId = toAgentId(agentDisplay);
-                                agentIds.add(currentAgentId);
-                                agentDisplayNames.putIfAbsent(currentAgentId, agentDisplay);
-                            }
-                        }
-                    } catch (Exception e) {
-                        LOG.debug("Skipping agent metadata in " + jsonlPath.getFileName() + ": " + e.getMessage());
-                    }
-                }
+                // Agent attribution uses the session-level agent exclusively.
+                // Individual entry "agent" fields are ignored here because they can contain
+                // model names or sub-agent identifiers that would create phantom chart series.
 
                 if (!line.contains("\"turnStats\"")) continue;
 
@@ -165,7 +149,7 @@ final class UsageStatisticsLoader {
                     }
                     if (date.isBefore(startDate) || date.isAfter(endDate)) continue;
 
-                    DayAgentKey key = new DayAgentKey(date, currentAgentId);
+                    DayAgentKey key = new DayAgentKey(date, sessionAgentId);
                     Accumulator acc = accumulators.computeIfAbsent(key, k -> new Accumulator());
                     acc.turns++;
                     acc.inputTokens += stats.getInputTokens();

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentIdMapperTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentIdMapperTest.java
@@ -4,7 +4,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.InvocationTargetException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for {@link AgentIdMapper}.
@@ -68,5 +72,14 @@ class AgentIdMapperTest {
         void unknownAgent() {
             assertEquals("my-custom-agent", AgentIdMapper.toAgentId("My Custom Agent"));
         }
+    }
+
+    @Test
+    @DisplayName("private constructor enforces utility-class pattern")
+    void constructorThrowsUtilityClassException() throws Exception {
+        var constructor = AgentIdMapper.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        var ex = assertThrows(InvocationTargetException.class, constructor::newInstance);
+        assertInstanceOf(IllegalStateException.class, ex.getCause());
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentIdMapperTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/AgentIdMapperTest.java
@@ -1,0 +1,72 @@
+package com.github.catatafishen.agentbridge.services;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link AgentIdMapper}.
+ */
+class AgentIdMapperTest {
+
+    @Nested
+    @DisplayName("toAgentId")
+    class ToAgentId {
+
+        @Test
+        @DisplayName("returns 'unknown' for null")
+        void nullAgent() {
+            assertEquals("unknown", AgentIdMapper.toAgentId(null));
+        }
+
+        @Test
+        @DisplayName("returns 'unknown' for empty string")
+        void emptyAgent() {
+            assertEquals("unknown", AgentIdMapper.toAgentId(""));
+        }
+
+        @Test
+        @DisplayName("maps 'GitHub Copilot' → 'copilot'")
+        void copilot() {
+            assertEquals("copilot", AgentIdMapper.toAgentId("GitHub Copilot"));
+        }
+
+        @Test
+        @DisplayName("maps 'Claude Code' → 'claude-cli'")
+        void claude() {
+            assertEquals("claude-cli", AgentIdMapper.toAgentId("Claude Code"));
+        }
+
+        @Test
+        @DisplayName("maps 'OpenCode Agent' → 'opencode'")
+        void opencode() {
+            assertEquals("opencode", AgentIdMapper.toAgentId("OpenCode Agent"));
+        }
+
+        @Test
+        @DisplayName("maps 'Junie' → 'junie'")
+        void junie() {
+            assertEquals("junie", AgentIdMapper.toAgentId("Junie"));
+        }
+
+        @Test
+        @DisplayName("maps 'Kiro' → 'kiro'")
+        void kiro() {
+            assertEquals("kiro", AgentIdMapper.toAgentId("Kiro"));
+        }
+
+        @Test
+        @DisplayName("maps 'codex-mini' → 'codex'")
+        void codex() {
+            assertEquals("codex", AgentIdMapper.toAgentId("codex-mini"));
+        }
+
+        @Test
+        @DisplayName("normalizes unknown agent names to lowercase kebab-case")
+        void unknownAgent() {
+            assertEquals("my-custom-agent", AgentIdMapper.toAgentId("My Custom Agent"));
+        }
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsBackfillTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsBackfillTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
@@ -15,6 +16,8 @@ import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -326,5 +329,40 @@ class ToolCallStatisticsBackfillTest {
         Files.createDirectories(sessionsDir);
         Files.writeString(sessionsDir.resolve(sessionId + ".jsonl"),
             String.join("\n", entries) + "\n");
+    }
+
+    @Test
+    @DisplayName("BackfillResult.toString() includes inserted, skipped, and errors counts")
+    void backfillResultToStringIncludesAllFields() {
+        ToolCallStatisticsBackfill.BackfillResult result =
+            new ToolCallStatisticsBackfill.BackfillResult(5, 3, 1);
+        assertEquals("BackfillResult{inserted=5, skipped=3, errors=1}", result.toString());
+    }
+
+    @Test
+    @DisplayName("JSONL path that is a directory triggers IOException path (logs warning, returns zeros)")
+    void backfillSessionJsonlIsDirectoryIsHandledGracefully() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "dir-session", "GitHub Copilot");
+
+        // Create a directory at the JSONL path — Files.newBufferedReader will throw IOException
+        Path sessionsDir = Path.of(basePath, ".agent-work", "sessions");
+        Files.createDirectories(sessionsDir.resolve("dir-session.jsonl"));
+
+        ToolCallStatisticsBackfill.BackfillResult result =
+            ToolCallStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(0, result.inserted());
+        assertEquals(0, result.errors());
+        assertEquals(0, service.getRecordCount());
+    }
+
+    @Test
+    @DisplayName("private constructor enforces utility-class pattern")
+    void constructorThrowsUtilityClassException() throws Exception {
+        var constructor = ToolCallStatisticsBackfill.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        var ex = assertThrows(InvocationTargetException.class, constructor::newInstance);
+        assertInstanceOf(IllegalStateException.class, ex.getCause());
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsBackfillTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsBackfillTest.java
@@ -1,0 +1,233 @@
+package com.github.catatafishen.agentbridge.services;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link ToolCallStatisticsBackfill} — exercises backfill from
+ * session JSONL files into the SQLite database.
+ */
+class ToolCallStatisticsBackfillTest {
+
+    @TempDir
+    Path tempDir;
+
+    private ToolCallStatisticsService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Class.forName("org.sqlite.JDBC");
+        Path dbPath = tempDir.resolve("tool-stats.db");
+        Connection connection = DriverManager.getConnection("jdbc:sqlite:" + dbPath);
+        service = new ToolCallStatisticsService();
+        service.initializeWithConnection(connection);
+    }
+
+    @AfterEach
+    void tearDown() {
+        service.dispose();
+    }
+
+    @Test
+    @DisplayName("backfills tool entries from JSONL session files")
+    void backfillsToolEntries() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        createSessionJsonl(basePath, "session-1",
+            toolEntry("read_file", "completed", "2025-01-15T10:00:00Z",
+                "{\"path\":\"test.java\"}", "file contents here"),
+            toolEntry("search_text", "completed", "2025-01-15T10:01:00Z",
+                "{\"query\":\"foo\"}", "3 matches found"));
+
+        ToolCallStatisticsBackfill.BackfillResult result =
+            ToolCallStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(2, result.inserted());
+        assertEquals(0, result.skipped());
+        assertEquals(0, result.errors());
+        assertEquals(2, service.getRecordCount());
+    }
+
+    @Test
+    @DisplayName("skips duplicate entries on re-run (idempotent)")
+    void idempotentBackfill() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        createSessionJsonl(basePath, "session-1",
+            toolEntry("read_file", "completed", "2025-01-15T10:00:00Z",
+                "{}", "ok"));
+
+        ToolCallStatisticsBackfill.backfill(service, basePath);
+        ToolCallStatisticsBackfill.BackfillResult result =
+            ToolCallStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(0, result.inserted());
+        assertEquals(1, result.skipped());
+        assertEquals(1, service.getRecordCount());
+    }
+
+    @Test
+    @DisplayName("maps session agent to correct clientId")
+    void mapsAgentToClientId() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "Claude Code");
+        createSessionJsonl(basePath, "session-1",
+            toolEntry("edit_file", "completed", "2025-01-15T10:00:00Z",
+                "{}", "done"));
+
+        ToolCallStatisticsBackfill.backfill(service, basePath);
+
+        var clients = service.getDistinctClients();
+        assertEquals(1, clients.size());
+        assertEquals("claude-cli", clients.getFirst());
+    }
+
+    @Test
+    @DisplayName("handles failed tool entries with error message")
+    void handlesFailedEntries() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        createSessionJsonl(basePath, "session-1",
+            toolEntry("write_file", "error", "2025-01-15T10:00:00Z",
+                "{}", "Error: file not found"));
+
+        ToolCallStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(1, service.getRecordCount());
+        var errors = service.queryRecentErrors(null, null, 10);
+        assertEquals(1, errors.size());
+        assertEquals("Error: file not found", errors.getFirst().errorMessage());
+    }
+
+    @Test
+    @DisplayName("skips non-tool entries in JSONL files")
+    void skipsNonToolEntries() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        String textEntry = """
+            {"type":"text","content":"hello","timestamp":"2025-01-15T10:00:00Z"}""";
+        String thinkingEntry = """
+            {"type":"thinking","content":"hmm","timestamp":"2025-01-15T10:00:01Z"}""";
+        createSessionJsonl(basePath, "session-1",
+            textEntry, thinkingEntry,
+            toolEntry("read_file", "completed", "2025-01-15T10:00:02Z", "{}", "ok"));
+
+        ToolCallStatisticsBackfill.BackfillResult result =
+            ToolCallStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(1, result.inserted());
+        assertEquals(0, result.errors());
+    }
+
+    @Test
+    @DisplayName("returns empty result when no sessions exist")
+    void noSessions() {
+        ToolCallStatisticsBackfill.BackfillResult result =
+            ToolCallStatisticsBackfill.backfill(service, tempDir.toString());
+
+        assertEquals(0, result.inserted());
+        assertEquals(0, result.skipped());
+        assertEquals(0, result.errors());
+    }
+
+    @Test
+    @DisplayName("hasRecordAt finds existing records")
+    void hasRecordAt() {
+        Instant ts = Instant.parse("2025-01-15T10:00:00Z");
+        service.recordCall(new ToolCallRecord(
+            "read_file", null, 10, 100, 50, true, null, "copilot", ts));
+
+        assertTrue(service.hasRecordAt(ts, "read_file"));
+        assertFalse(service.hasRecordAt(ts, "write_file"));
+        assertFalse(service.hasRecordAt(Instant.parse("2025-01-15T11:00:00Z"), "read_file"));
+    }
+
+    @Test
+    @DisplayName("getRecordCount returns correct count")
+    void getRecordCount() {
+        assertEquals(0, service.getRecordCount());
+        service.recordCall(new ToolCallRecord(
+            "tool1", null, 0, 0, 0, true, null, "copilot", Instant.now()));
+        service.recordCall(new ToolCallRecord(
+            "tool2", null, 0, 0, 0, true, null, "copilot", Instant.now()));
+        assertEquals(2, service.getRecordCount());
+    }
+
+    @Test
+    @DisplayName("backfills multiple sessions with different agents")
+    void multipleSessions() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath,
+            new String[]{"session-1", "GitHub Copilot"},
+            new String[]{"session-2", "Claude Code"});
+        createSessionJsonl(basePath, "session-1",
+            toolEntry("read_file", "completed", "2025-01-15T10:00:00Z", "{}", "ok"));
+        createSessionJsonl(basePath, "session-2",
+            toolEntry("edit_file", "completed", "2025-01-15T11:00:00Z", "{}", "done"));
+
+        ToolCallStatisticsBackfill.BackfillResult result =
+            ToolCallStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(2, result.inserted());
+        var clients = service.getDistinctClients();
+        assertTrue(clients.contains("copilot"));
+        assertTrue(clients.contains("claude-cli"));
+    }
+
+    private static String toolEntry(String title, String status, String timestamp,
+                                    String arguments, String result) {
+        return "{\"type\":\"tool\",\"title\":\"" + title
+            + "\",\"status\":\"" + status
+            + "\",\"timestamp\":\"" + timestamp
+            + "\",\"arguments\":\"" + arguments.replace("\"", "\\\"")
+            + "\",\"result\":\"" + result.replace("\"", "\\\"")
+            + "\"}";
+    }
+
+    private static void createSessionIndex(String basePath, String sessionId,
+                                           String agent) throws IOException {
+        createSessionIndex(basePath, new String[]{sessionId, agent});
+    }
+
+    private static void createSessionIndex(String basePath,
+                                           String[]... sessions) throws IOException {
+        Path indexDir = Path.of(basePath, ".agent-work", "sessions");
+        Files.createDirectories(indexDir);
+
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < sessions.length; i++) {
+            if (i > 0) sb.append(",");
+            sb.append("{\"id\":\"").append(sessions[i][0]).append("\"")
+                .append(",\"agent\":\"").append(sessions[i][1]).append("\"")
+                .append(",\"name\":\"Test Session\"")
+                .append(",\"createdAt\":1736935200")
+                .append(",\"updatedAt\":1736942400")
+                .append(",\"turnCount\":5")
+                .append("}");
+        }
+        sb.append("]");
+        Files.writeString(indexDir.resolve("sessions-index.json"), sb.toString());
+    }
+
+    private static void createSessionJsonl(String basePath, String sessionId,
+                                           String... entries) throws IOException {
+        Path sessionsDir = Path.of(basePath, ".agent-work", "sessions");
+        Files.createDirectories(sessionsDir);
+        Files.writeString(sessionsDir.resolve(sessionId + ".jsonl"),
+            String.join("\n", entries) + "\n");
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsBackfillTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsBackfillTest.java
@@ -188,6 +188,103 @@ class ToolCallStatisticsBackfillTest {
         assertTrue(clients.contains("claude-cli"));
     }
 
+    @Test
+    @DisplayName("invalid timestamp in tool entry is counted as error")
+    void invalidTimestampCountedAsError() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        // Entry has a non-empty but unparseable timestamp → Instant.parse() throws
+        createSessionJsonl(basePath, "session-1",
+            toolEntry("read_file", "completed", "NOT-AN-ISO-DATE", "{}", "ok"));
+
+        ToolCallStatisticsBackfill.BackfillResult result =
+            ToolCallStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(0, result.inserted());
+        assertEquals(1, result.errors(), "Invalid timestamp should increment the error count");
+    }
+
+    @Test
+    @DisplayName("entry with empty tool name is ignored (not inserted and not an error)")
+    void emptyToolNameIsIgnored() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        createSessionJsonl(basePath, "session-1",
+            toolEntry("", "completed", "2025-01-15T10:00:00Z", "{}", "ok"));
+
+        ToolCallStatisticsBackfill.BackfillResult result =
+            ToolCallStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(0, result.inserted());
+        assertEquals(0, result.errors(), "Empty title is an ignored entry, not an error");
+        assertEquals(0, service.getRecordCount());
+    }
+
+    @Test
+    @DisplayName("entry with empty timestamp is ignored (not inserted and not an error)")
+    void emptyTimestampIsIgnored() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        createSessionJsonl(basePath, "session-1",
+            toolEntry("read_file", "completed", "", "{}", "ok"));
+
+        ToolCallStatisticsBackfill.BackfillResult result =
+            ToolCallStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(0, result.inserted());
+        assertEquals(0, result.errors(), "Empty timestamp is an ignored entry, not an error");
+        assertEquals(0, service.getRecordCount());
+    }
+
+    @Test
+    @DisplayName("kind field is stored as category on the inserted record")
+    void kindFieldStoredAsCategory() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        String entryWithKind = "{\"type\":\"tool\",\"title\":\"read_file\","
+            + "\"kind\":\"FILE\","
+            + "\"timestamp\":\"2025-01-15T10:00:00Z\",\"status\":\"completed\","
+            + "\"arguments\":\"{}\",\"result\":\"file contents\"}";
+        createSessionJsonl(basePath, "session-1", entryWithKind);
+
+        ToolCallStatisticsBackfill.BackfillResult result =
+            ToolCallStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(1, result.inserted(), "Entry with kind field should be inserted");
+        assertEquals(0, result.errors());
+    }
+
+    @Test
+    @DisplayName("error message longer than 500 chars is truncated before storing")
+    void longErrorMessageIsTruncated() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        createSessionJsonl(basePath, "session-1",
+            toolEntry("write_file", "error", "2025-01-15T10:00:00Z", "{}", "E".repeat(600)));
+
+        ToolCallStatisticsBackfill.backfill(service, basePath);
+
+        var errors = service.queryRecentErrors(null, null, 10);
+        assertEquals(1, errors.size());
+        assertEquals(500, errors.getFirst().errorMessage().length(),
+            "Error message should be truncated to 500 characters");
+    }
+
+    @Test
+    @DisplayName("session in index with no corresponding JSONL file is silently skipped")
+    void missingJsonlFileIsSkipped() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-missing", "GitHub Copilot");
+        // Intentionally NOT calling createSessionJsonl — the file does not exist
+
+        ToolCallStatisticsBackfill.BackfillResult result =
+            ToolCallStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(0, result.inserted());
+        assertEquals(0, result.errors(), "Missing JSONL file should be silently skipped");
+        assertEquals(0, service.getRecordCount());
+    }
+
     private static String toolEntry(String title, String status, String timestamp,
                                     String arguments, String result) {
         return "{\"type\":\"tool\",\"title\":\"" + title

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
@@ -246,8 +246,8 @@ class ToolCallStatisticsServiceTest {
 
         var errors = service.queryRecentErrors(null, "opencode", 10);
         assertEquals(1, errors.size());
-        assertEquals("tool_b", errors.get(0).toolName());
-        assertEquals("opencode", errors.get(0).clientId());
+        assertEquals("tool_b", errors.getFirst().toolName());
+        assertEquals("opencode", errors.getFirst().clientId());
     }
 
     @Test
@@ -269,6 +269,79 @@ class ToolCallStatisticsServiceTest {
         service2.initializeWithConnection(conn2);
         // Second init on same connection — migration should be idempotent
         service2.initializeWithConnection(conn2);
+        // Verify DB is still functional after double-init
+        service2.recordCall(new ToolCallRecord("test", null, 0, 0, 0, true, null, "copilot", Instant.now()));
+        assertEquals(1, service2.getRecordCount());
         service2.dispose();
+    }
+
+    @Test
+    void hasRecordAtFindsExistingRecord() {
+        Instant ts = Instant.parse("2026-01-15T10:30:00Z");
+        service.recordCall(new ToolCallRecord("read_file", "FILE", 100, 200, 10, true, null, "copilot", ts));
+
+        assertTrue(service.hasRecordAt(ts, "read_file"));
+    }
+
+    @Test
+    void hasRecordAtReturnsFalseForNonExistent() {
+        Instant ts = Instant.parse("2026-01-15T10:30:00Z");
+        service.recordCall(new ToolCallRecord("read_file", "FILE", 100, 200, 10, true, null, "copilot", ts));
+
+        assertFalse(service.hasRecordAt(ts, "write_file"));
+        assertFalse(service.hasRecordAt(Instant.parse("2026-01-16T10:30:00Z"), "read_file"));
+    }
+
+    @Test
+    void getRecordCountReturnsCorrectCount() {
+        assertEquals(0, service.getRecordCount());
+
+        Instant ts = Instant.now();
+        service.recordCall(new ToolCallRecord("a", null, 0, 0, 0, true, null, "copilot", ts));
+        assertEquals(1, service.getRecordCount());
+
+        service.recordCall(new ToolCallRecord("b", null, 0, 0, 0, true, null, "copilot", ts.plusSeconds(1)));
+        assertEquals(2, service.getRecordCount());
+    }
+
+    @Test
+    void recordCallWithNullConnectionDoesNotThrow() {
+        // Create a service without initializing a connection
+        var uninitService = new ToolCallStatisticsService();
+        // Should not throw — just silently drops the call
+        uninitService.recordCall(new ToolCallRecord("test", null, 0, 0, 0, true, null, "copilot", Instant.now()));
+        // Verify getRecordCount also handles null connection
+        assertEquals(0, uninitService.getRecordCount());
+    }
+
+    @Test
+    void hasRecordAtWithNullConnectionReturnsFalse() {
+        var uninitService = new ToolCallStatisticsService();
+        assertFalse(uninitService.hasRecordAt(Instant.now(), "anything"));
+    }
+
+    @Test
+    void getRecordCountWithNullConnectionReturnsZero() {
+        var uninitService = new ToolCallStatisticsService();
+        assertEquals(0, uninitService.getRecordCount());
+    }
+
+    @Test
+    void queryMethodsWithNullConnectionReturnEmpty() {
+        var uninitService = new ToolCallStatisticsService();
+        assertTrue(uninitService.queryAggregates(null, null).isEmpty());
+        assertTrue(uninitService.querySummary(null, null).isEmpty());
+        assertTrue(uninitService.getDistinctClients().isEmpty());
+        assertTrue(uninitService.queryRecentErrors(null, null, 10).isEmpty());
+    }
+
+    @Test
+    void isDbMovedDetectsSqliteReadonlyDbmoved() {
+        assertTrue(ToolCallStatisticsService.isDbMoved(
+            new SQLException("[SQLITE_READONLY_DBMOVED] database file moved or deleted")));
+        assertFalse(ToolCallStatisticsService.isDbMoved(
+            new SQLException("some other error")));
+        assertFalse(ToolCallStatisticsService.isDbMoved(
+            new SQLException((String) null)));
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
@@ -1,9 +1,11 @@
 package com.github.catatafishen.agentbridge.services;
 
+import com.intellij.openapi.project.Project;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 
 import java.nio.file.Path;
 import java.sql.Connection;
@@ -16,6 +18,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -246,8 +249,9 @@ class ToolCallStatisticsServiceTest {
 
         var errors = service.queryRecentErrors(null, "opencode", 10);
         assertEquals(1, errors.size());
-        assertEquals("tool_b", errors.getFirst().toolName());
-        assertEquals("opencode", errors.getFirst().clientId());
+        var first = errors.getFirst();
+        assertEquals("tool_b", first.toolName());
+        assertEquals("opencode", first.clientId());
     }
 
     @Test
@@ -343,5 +347,14 @@ class ToolCallStatisticsServiceTest {
             new SQLException("some other error")));
         assertFalse(ToolCallStatisticsService.isDbMoved(
             new SQLException((String) null)));
+    }
+
+    @Test
+    void initializeThrowsWhenBasePathIsNull() {
+        Project mockProject = Mockito.mock(Project.class);
+        Mockito.when(mockProject.getBasePath()).thenReturn(null);
+
+        ToolCallStatisticsService svc = new ToolCallStatisticsService(mockProject);
+        assertThrows(IllegalStateException.class, svc::initialize);
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoaderTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoaderTest.java
@@ -15,10 +15,8 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -233,24 +231,23 @@ class UsageStatisticsLoaderTest {
             Files.writeString(jsonlPath, line1 + "\n" + line2 + "\n");
 
             Map<Object, Object> accumulators = new LinkedHashMap<>();
-            LinkedHashSet<String> agentIds = new LinkedHashSet<>();
-            Map<String, String> agentDisplayNames = new LinkedHashMap<>();
-            invokeCollectTurnStats(jsonlPath, "copilot", accumulators, agentIds, agentDisplayNames);
+            invokeCollectTurnStats(jsonlPath, "copilot", accumulators);
 
             assertEquals(1, accumulators.size(),
                 "Two entries on the same date/agent should produce exactly one accumulator bucket");
         }
 
         @Test
-        void tracksAgentChangesWithinSession(@TempDir Path tempDir) throws Exception {
+        void usesSessionAgentEvenWhenEntriesHaveDifferentAgentFields(@TempDir Path tempDir) throws Exception {
             Path jsonlPath = tempDir.resolve("mixed.jsonl");
+            // Text entries with different agent names (one is a client, one is a model name)
             String line1 = "{\"type\":\"text\",\"raw\":\"hello\",\"agent\":\"GitHub Copilot\","
                 + "\"entryId\":\"e1\"}";
             String line2 = "{\"type\":\"turnStats\",\"turnId\":\"t1\",\"durationMs\":5000,"
                 + "\"inputTokens\":100,\"outputTokens\":200,\"toolCallCount\":3,"
                 + "\"linesAdded\":10,\"linesRemoved\":5,\"multiplier\":\"1x\","
                 + "\"timestamp\":\"2024-06-15T10:00:00Z\",\"entryId\":\"e2\"}";
-            String line3 = "{\"type\":\"text\",\"raw\":\"hello\",\"agent\":\"Claude Code\","
+            String line3 = "{\"type\":\"text\",\"raw\":\"hello\",\"agent\":\"claude-3.5-sonnet\","
                 + "\"entryId\":\"e3\"}";
             String line4 = "{\"type\":\"turnStats\",\"turnId\":\"t2\",\"durationMs\":3000,"
                 + "\"inputTokens\":50,\"outputTokens\":100,\"toolCallCount\":1,"
@@ -259,24 +256,20 @@ class UsageStatisticsLoaderTest {
             Files.writeString(jsonlPath, line1 + "\n" + line2 + "\n" + line3 + "\n" + line4 + "\n");
 
             Map<Object, Object> accumulators = new LinkedHashMap<>();
-            LinkedHashSet<String> agentIds = new LinkedHashSet<>();
-            Map<String, String> agentDisplayNames = new LinkedHashMap<>();
-            invokeCollectTurnStats(jsonlPath, "unknown", accumulators, agentIds, agentDisplayNames);
+            invokeCollectTurnStats(jsonlPath, "copilot", accumulators);
 
             Method buildMethod = UsageStatisticsLoader.class.getDeclaredMethod("buildDailyStats", Map.class);
             buildMethod.setAccessible(true);
             List<?> result = (List<?>) buildMethod.invoke(null, accumulators);
 
-            assertEquals(2, result.size());
-            assertTrue(agentIds.contains("copilot"));
-            assertTrue(agentIds.contains("claude-cli"));
-            assertEquals("GitHub Copilot", agentDisplayNames.get("copilot"));
-            assertEquals("Claude Code", agentDisplayNames.get("claude-cli"));
-
-            UsageStatisticsData.DailyAgentStats first = (UsageStatisticsData.DailyAgentStats) result.get(0);
-            UsageStatisticsData.DailyAgentStats second = (UsageStatisticsData.DailyAgentStats) result.get(1);
-            assertTrue(Set.of(first.agentId(), second.agentId()).contains("copilot"));
-            assertTrue(Set.of(first.agentId(), second.agentId()).contains("claude-cli"));
+            // Both TurnStats entries should be attributed to the session-level agent "copilot",
+            // NOT split into separate series based on the entry-level "agent" field
+            assertEquals(1, result.size(), "All entries in a session should use the session-level agent");
+            UsageStatisticsData.DailyAgentStats stats = (UsageStatisticsData.DailyAgentStats) result.get(0);
+            assertEquals("copilot", stats.agentId());
+            assertEquals(2, stats.turns());
+            assertEquals(150, stats.inputTokens());
+            assertEquals(300, stats.outputTokens());
         }
 
         @Test
@@ -285,9 +278,7 @@ class UsageStatisticsLoaderTest {
             Files.writeString(jsonlPath, "");
 
             Map<Object, Object> accumulators = new LinkedHashMap<>();
-            LinkedHashSet<String> agentIds = new LinkedHashSet<>();
-            Map<String, String> agentDisplayNames = new LinkedHashMap<>();
-            invokeCollectTurnStats(jsonlPath, "copilot", accumulators, agentIds, agentDisplayNames);
+            invokeCollectTurnStats(jsonlPath, "copilot", accumulators);
 
             assertTrue(accumulators.isEmpty());
         }
@@ -302,9 +293,7 @@ class UsageStatisticsLoaderTest {
             Files.writeString(jsonlPath, line + "\n");
 
             Map<Object, Object> accumulators = new LinkedHashMap<>();
-            LinkedHashSet<String> agentIds = new LinkedHashSet<>();
-            Map<String, String> agentDisplayNames = new LinkedHashMap<>();
-            invokeCollectTurnStats(jsonlPath, "copilot", accumulators, agentIds, agentDisplayNames);
+            invokeCollectTurnStats(jsonlPath, "copilot", accumulators);
 
             assertTrue(accumulators.isEmpty());
         }
@@ -326,9 +315,7 @@ class UsageStatisticsLoaderTest {
             Files.writeString(jsonlPath, line + "\n");
 
             Map<Object, Object> accumulators = new LinkedHashMap<>();
-            LinkedHashSet<String> agentIds = new LinkedHashSet<>();
-            Map<String, String> agentDisplayNames = new LinkedHashMap<>();
-            invokeCollectTurnStats(jsonlPath, "copilot", accumulators, agentIds, agentDisplayNames);
+            invokeCollectTurnStats(jsonlPath, "copilot", accumulators);
 
             assertFalse(accumulators.isEmpty(), "Precondition: accumulators must be populated");
 
@@ -356,14 +343,12 @@ class UsageStatisticsLoaderTest {
     }
 
     private static void invokeCollectTurnStats(Path jsonlPath, String agentId,
-                                               Map<Object, Object> accumulators,
-                                               Set<String> agentIds,
-                                               Map<String, String> agentDisplayNames) throws Exception {
+                                               Map<Object, Object> accumulators) throws Exception {
         Method m = UsageStatisticsLoader.class.getDeclaredMethod(
-            "collectTurnStats", Path.class, String.class, LocalDate.class, LocalDate.class, Map.class, Set.class, Map.class);
+            "collectTurnStats", Path.class, String.class, LocalDate.class, LocalDate.class, Map.class);
         m.setAccessible(true);
         m.invoke(null, jsonlPath, agentId,
             LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31),
-            accumulators, agentIds, agentDisplayNames);
+            accumulators);
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoaderTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoaderTest.java
@@ -297,6 +297,43 @@ class UsageStatisticsLoaderTest {
 
             assertTrue(accumulators.isEmpty());
         }
+
+        @Test
+        void turnStatsWithoutOwnTimestampUsesPrecedingEntryTimestamp(@TempDir Path tempDir) throws Exception {
+            Path jsonlPath = tempDir.resolve("session.jsonl");
+            // A text entry with a timestamp provides the lastSeenTimestamp fallback
+            String textLine = "{\"type\":\"text\",\"content\":\"hello\","
+                + "\"timestamp\":\"2024-06-15T10:00:00Z\",\"entryId\":\"e1\"}";
+            // TurnStats with no timestamp field: must use the fallback from the preceding line
+            String turnStatsNoTs = "{\"type\":\"turnStats\",\"turnId\":\"t1\",\"durationMs\":5000,"
+                + "\"inputTokens\":100,\"outputTokens\":200,\"toolCallCount\":3,"
+                + "\"linesAdded\":10,\"linesRemoved\":5,\"multiplier\":\"1x\","
+                + "\"entryId\":\"e2\"}";
+            Files.writeString(jsonlPath, textLine + "\n" + turnStatsNoTs + "\n");
+
+            Map<Object, Object> accumulators = new LinkedHashMap<>();
+            invokeCollectTurnStats(jsonlPath, "copilot", accumulators);
+
+            assertEquals(1, accumulators.size(),
+                "TurnStats without its own timestamp should use the preceding entry's timestamp as fallback");
+        }
+
+        @Test
+        void turnStatsWithNoResolvableTimestampIsSkipped(@TempDir Path tempDir) throws Exception {
+            Path jsonlPath = tempDir.resolve("session.jsonl");
+            // Single TurnStats with no timestamp and no preceding line to provide a fallback
+            String turnStatsNoTs = "{\"type\":\"turnStats\",\"turnId\":\"t1\",\"durationMs\":5000,"
+                + "\"inputTokens\":100,\"outputTokens\":200,\"toolCallCount\":3,"
+                + "\"linesAdded\":10,\"linesRemoved\":5,\"multiplier\":\"1x\","
+                + "\"entryId\":\"e1\"}";
+            Files.writeString(jsonlPath, turnStatsNoTs + "\n");
+
+            Map<Object, Object> accumulators = new LinkedHashMap<>();
+            invokeCollectTurnStats(jsonlPath, "copilot", accumulators);
+
+            assertTrue(accumulators.isEmpty(),
+                "TurnStats with no resolvable timestamp should be skipped");
+        }
     }
 
     // ── buildDailyStats (private static, via reflection) ────────────────


### PR DESCRIPTION
## Summary

Fixes two bugs in the statistics system:

### Bug 1: Tool statistics stale/unchanged

**Root cause:** `ToolCallStatisticsService.initialize()` caught all exceptions and returned normally, so `getInstance()` set `initialized=true` even when SQLite connection failed. All subsequent `recordCall()` invocations silently dropped tool calls.

**Fix:**
- `initialize()` now throws on failure instead of swallowing exceptions
- `getInstance()` catches the exception and logs it prominently
- `recordCall()` logs a warning when the connection is unavailable

### Bug 2: Charts mixing clients and models

**Root cause:** `UsageStatisticsLoader.collectTurnStats()` scanned the `"agent"` field from ALL JSONL entry types (Text, ToolCall, SubAgent). These can contain model names (e.g., `"claude-3.5-sonnet"`) which the `toAgentId()` substring matcher would interpret as phantom client IDs.

**Fix:**
- `collectTurnStats()` now uses only the session-level agent ID for attribution
- Individual entry `"agent"` fields are ignored, eliminating model-name contamination

### Files changed
- `ToolCallStatisticsService.java` — init error handling, recordCall logging
- `UsageStatisticsLoader.java` — simplified collectTurnStats to use session-level agent
- `UsageStatisticsLoaderTest.java` — updated tests for new behavior