### PR TITLE
fix: preserve original agent in session index to fix statistics chart attribution

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2.java
@@ -455,7 +455,12 @@ public final class SessionStoreV2 implements Disposable {
         for (JsonObject rec : records) {
             if (rec.has(KEY_ID) && sessionId.equals(rec.get(KEY_ID).getAsString())) {
                 rec.addProperty(KEY_UPDATED_AT, now);
-                rec.addProperty(KEY_AGENT, agentName);
+                // Never overwrite agent — keep the original agent from session creation.
+                // Overwriting here causes the statistics chart to attribute all turns in
+                // this session to the last-used agent instead of the original one.
+                if (!rec.has(KEY_AGENT)) {
+                    rec.addProperty(KEY_AGENT, agentName);
+                }
                 if (additionalTurns > 0) {
                     int current = rec.has(KEY_TURN_COUNT) ? rec.get(KEY_TURN_COUNT).getAsInt() : 0;
                     rec.addProperty(KEY_TURN_COUNT, current + additionalTurns);

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2Test.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2Test.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1627,6 +1628,59 @@ class SessionStoreV2Test {
             assertEquals(1, branchEntries.size());
             assertInstanceOf(EntryData.Prompt.class, branchEntries.get(0));
             assertEquals(promptText, ((EntryData.Prompt) branchEntries.get(0)).getText());
+        }
+
+        // ── appendSessionsIndex agent-preservation ────────────────────────────
+
+        @Test
+        @DisplayName("agent is not overwritten on subsequent appendEntries calls")
+        void appendSessionsIndex_agentPreservedOnSubsequentAppend() {
+            SessionStoreV2 store = newStore();
+            store.setCurrentAgent("agent-one");
+
+            store.appendEntries(tempDir.toString(),
+                List.of(new EntryData.Prompt("First prompt", "2024-01-01T00:00:00Z", null, "p1", "p1")));
+            String sessionId = store.getCurrentSessionId(tempDir.toString());
+
+            // Switch to a different agent and append more entries.
+            store.setCurrentAgent("agent-two");
+            store.appendEntries(tempDir.toString(),
+                List.of(new EntryData.Prompt("Second prompt", "2024-01-01T00:01:00Z", null, "p2", "p2")));
+
+            Optional<SessionStoreV2.SessionRecord> rec = store.listSessions(tempDir.toString())
+                .stream().filter(r -> r.id().equals(sessionId)).findFirst();
+            assertTrue(rec.isPresent(), "session should be in the index");
+            assertEquals("agent-one", rec.get().agent(),
+                "original agent must not be overwritten by subsequent appends");
+        }
+
+        @Test
+        @DisplayName("agent is set from index record when field was previously absent")
+        void appendSessionsIndex_agentSetWhenMissingFromExistingRecord() throws IOException {
+            SessionStoreV2 store = newStore();
+            store.setCurrentAgent("original-agent");
+
+            // Bootstrap the sessions directory and current-session-id file.
+            store.appendEntries(tempDir.toString(),
+                List.of(new EntryData.Prompt("Seed", "2024-01-01T00:00:00Z", null, "p1", "p1")));
+            String sessionId = store.getCurrentSessionId(tempDir.toString());
+
+            // Rewrite the sessions index without the "agent" field to simulate an old record.
+            Path indexFile = sessionsDir().resolve("sessions-index.json");
+            String indexJson = Files.readString(indexFile);
+            String withoutAgent = indexJson.replaceAll(",?\"agent\":\"[^\"]*\"", "");
+            Files.writeString(indexFile, withoutAgent, StandardCharsets.UTF_8);
+
+            // Appending entries should set the agent on the now-agent-less record.
+            store.setCurrentAgent("backfill-agent");
+            store.appendEntries(tempDir.toString(),
+                List.of(new EntryData.Prompt("Follow-up", "2024-01-01T00:02:00Z", null, "p3", "p3")));
+
+            Optional<SessionStoreV2.SessionRecord> rec = store.listSessions(tempDir.toString())
+                .stream().filter(r -> r.id().equals(sessionId)).findFirst();
+            assertTrue(rec.isPresent(), "session should still be in the index");
+            assertEquals("backfill-agent", rec.get().agent(),
+                "agent should be set when the existing record had no agent field");
         }
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2Test.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2Test.java
@@ -1533,6 +1533,25 @@ class SessionStoreV2Test {
                 "session name should remain from the very first prompt");
         }
 
+        @Test
+        @DisplayName("appendEntries does not overwrite agent after switching to a different agent")
+        void appendEntries_preservesOriginalAgent() {
+            SessionStoreV2 store = newStore(); // currentAgent = "test-agent"
+
+            store.appendEntries(tempDir.toString(),
+                List.of(new EntryData.Prompt("Hello", "2024-01-01T00:00:00Z", null, "p1", "p1")));
+
+            // Simulate switching to a different agent mid-session
+            store.setCurrentAgent("different-agent");
+            store.appendEntries(tempDir.toString(),
+                List.of(new EntryData.Text("Reply", "2024-01-01T00:00:01Z", "different-agent", "gpt-4", "t1")));
+
+            List<SessionStoreV2.SessionRecord> sessions = store.listSessions(tempDir.toString());
+            assertEquals(1, sessions.size());
+            assertEquals("test-agent", sessions.get(0).agent(),
+                "session agent should remain from the first append, not be overwritten by the current agent");
+        }
+
         // ── branchCurrentSession ──────────────────────────────────────────────
 
         @Test


### PR DESCRIPTION
## Problem

`SessionStoreV2.appendSessionsIndex()` unconditionally overwrote the `KEY_AGENT` field on every session update. When switching agents mid-session (e.g. Copilot → Junie), this relabeled the entire session as the new agent, causing all historical turns to appear under the wrong client in the statistics charts.

## Root Cause

`SessionStoreV2.java:458` — `rec.addProperty(KEY_AGENT, agent)` ran on every `appendEntries()` call, not just on session creation.

## Fix

Only set `KEY_AGENT` when creating a new session record (first append). Subsequent updates preserve the original agent identity.

```java
// Before: unconditional overwrite
rec.addProperty(KEY_AGENT, agent);

// After: only set on creation
if (!rec.has(KEY_AGENT)) {
    rec.addProperty(KEY_AGENT, agent);
}
```

## Test

Added `appendEntries_preservesOriginalAgent` — creates a session with one agent, switches to a different agent, appends more entries, and verifies the session record still shows the original agent.