### PR TITLE
fix: resolve file reference ORCs in nudge text

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -780,21 +780,27 @@ class ChatToolWindowContent(
         if (!isSending) return
         val rawText = promptTextArea.text.trim()
         if (rawText.isEmpty()) return
+
+        // Resolve file reference ORCs to plain text names before clearing the editor —
+        // nudges don't support context attachments, so inline chips become backtick-wrapped names.
+        val contextItems = contextManager.collectInlineContextItems()
+        val text = contextManager.replaceOrcsWithTextRefs(rawText, contextItems)
+
         promptTextArea.text = ""
 
         val existingId = pendingNudgeId
         if (existingId != null) {
-            pendingNudgeText = (pendingNudgeText ?: "") + "\n\n" + rawText
+            pendingNudgeText = (pendingNudgeText ?: "") + "\n\n" + text
             consolePanel.showNudgeBubble(existingId, pendingNudgeText!!)
         } else {
             val id = System.currentTimeMillis().toString()
             pendingNudgeId = id
-            pendingNudgeText = rawText
-            consolePanel.showNudgeBubble(id, rawText)
+            pendingNudgeText = text
+            consolePanel.showNudgeBubble(id, text)
         }
 
         val psiBridge = com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(project)
-        psiBridge.setPendingNudge(rawText)
+        psiBridge.setPendingNudge(text)
         val resolveId = pendingNudgeId!!
         psiBridge.setOnNudgeConsumed {
             val capturedText = pendingNudgeText


### PR DESCRIPTION
**Root cause:** The nudge flow in `onNudgeClicked()` sent raw ORC characters (`U+FFFC`) from inline context chips directly to the agent and UI bubble. Unlike the prompt-send flow, it never called `collectInlineContextItems()` + `replaceOrcsWithTextRefs()` to convert file chips into backtick-wrapped text names.

The invisible ORC character would appear as a broken reference when injected into the tool result as a nudge.

**Fix:** Collect context items and resolve ORCs before clearing the prompt editor, so file references in nudges become plain text like `ToolCallStatisticsService.java:103-127` instead of invisible ORC characters.