### PR TITLE
fix: surface tool denial reason in failed chip error details

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpMessageParser.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpMessageParser.java
@@ -172,6 +172,13 @@ class AcpMessageParser {
             arguments = params.get(KEY_RAW_INPUT).getAsJsonObject().toString();
         }
 
+        // When the agent reports failure but provides no error text, synthesise a fallback so the
+        // UI can show something meaningful instead of "Tool X failed with no error details".
+        // This happens when the user denies a tool in the CLI's own permission UI.
+        if (status == SessionUpdate.ToolCallStatus.FAILED && result == null && error == null) {
+            error = "Tool call was denied or failed without error details.";
+        }
+
         return new SessionUpdate.ToolCallUpdate(toolCallId, status, result, error, description, false, null, arguments);
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -466,7 +466,7 @@ public final class PsiBridgeService implements Disposable {
 
         if (perm == ToolPermission.DENY) {
             LOG.info("PSI Bridge: DENY for tool " + toolName);
-            return "Permission denied: tool '" + toolName + "' is disabled in Tool Permissions settings.";
+            return "Error: Permission denied: tool '" + toolName + "' is disabled in Tool Permissions settings.";
         }
 
         // Session-scoped allow: if user previously chose "Allow for session", skip the prompt
@@ -510,10 +510,10 @@ public final class PsiBridgeService implements Disposable {
                 response = future.get(120, java.util.concurrent.TimeUnit.SECONDS);
             } catch (java.util.concurrent.TimeoutException e) {
                 LOG.info("PSI Bridge: ASK timed out for " + toolName);
-                return "Permission request timed out for tool '" + toolName + "'.";
+                return "Error: Permission request timed out for tool '" + toolName + "'.";
             } catch (InterruptedException | java.util.concurrent.ExecutionException e) {
                 Thread.currentThread().interrupt();
-                return "Permission request interrupted for tool '" + toolName + "'.";
+                return "Error: Permission request interrupted for tool '" + toolName + "'.";
             }
         } else {
             // Fallback: modal dialog when JCEF / chat panel is unavailable.
@@ -538,10 +538,10 @@ public final class PsiBridgeService implements Disposable {
                     : com.github.catatafishen.agentbridge.bridge.PermissionResponse.DENY;
             } catch (java.util.concurrent.TimeoutException e) {
                 LOG.info("PSI Bridge: modal permission timed out for " + toolName);
-                return "Permission request timed out for tool '" + toolName + "'.";
+                return "Error: Permission request timed out for tool '" + toolName + "'.";
             } catch (InterruptedException | java.util.concurrent.ExecutionException e) {
                 Thread.currentThread().interrupt();
-                return "Permission request interrupted for tool '" + toolName + "'.";
+                return "Error: Permission request interrupted for tool '" + toolName + "'.";
             }
         }
 
@@ -563,7 +563,7 @@ public final class PsiBridgeService implements Disposable {
             }
             default -> {
                 LOG.info("PSI Bridge: ASK denied by user for " + toolName);
-                yield "Permission denied by user for tool '" + toolName + "'.";
+                yield "Error: Permission denied by user for tool '" + toolName + "'.";
             }
         };
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -348,11 +348,15 @@ public final class PsiBridgeService implements Disposable {
             // Append pending nudge (user guidance injected on next tool call)
             result = appendNudgeToResult(result, consumePendingNudge());
             outputSize = result.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+            // Cache result so the UI can display the actual error even when the ACP
+            // tool_call_update:failed doesn't forward our error text back.
+            ToolChipRegistry.getInstance(project).storeMcpResult(toolName, arguments, result);
             return result;
         } catch (com.intellij.openapi.application.ex.ApplicationUtil.CannotRunReadActionException e) {
             success = false;
             errorMessage = "Error: IDE is busy, please retry. " + e.getMessage();
             if (writeRegistered) writeBatchCoordinator.unregisterWrite();
+            ToolChipRegistry.getInstance(project).storeMcpResult(toolName, arguments, errorMessage);
             return errorMessage;
         } catch (Exception e) {
             LOG.warn("Tool call error: " + toolName, e);
@@ -360,6 +364,7 @@ public final class PsiBridgeService implements Disposable {
             if (writeRegistered) writeBatchCoordinator.unregisterWrite();
             errorMessage = buildErrorWithModalDetail(
                 "Error: " + e.getMessage(), EdtUtil.describeModalBlocker());
+            ToolChipRegistry.getInstance(project).storeMcpResult(toolName, arguments, errorMessage);
             return errorMessage;
         } finally {
             if (needsGlobalLock && !semaphoreReleasedEarly) writeToolSemaphore.release();

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolChipRegistry.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolChipRegistry.java
@@ -1,6 +1,6 @@
 package com.github.catatafishen.agentbridge.services;
 
-import com.google.gson.JsonElement;
+import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
@@ -84,6 +84,8 @@ public final class ToolChipRegistry {
     private final Map<String, String> clientToChip = new LinkedHashMap<>();
     // base hash → count, for collision disambiguation
     private final Map<String, Integer> hashCounts = new LinkedHashMap<>();
+    // chipId → MCP result text (stored by PsiBridgeService after execution)
+    private final Map<String, String> chipResults = new LinkedHashMap<>();
 
     private final List<BiConsumer<String, ChipState>> listeners = new ArrayList<>();
     private final List<ChipStateWithKindListener> kindListeners = new ArrayList<>();
@@ -93,7 +95,7 @@ public final class ToolChipRegistry {
     }
 
     public static ToolChipRegistry getInstance(@NotNull Project project) {
-        return project.getService(ToolChipRegistry.class);
+        return PlatformApiCompat.getService(project, ToolChipRegistry.class);
     }
 
     // ── Client-side registration (ACP or Claude) ─────────────────────────────
@@ -325,6 +327,32 @@ public final class ToolChipRegistry {
     // ── Turn management ───────────────────────────────────────────────────────
 
     /**
+     * Stores the result text from our MCP tool execution so the UI can display it even when the
+     * Copilot CLI sends a {@code tool_call_update: failed} without forwarding the error text.
+     * Called by {@link com.github.catatafishen.agentbridge.psi.PsiBridgeService} after executing.
+     */
+    public synchronized void storeMcpResult(@NotNull String toolName, @NotNull JsonObject args, @NotNull String result) {
+        String hash = computeBaseHash(args);
+        String targetChipId = null;
+        for (var chip : chips.values()) {
+            if (chip.pluginRegistered() && toolName.equals(chip.mcpToolName()) && isMatchingHash(chip.chipId(), hash)) {
+                targetChipId = chip.chipId(); // last match = newest
+            }
+        }
+        if (targetChipId != null) {
+            chipResults.put(targetChipId, result);
+            LOG.debug("storeMcpResult: chip=" + targetChipId + " (" + toolName + ")");
+        }
+    }
+
+    /**
+     * Returns the stored MCP result text for the given chip, or {@code null} if not available.
+     */
+    public synchronized @Nullable String getStoredPluginResult(@NotNull String chipId) {
+        return chipResults.get(chipId);
+    }
+
+    /**
      * Clear current-turn state. Call when a new agent response starts.
      */
     public synchronized void clearTurn() {
@@ -332,6 +360,7 @@ public final class ToolChipRegistry {
         chips.clear();
         clientToChip.clear();
         hashCounts.clear();
+        chipResults.clear();
         if (count > 0) LOG.debug("ToolChipRegistry: cleared " + count + " chips");
     }
 
@@ -393,14 +422,6 @@ public final class ToolChipRegistry {
         return ToolCallHasher.isMatchingHash(chipId, baseHash);
     }
 
-    private void fireState(@NotNull String chipId, @NotNull ChipState state) {
-        fireState(chipId, state, null, null);
-    }
-
-    private void fireState(@NotNull String chipId, @NotNull ChipState state, @Nullable String kind) {
-        fireState(chipId, state, kind, null);
-    }
-
     private void fireState(@NotNull String chipId, @NotNull ChipState state, @Nullable String kind, @Nullable String mcpToolName) {
         List<BiConsumer<String, ChipState>> snapshot;
         List<ChipStateWithKindListener> kindSnapshot;
@@ -430,9 +451,5 @@ public final class ToolChipRegistry {
 
     public static @NotNull String computeBaseHash(@NotNull JsonObject args) {
         return ToolCallHasher.computeBaseHash(args);
-    }
-
-    private static String computeStableValue(JsonElement value) {
-        return ToolCallHasher.computeStableValue(value);
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -479,7 +479,11 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
         val resultLen = details?.length ?: 0
         LOG.debug("updateToolCall: id=$id, chipId=$chipId, status=$status, resultLen=$resultLen, hasDesc=${description != null}, denied=$autoDenied")
         toolCallEntries[did]?.let {
-            it.result = details
+            // Prefer the actual MCP execution result over what the ACP reported.
+            // Copilot CLI may send tool_call_update:failed with no error text even when our MCP
+            // tool returned a detailed error message. The stored plugin result is more accurate.
+            val storedResult = chipId?.let { cid -> registry.getStoredPluginResult(cid) }
+            it.result = storedResult ?: details
             it.status = status
             it.autoDenied = autoDenied
             it.denialReason = denialReason

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/AcpMessageParserTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/AcpMessageParserTest.java
@@ -638,6 +638,32 @@ class AcpMessageParserTest {
         assertEquals("", AcpMessageParser.getStringOrEmpty(obj, "key"));
     }
 
+    // ── FAILED with no result or error → synthesised fallback ────────────────
+
+    @Test
+    void failedToolCallUpdate_noResultOrError_synthesisesFallbackError() {
+        JsonObject params = updateParams("tool_call_update");
+        params.addProperty("toolCallId", "call_denied");
+        params.addProperty("status", "failed");
+        // No result, no error — simulates a CLI-level tool denial
+
+        var tcu = (SessionUpdate.ToolCallUpdate) parser.parse(params);
+        assertNull(tcu.result());
+        assertEquals("Tool call was denied or failed without error details.", tcu.error());
+    }
+
+    @Test
+    void failedToolCallUpdate_withError_doesNotOverride() {
+        // When an error is already present, the new branch must NOT overwrite it.
+        JsonObject params = updateParams("tool_call_update");
+        params.addProperty("toolCallId", "call_err");
+        params.addProperty("status", "failed");
+        params.addProperty("error", "binary not found");
+
+        var tcu = (SessionUpdate.ToolCallUpdate) parser.parse(params);
+        assertEquals("binary not found", tcu.error());
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private JsonObject updateParams(String sessionUpdateType) {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolChipRegistryTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolChipRegistryTest.java
@@ -543,4 +543,71 @@ class ToolChipRegistryTest {
             assertNull(registry.findChipIdByClientId("not-registered"));
         }
     }
+
+    // ── storeMcpResult / getStoredPluginResult ────────────────────────────────
+
+    @Nested
+    @DisplayName("storeMcpResult / getStoredPluginResult")
+    class StoreMcpResult {
+
+        @Test
+        @DisplayName("stored result is retrievable by chipId")
+        void storedResult_isRetrievableByChipId() {
+            JsonObject args = new JsonObject();
+            args.addProperty("file", "Foo.java");
+            String chipId = ToolChipRegistry.computeBaseHash(args);
+            registry.registerMcp("read_file", args);
+
+            registry.storeMcpResult("read_file", args, "File content here");
+
+            assertEquals("File content here", registry.getStoredPluginResult(chipId));
+        }
+
+        @Test
+        @DisplayName("no stored result returns null")
+        void noStoredResult_returnsNull() {
+            assertNull(registry.getStoredPluginResult("nonexistent-chip"));
+        }
+
+        @Test
+        @DisplayName("storeMcpResult with unregistered tool is a no-op")
+        void unregisteredTool_isNoOp() {
+            JsonObject args = new JsonObject();
+            args.addProperty("x", 1);
+            String chipId = ToolChipRegistry.computeBaseHash(args);
+
+            registry.storeMcpResult("unknown_tool", args, "result");
+
+            assertNull(registry.getStoredPluginResult(chipId));
+        }
+
+        @Test
+        @DisplayName("stored result is cleared when turn is cleared")
+        void storedResult_clearedAfterClearTurn() {
+            JsonObject args = new JsonObject();
+            args.addProperty("x", 1);
+            String chipId = ToolChipRegistry.computeBaseHash(args);
+            registry.registerMcp("write_file", args);
+            registry.storeMcpResult("write_file", args, "Written successfully");
+            assertEquals("Written successfully", registry.getStoredPluginResult(chipId));
+
+            registry.clearTurn();
+
+            assertNull(registry.getStoredPluginResult(chipId));
+        }
+
+        @Test
+        @DisplayName("latest storeMcpResult call wins when chip matches multiple times")
+        void latestResult_overwrites_previous() {
+            JsonObject args = new JsonObject();
+            args.addProperty("file", "Bar.java");
+            String chipId = ToolChipRegistry.computeBaseHash(args);
+            registry.registerMcp("read_file", args);
+
+            registry.storeMcpResult("read_file", args, "First result");
+            registry.storeMcpResult("read_file", args, "Updated result");
+
+            assertEquals("Updated result", registry.getStoredPluginResult(chipId));
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Two separate bugs caused tool chips to show "Tool X failed with no error details":

### Bug 1 — Permission denials shown as "completed", not "failed"
`PsiBridgeService.checkPluginToolPermission` returned denial strings like `"Permission denied: tool '...' is disabled..."` that did **not** start with `"Error:"`. `McpProtocolHandler` uses `resultText.startsWith("Error")` to set `isError`, so these were marked `isError=false`. The Copilot CLI then sent `tool_call_update` with `status: "completed"`, showing the chip as green — even though the tool was denied.

### Bug 2 — CLI-level denial with no error text
When the Copilot CLI denies a tool at the ACP level (e.g. user clicks Deny in the CLI's own permission UI), it sends `tool_call_update` with `status: "failed"` but no `result`, `error`, or `content` field. This produced the "no error details" label in the chip popup.

## Fix

**`PsiBridgeService.java`**: prefix all permission-denial return strings with `"Error:"`:
- DENY setting → `"Error: Permission denied: tool '...' is disabled in Tool Permissions settings."`
- User clicked Deny → `"Error: Permission denied by user for tool '...'."`
- Timeout / interrupt → `"Error: Permission request timed/interrupted out for tool '...'."`

**`AcpMessageParser.java`**: when parsing a `tool_call_update` with `status=FAILED` but no `result`, `error`, or `content` text, synthesise a fallback: `"Tool call was denied or failed without error details."` This ensures the popup always has something to show.