### PR TITLE
feat: manual JetBrains Marketplace publish workflow + Jazzer fuzz tests (closes #192)

### DIFF
--- a/.github/workflows/publish-marketplace.yml
+++ b/.github/workflows/publish-marketplace.yml
@@ -26,6 +26,7 @@ jobs:
   publish:
     name: Upload ${{ inputs.tag }} to JetBrains Marketplace
     runs-on: ubuntu-latest
+    environment: marketplace
     permissions:
       contents: read
     steps:
@@ -37,8 +38,9 @@ jobs:
       - name: Download plugin ZIP from GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          gh release download "${{ inputs.tag }}" \
+          gh release download "$RELEASE_TAG" \
             --repo "${{ github.repository }}" \
             --pattern "agentbridge-*.zip" \
             --dir release-artifacts

--- a/.github/workflows/publish-marketplace.yml
+++ b/.github/workflows/publish-marketplace.yml
@@ -1,0 +1,76 @@
+name: Publish to JetBrains Marketplace
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'GitHub release tag to publish (e.g. v1.52.0)'
+        required: true
+        type: string
+      channel:
+        description: 'Marketplace channel (leave as "stable" for production releases)'
+        required: true
+        type: choice
+        options:
+          - stable
+          - eap
+          - beta
+        default: stable
+
+permissions: read-all
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  publish:
+    name: Upload ${{ inputs.tag }} to JetBrains Marketplace
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176  # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Download plugin ZIP from GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "${{ inputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern "agentbridge-*.zip" \
+            --dir release-artifacts
+          ls -la release-artifacts/
+
+      - name: Upload to JetBrains Marketplace
+        env:
+          JETBRAINS_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          PLUGIN_ZIP=$(ls release-artifacts/agentbridge-*.zip | head -1)
+          echo "Uploading: $PLUGIN_ZIP to channel '${CHANNEL}'"
+
+          CURL_ARGS=(
+            --header "Authorization: Bearer $JETBRAINS_TOKEN"
+            -F "xmlId=com.github.catatafishen.ideagentforcopilot"
+            -F "file=@$PLUGIN_ZIP"
+          )
+          # The stable channel is the default — only pass channel for non-stable uploads
+          if [ "$CHANNEL" != "stable" ]; then
+            CURL_ARGS+=(-F "channel=$CHANNEL")
+          fi
+
+          HTTP_STATUS=$(curl -s -o response.txt -w "%{http_code}" "${CURL_ARGS[@]}" \
+            https://plugins.jetbrains.com/plugin/uploadPlugin)
+
+          echo "--- Marketplace response ---"
+          cat response.txt
+          echo ""
+
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "Upload failed with HTTP status $HTTP_STATUS"
+            exit 1
+          fi
+          echo "Successfully published $PLUGIN_ZIP to the JetBrains Marketplace"

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,6 @@ gsonVersion=2.13.1
 junitVersion=5.11.4
 junit4Version=4.13.2
 mockitoVersion=5.14.2
+jazzerVersion=0.22.0
+sqliteJdbcVersion=3.51.3.0
 zxingVersion=3.5.3

--- a/plugin-core/build.gradle.kts
+++ b/plugin-core/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
     implementation("com.google.zxing:javase:${providers.gradleProperty("zxingVersion").get()}")
 
     // SQLite JDBC (used by OpenCode session import)
-    implementation("org.xerial:sqlite-jdbc:3.51.3.0")
+    implementation("org.xerial:sqlite-jdbc:${providers.gradleProperty("sqliteJdbcVersion").get()}")
 
     testImplementation("org.junit.jupiter:junit-jupiter:${providers.gradleProperty("junitVersion").get()}")
     testImplementation(
@@ -68,6 +68,9 @@ dependencies {
         }"
     )  // Required by IntelliJ test framework
     testImplementation("org.mockito:mockito-core:${providers.gradleProperty("mockitoVersion").get()}")
+    // Jazzer API stubs — presence of the import satisfies OpenSSF Scorecard fuzzing check;
+    // actual fuzz runs use the full Jazzer engine invoked separately (not during `gradle test`).
+    testImplementation("com.code_intelligence:jazzer-api:${providers.gradleProperty("jazzerVersion").get()}")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:${providers.gradleProperty("junitVersion").get()}")
 }

--- a/plugin-core/build.gradle.kts
+++ b/plugin-core/build.gradle.kts
@@ -70,7 +70,7 @@ dependencies {
     testImplementation("org.mockito:mockito-core:${providers.gradleProperty("mockitoVersion").get()}")
     // Jazzer API stubs — presence of the import satisfies OpenSSF Scorecard fuzzing check;
     // actual fuzz runs use the full Jazzer engine invoked separately (not during `gradle test`).
-    testImplementation("com.code_intelligence:jazzer-api:${providers.gradleProperty("jazzerVersion").get()}")
+    testImplementation("com.code-intelligence:jazzer-api:${providers.gradleProperty("jazzerVersion").get()}")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:${providers.gradleProperty("junitVersion").get()}")
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/fuzz/AgentIdMapperFuzz.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/fuzz/AgentIdMapperFuzz.java
@@ -4,7 +4,7 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.github.catatafishen.agentbridge.services.AgentIdMapper;
 
 /**
- * Jazzer fuzz target for the MCP protocol message parsing pipeline.
+ * Jazzer fuzz target for {@link AgentIdMapper}.
  *
  * <p>Tests that {@link AgentIdMapper#toAgentId(String)} handles arbitrary agent display names
  * without throwing uncaught exceptions, producing null, or entering infinite loops.
@@ -15,17 +15,16 @@ import com.github.catatafishen.agentbridge.services.AgentIdMapper;
  * which detects the {@code com.code_intelligence.jazzer.api.FuzzedDataProvider} import.
  *
  * <p>To run: {@code java -jar jazzer.jar --cp=<test-classpath>
- * --target_class=com.github.catatafishen.agentbridge.fuzz.McpProtocolHandlerFuzz}
+ * --target_class=com.github.catatafishen.agentbridge.fuzz.AgentIdMapperFuzz}
  */
-public class McpProtocolHandlerFuzz {
+public class AgentIdMapperFuzz {
 
     public static void fuzzerTestOneInput(FuzzedDataProvider data) {
         String agentName = data.consumeRemainingAsString();
-        // toAgentId must return a non-null, non-empty ID for any input including
-        // null, empty string, extremely long strings, and unicode edge cases.
+        // toAgentId is @NotNull — only check for unexpected empty results.
         String result = AgentIdMapper.toAgentId(agentName);
-        if (result == null || result.isEmpty()) {
-            throw new AssertionError("toAgentId returned null or empty for: " + agentName);
+        if (result.isEmpty()) {
+            throw new AssertionError("toAgentId returned empty for: " + agentName);
         }
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/fuzz/MarkdownRendererFuzz.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/fuzz/MarkdownRendererFuzz.java
@@ -1,0 +1,24 @@
+package com.github.catatafishen.agentbridge.fuzz;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.github.catatafishen.agentbridge.ui.MarkdownRenderer;
+
+/**
+ * Jazzer fuzz target for {@link MarkdownRenderer}.
+ *
+ * <p>Validates that rendering arbitrary Markdown to HTML never causes uncaught exceptions,
+ * infinite loops, or other unexpected failures. This is a high-value target because the
+ * chat panel renders untrusted output from AI agent processes.
+ *
+ * <p>To run: {@code java -jar jazzer.jar --cp=<test-classpath>
+ * --target_class=com.github.catatafishen.agentbridge.fuzz.MarkdownRendererFuzz}
+ */
+public class MarkdownRendererFuzz {
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        String text = data.consumeRemainingAsString();
+        // All lambda parameters have no-op defaults matching the production defaults.
+        // Any uncaught exception is a Jazzer finding.
+        MarkdownRenderer.INSTANCE.markdownToHtml(text, s -> null, s -> null, s -> false);
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/fuzz/McpProtocolHandlerFuzz.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/fuzz/McpProtocolHandlerFuzz.java
@@ -1,0 +1,31 @@
+package com.github.catatafishen.agentbridge.fuzz;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.github.catatafishen.agentbridge.services.AgentIdMapper;
+
+/**
+ * Jazzer fuzz target for the MCP protocol message parsing pipeline.
+ *
+ * <p>Tests that {@link AgentIdMapper#toAgentId(String)} handles arbitrary agent display names
+ * without throwing uncaught exceptions, producing null, or entering infinite loops.
+ * This is called with agent names extracted from session files and AI responses —
+ * both untrusted sources.
+ *
+ * <p>Also serves to register the repository with the OpenSSF Scorecard Fuzzing check,
+ * which detects the {@code com.code_intelligence.jazzer.api.FuzzedDataProvider} import.
+ *
+ * <p>To run: {@code java -jar jazzer.jar --cp=<test-classpath>
+ * --target_class=com.github.catatafishen.agentbridge.fuzz.McpProtocolHandlerFuzz}
+ */
+public class McpProtocolHandlerFuzz {
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        String agentName = data.consumeRemainingAsString();
+        // toAgentId must return a non-null, non-empty ID for any input including
+        // null, empty string, extremely long strings, and unicode edge cases.
+        String result = AgentIdMapper.toAgentId(agentName);
+        if (result == null || result.isEmpty()) {
+            throw new AssertionError("toAgentId returned null or empty for: " + agentName);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

### Manual JetBrains Marketplace Publish Workflow

Adds `.github/workflows/publish-marketplace.yml` — a `workflow_dispatch` workflow to manually upload a pre-built plugin ZIP to the JetBrains Marketplace.

**How it works:**
1. Go to Actions → "Publish to JetBrains Marketplace"
2. Enter the release tag (e.g. `v1.52.0`) and select the channel (`stable`/`eap`/`beta`)
3. The workflow downloads `agentbridge-*.zip` from the selected GitHub Release (no rebuild, no checkout needed)
4. Uploads via the JetBrains Marketplace REST API using a Bearer token

**Required secret:** Add `JETBRAINS_MARKETPLACE_TOKEN` in Settings → Secrets → Actions.
This should be a JetBrains Hub Permanent Token with plugin upload permissions from your JetBrains account.

### Jazzer Fuzz Tests (closes #192)

Adds two Jazzer fuzz targets to satisfy the OpenSSF Scorecard Fuzzing check (currently scoring 0/10):

- **`MarkdownRendererFuzz`** — fuzzes arbitrary text through `markdownToHtml`. High-value target since the chat panel renders untrusted AI output.
- **`AgentIdMapperFuzz`** — asserts `AgentIdMapper.toAgentId()` postcondition: result must be non-empty for any input (including null, empty string, unicode).

The `com.code_intelligence.jazzer.api.FuzzedDataProvider` import triggers the Scorecard Fuzzing detection. The `jazzer-api` JAR is ~15KB (API stubs only) and doesn't affect `./gradlew test` — fuzz runs require the full Jazzer engine separately.

Also extracts `sqlite-jdbc` version to `gradle.properties` (was hardcoded — SonarQube S6624).