### PR TITLE
feat: Ctrl+/ cheat-sheet popup for chat prompt shortcuts

### DIFF
--- a/plugin-core/chat-ui/src/components/ChatContainer.ts
+++ b/plugin-core/chat-ui/src/components/ChatContainer.ts
@@ -1,7 +1,6 @@
 export default class ChatContainer extends HTMLElement {
     private _init = false;
     private _autoScroll = true;
-    private _autoScrollLocked = false; // true when user explicitly disabled via toggle
     private _restoring = false; // true while initial history batch is being inserted
     private _messages!: HTMLDivElement;
     private _workingIndicator!: HTMLElement;
@@ -32,18 +31,16 @@ export default class ChatContainer extends HTMLElement {
                 this._prevScrollTop = this.scrollTop;
                 return;
             }
-            const atBottom = this.scrollTop + this.clientHeight >= this.scrollHeight - 40;
-            if (atBottom && !this._autoScrollLocked) {
-                this._autoScroll = true;
-            } else if (this.scrollTop < this._prevScrollTop) {
-                // User intentionally scrolled up — disable auto-scroll
+            // Any manual scroll disables auto-scroll — the button is the only way to re-enable
+            if (this._autoScroll) {
                 this._autoScroll = false;
-                // Trigger load-more when scrolled near the top.
-                if (this.scrollTop <= 30) {
-                    const lm = this._messages.querySelector<HTMLElement>('load-more:not([loading])');
-                    if (lm) {
-                        lm.click();
-                    }
+                globalThis._bridge?.autoScrollDisabled?.();
+            }
+            // Trigger load-more when scrolled near the top while scrolling up
+            if (this.scrollTop < this._prevScrollTop && this.scrollTop <= 30) {
+                const lm = this._messages.querySelector<HTMLElement>('load-more:not([loading])');
+                if (lm) {
+                    lm.click();
                 }
             }
             this._prevScrollTop = this.scrollTop;
@@ -161,7 +158,6 @@ export default class ChatContainer extends HTMLElement {
     }
 
     set autoScroll(enabled: boolean) {
-        this._autoScrollLocked = !enabled;
         this._autoScroll = enabled;
         if (enabled) {
             this._programmaticScroll = true;

--- a/plugin-core/chat-ui/src/components/ChatContainer.ts
+++ b/plugin-core/chat-ui/src/components/ChatContainer.ts
@@ -9,8 +9,8 @@ export default class ChatContainer extends HTMLElement {
     private _observer!: MutationObserver;
     private _copyObs!: MutationObserver;
     private _prevScrollTop = 0;
-    private _programmaticScroll = false;
     private _onScroll: (() => void) | null = null;
+    private _onWheel: (() => void) | null = null;
     private _resizeObs: ResizeObserver | null = null;
 
     connectedCallback(): void {
@@ -24,19 +24,18 @@ export default class ChatContainer extends HTMLElement {
         this._workingIndicator = document.createElement('working-indicator');
         this.appendChild(this._workingIndicator);
 
-        this._onScroll = () => {
-            // Ignore scroll events caused by our own scrollTop assignments
-            if (this._programmaticScroll) {
-                this._programmaticScroll = false;
-                this._prevScrollTop = this.scrollTop;
-                return;
-            }
-            // Any manual scroll disables auto-scroll — the button is the only way to re-enable
+        // Wheel events are user-initiated — never fired by programmatic scrollTop changes.
+        // Using wheel (not scroll) eliminates the programmatic-vs-manual race condition.
+        this._onWheel = () => {
             if (this._autoScroll) {
                 this._autoScroll = false;
                 globalThis._bridge?.autoScrollDisabled?.();
             }
-            // Trigger load-more when scrolled near the top while scrolling up
+        };
+        this.addEventListener('wheel', this._onWheel, {passive: true});
+
+        // Scroll handler: only used for load-more trigger at the top.
+        this._onScroll = () => {
             if (this.scrollTop < this._prevScrollTop && this.scrollTop <= 30) {
                 const lm = this._messages.querySelector<HTMLElement>('load-more:not([loading])');
                 if (lm) {
@@ -50,7 +49,6 @@ export default class ChatContainer extends HTMLElement {
         // When the container or its content resizes, re-anchor to bottom if auto-scrolling
         this._resizeObs = new ResizeObserver(() => {
             if (this._autoScroll && !this._restoring) {
-                this._programmaticScroll = true;
                 this.scrollTop = this.scrollHeight;
             }
         });
@@ -160,20 +158,17 @@ export default class ChatContainer extends HTMLElement {
     set autoScroll(enabled: boolean) {
         this._autoScroll = enabled;
         if (enabled) {
-            this._programmaticScroll = true;
             this.scrollTop = this.scrollHeight;
         }
     }
 
     scrollIfNeeded(): void {
         if (this._autoScroll && !this._restoring) {
-            this._programmaticScroll = true;
             this.scrollTop = this.scrollHeight;
         }
     }
 
     forceScroll(): void {
-        this._programmaticScroll = true;
         this.scrollTop = this.scrollHeight;
     }
 
@@ -188,7 +183,6 @@ export default class ChatContainer extends HTMLElement {
     }
 
     compensateScroll(targetY: number): void {
-        this._programmaticScroll = true;
         this.scrollTop = targetY;
     }
 
@@ -197,6 +191,7 @@ export default class ChatContainer extends HTMLElement {
         this._copyObs?.disconnect();
         this._resizeObs?.disconnect();
         if (this._onScroll) this.removeEventListener('scroll', this._onScroll);
+        if (this._onWheel) this.removeEventListener('wheel', this._onWheel);
         if (this._scrollRAF) {
             cancelAnimationFrame(this._scrollRAF);
             this._scrollRAF = null;

--- a/plugin-core/chat-ui/src/globals.d.ts
+++ b/plugin-core/chat-ui/src/globals.d.ts
@@ -10,14 +10,24 @@ import type ChatControllerType from './ChatController';
 /** Extended bridge for the web app — adds methods not needed by the in-IDE panel. */
 export interface WebBridge {
     openFile(href: string): void;
+
     openUrl(href: string): void;
+
     setCursor(cursor: string): void;
+
     loadMore(): Promise<Response>;
+
     quickReply(text: string): Promise<Response>;
+
     permissionResponse(data: string): void;
+
     openScratch(): void;
+
     showToolPopup(): void;
+
     cancelNudge(id: string): Promise<Response>;
+
+    autoScrollDisabled?(): void;
 }
 
 declare global {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -365,6 +365,12 @@ public final class PsiBridgeService implements Disposable {
             if (writeRegistered) writeBatchCoordinator.unregisterWrite();
             ToolChipRegistry.getInstance(project).storeMcpResult(toolName, arguments, errorMessage);
             return errorMessage;
+        } catch (com.intellij.openapi.progress.ProcessCanceledException e) {
+            // ProcessCanceledException must not be swallowed — signals IDE shutdown or project disposal.
+            // Let it propagate so McpProtocolHandler can respond with an error and the MCP thread
+            // terminates cleanly rather than silently masking the cancellation.
+            if (writeRegistered) writeBatchCoordinator.unregisterWrite();
+            throw e;
         } catch (Exception e) {
             LOG.warn("Tool call error: " + toolName, e);
             success = false;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
@@ -6,11 +6,11 @@ import com.github.catatafishen.agentbridge.services.AgentTabTracker;
 import com.github.catatafishen.agentbridge.ui.renderers.SearchResultRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
-import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.usageView.UsageInfo;
@@ -118,10 +118,14 @@ public final class SearchTextTool extends NavigationTool {
         boolean followAgent = ActiveAgentManager.getFollowAgentFiles(project);
 
         showSearchFeedback("Searching text: " + query);
-        // Cast required: disambiguates Computable<T> vs ThrowableComputable<T,E> overloads.
-        // The IDE falsely reports this as redundant; Gradle fails without it.
-        Computable<String> action = () -> performSearch(query, filePattern, isRegex, caseSensitive, maxResults, contextLines, followAgent);
-        String result = ApplicationManager.getApplication().runReadAction(action);
+        // NonBlockingReadAction: iterating all project files can hold the read lock for several
+        // seconds on large projects. runReadAction() would block ALL write actions (EDT, indexing,
+        // daemon analysis) for the entire duration and cause "IDE not responding" freezes.
+        // executeSynchronously() yields to write actions when they need to run, then restarts the
+        // search (performSearch creates fresh collections, so restart is safe).
+        String result = ReadAction.nonBlocking(
+            () -> performSearch(query, filePattern, isRegex, caseSensitive, maxResults, contextLines, followAgent)
+        ).executeSynchronously();
         showSearchFeedback("Text search complete: " + query);
         return result;
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -36,6 +36,7 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
     override var onStatusMessage: ((type: String, message: String) -> Unit)? = null
     var onCancelNudge: ((String) -> Unit)? = null
     var onCancelQueuedMessage: ((id: String, text: String) -> Unit)? = null
+    var onAutoScrollDisabled: (() -> Unit)? = null
 
     // ── Data model (same types as V1 for serialization compat) ─────
     private val entries = mutableListOf<EntryData>()
@@ -90,6 +91,7 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
     private var showToolPopupBridgeJs = ""
     private var cancelNudgeBridgeJs = ""
     private var cancelQueuedMessageBridgeJs = ""
+    private var autoScrollDisabledBridgeJs = ""
 
     @Volatile
     private var htmlPageFuture: java.util.concurrent.CompletableFuture<String>? = null
@@ -207,6 +209,11 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
             }
             Disposer.register(this, cancelQueuedMessageQuery)
             cancelQueuedMessageBridgeJs = cancelQueuedMessageQuery.inject("JSON.stringify({id: id, text: text})")
+
+            val autoScrollDisabledQuery = JBCefJSQuery.create(browser as com.intellij.ui.jcef.JBCefBrowserBase)
+            autoScrollDisabledQuery.addHandler { onAutoScrollDisabled?.invoke(); null }
+            Disposer.register(this, autoScrollDisabledQuery)
+            autoScrollDisabledBridgeJs = autoScrollDisabledQuery.inject("''")
 
             add(browser.component, BorderLayout.CENTER)
 
@@ -1631,7 +1638,8 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
                 openScratch: function(lang, content) { $openScratchBridgeJs },
                 showToolPopup: function(id) { $showToolPopupBridgeJs },
                 cancelNudge: function(id) { $cancelNudgeBridgeJs },
-                cancelQueuedMessage: function(id, text) { $cancelQueuedMessageBridgeJs }
+                cancelQueuedMessage: function(id, text) { $cancelQueuedMessageBridgeJs },
+                autoScrollDisabled: function() { $autoScrollDisabledBridgeJs }
             };
         """.trimIndent()
         val css = loadResource("/chat/chat.css")

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -1530,7 +1530,10 @@ class ChatToolWindowContent(
             psiBridge.removeQueuedMessage(text)
             ApplicationManager.getApplication().invokeLater { consolePanel.removeQueuedMessage(id) }
         }
-        chatConsolePanel.onAutoScrollDisabled = { autoScrollEnabled = false }
+        chatConsolePanel.onAutoScrollDisabled = {
+            autoScrollEnabled = false
+            ActivityTracker.getInstance().inc()
+        }
         consolePanel.onQuickReply = { text ->
             ApplicationManager.getApplication().invokeLater {
                 if (!consolePanel.consumePendingAskUserResponse(text)) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -1596,6 +1596,7 @@ class ChatToolWindowContent(
         registerShiftEnterNewLine(editor, contentComponent)
         registerCtrlEnterNudge(contentComponent)
         registerCtrlShiftEnterQueue(contentComponent)
+        registerShowShortcutsPopup(contentComponent)
         registerPasteIntercept(editor, contentComponent)
         registerTriggerCharDetection(editor)
     }
@@ -1664,6 +1665,21 @@ class ChatToolWindowContent(
                 KeyStroke.getKeyStroke(
                     java.awt.event.KeyEvent.VK_ENTER,
                     java.awt.event.InputEvent.CTRL_DOWN_MASK or java.awt.event.InputEvent.SHIFT_DOWN_MASK
+                )
+            ),
+            contentComponent
+        )
+    }
+
+    private fun registerShowShortcutsPopup(contentComponent: JComponent) {
+        object : AnAction() {
+            override fun actionPerformed(e: AnActionEvent) = ShortcutCheatSheetPopup.show(promptTextArea)
+        }.registerCustomShortcutSet(
+            PromptShortcutAction.resolveShortcutSet(
+                PromptShortcutAction.SHOW_SHORTCUTS_ID,
+                KeyStroke.getKeyStroke(
+                    java.awt.event.KeyEvent.VK_SLASH,
+                    java.awt.event.InputEvent.CTRL_DOWN_MASK
                 )
             ),
             contentComponent

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -8,6 +8,7 @@ import com.github.catatafishen.agentbridge.session.SessionSwitchService
 import com.github.catatafishen.agentbridge.session.migration.V1ToV2Migrator
 import com.github.catatafishen.agentbridge.session.v2.SessionStoreV2
 import com.github.catatafishen.agentbridge.settings.ChatHistorySettings
+import com.intellij.ide.ActivityTracker
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.actionSystem.ex.ComboBoxAction

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -1530,6 +1530,7 @@ class ChatToolWindowContent(
             psiBridge.removeQueuedMessage(text)
             ApplicationManager.getApplication().invokeLater { consolePanel.removeQueuedMessage(id) }
         }
+        chatConsolePanel.onAutoScrollDisabled = { autoScrollEnabled = false }
         consolePanel.onQuickReply = { text ->
             ApplicationManager.getApplication().invokeLater {
                 if (!consolePanel.consumePendingAskUserResponse(text)) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/KeyBadge.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/KeyBadge.kt
@@ -1,0 +1,40 @@
+package com.github.catatafishen.agentbridge.ui
+
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.RenderingHints
+
+/**
+ * Small label rendered with a rounded-rect border and subtle background,
+ * mimicking a physical keyboard key cap. Used in the shortcut hint overlay
+ * and the Ctrl+/ cheat-sheet popup.
+ */
+class KeyBadge(text: String) : JBLabel(text) {
+
+    init {
+        font = JBUI.Fonts.miniFont()
+        foreground = UIUtil.getLabelForeground()
+        border = JBUI.Borders.empty(1, 4, 1, 4)
+        isOpaque = false
+    }
+
+    override fun paintComponent(g: Graphics) {
+        val g2 = g as Graphics2D
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+        val arc = JBUI.scale(4)
+        g2.color = BACKGROUND
+        g2.fillRoundRect(0, 0, width - 1, height - 1, arc, arc)
+        g2.color = BORDER
+        g2.drawRoundRect(0, 0, width - 1, height - 1, arc, arc)
+        super.paintComponent(g)
+    }
+
+    companion object {
+        val BACKGROUND: JBColor = JBColor(0xF0F0F0, 0x3C3F41)
+        val BORDER: JBColor = JBColor(0xC8C8C8, 0x5E6060)
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutAction.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutAction.java
@@ -24,6 +24,7 @@ public final class PromptShortcutAction extends AnAction {
     public static final String NEW_LINE_ID = "AgentBridge.Prompt.NewLine";
     public static final String STOP_AND_SEND_ID = "AgentBridge.Prompt.StopAndSend";
     public static final String QUEUE_ID = "AgentBridge.Prompt.Queue";
+    public static final String SHOW_SHORTCUTS_ID = "AgentBridge.Prompt.ShowShortcuts";
 
     /**
      * Returns the shortcut set for the given action ID from the active keymap,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutHintPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutHintPanel.kt
@@ -2,7 +2,6 @@ package com.github.catatafishen.agentbridge.ui
 
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.keymap.KeymapUtil
-import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPanel
 import com.intellij.util.ui.JBUI
@@ -100,7 +99,7 @@ class PromptShortcutHintPanel(private val onClose: () -> Unit) : JBPanel<JBPanel
     private fun createRow(): JPanel {
         val row = JPanel(FlowLayout(FlowLayout.CENTER, JBUI.scale(2), 0))
         row.isOpaque = false
-        row.alignmentX = Component.CENTER_ALIGNMENT
+        row.alignmentX = CENTER_ALIGNMENT
         return row
     }
 
@@ -127,35 +126,5 @@ class PromptShortcutHintPanel(private val onClose: () -> Unit) : JBPanel<JBPanel
             foreground = UIUtil.getContextHelpForeground()
             border = JBUI.Borders.empty(0, 2)
         })
-    }
-
-    /**
-     * Small label rendered with a rounded-rect border and subtle background,
-     * mimicking a physical keyboard key cap.
-     */
-    private class KeyBadge(text: String) : JBLabel(text) {
-
-        init {
-            font = JBUI.Fonts.miniFont()
-            foreground = UIUtil.getLabelForeground()
-            border = JBUI.Borders.empty(1, 4, 1, 4)
-            isOpaque = false
-        }
-
-        override fun paintComponent(g: Graphics) {
-            val g2 = g as Graphics2D
-            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
-            val arc = JBUI.scale(4)
-            g2.color = KEY_BACKGROUND
-            g2.fillRoundRect(0, 0, width - 1, height - 1, arc, arc)
-            g2.color = KEY_BORDER
-            g2.drawRoundRect(0, 0, width - 1, height - 1, arc, arc)
-            super.paintComponent(g)
-        }
-
-        companion object {
-            private val KEY_BACKGROUND = JBColor(0xF0F0F0, 0x3C3F41)
-            private val KEY_BORDER = JBColor(0xC8C8C8, 0x5E6060)
-        }
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ShortcutCheatSheetPopup.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ShortcutCheatSheetPopup.kt
@@ -1,0 +1,109 @@
+package com.github.catatafishen.agentbridge.ui
+
+import com.intellij.openapi.keymap.KeymapUtil
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBPanel
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import com.intellij.vcsUtil.showAbove
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.Dimension
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
+import javax.swing.Box
+import javax.swing.BoxLayout
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.KeyStroke
+
+/**
+ * Cheat-sheet popup listing all chat prompt keyboard shortcuts.
+ * Shown when the user presses Ctrl+/ in the prompt — the same pattern
+ * used by Slack, GitHub, and VS Code.
+ */
+object ShortcutCheatSheetPopup {
+
+    private data class ShortcutRow(
+        val actionId: String,
+        val fallback: KeyStroke,
+        val description: String,
+    )
+
+    private val ROWS = listOf(
+        ShortcutRow(
+            PromptShortcutAction.SEND_ID,
+            KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
+            "Send prompt (or nudge agent)"
+        ),
+        ShortcutRow(
+            PromptShortcutAction.NEW_LINE_ID,
+            KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.SHIFT_DOWN_MASK),
+            "Insert new line"
+        ),
+        ShortcutRow(
+            PromptShortcutAction.STOP_AND_SEND_ID,
+            KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.CTRL_DOWN_MASK),
+            "Stop agent and send"
+        ),
+        ShortcutRow(
+            PromptShortcutAction.QUEUE_ID,
+            KeyStroke.getKeyStroke(
+                KeyEvent.VK_ENTER,
+                InputEvent.CTRL_DOWN_MASK or InputEvent.SHIFT_DOWN_MASK
+            ),
+            "Queue (send after agent finishes)"
+        ),
+        ShortcutRow(
+            PromptShortcutAction.SHOW_SHORTCUTS_ID,
+            KeyStroke.getKeyStroke(KeyEvent.VK_SLASH, InputEvent.CTRL_DOWN_MASK),
+            "Show this popup"
+        ),
+    )
+
+    fun show(owner: JComponent) {
+        val panel = buildPanel()
+        JBPopupFactory.getInstance()
+            .createComponentPopupBuilder(panel, null)
+            .setTitle("Chat shortcuts")
+            .setFocusable(false)
+            .setMovable(true)
+            .setResizable(false)
+            .createPopup()
+            .showAbove(owner)
+    }
+
+    private fun buildPanel(): JPanel {
+        val panel = JBPanel<JBPanel<*>>(null)
+        panel.layout = BoxLayout(panel, BoxLayout.Y_AXIS)
+        panel.border = JBUI.Borders.empty(4, 8, 8, 16)
+
+        for ((i, row) in ROWS.withIndex()) {
+            panel.add(buildRow(row))
+            if (i < ROWS.size - 1) {
+                panel.add(Box.createVerticalStrut(JBUI.scale(6)))
+            }
+        }
+        return panel
+    }
+
+    private fun buildRow(row: ShortcutRow): JPanel {
+        val stroke = PromptShortcutAction.resolveKeystroke(row.actionId, row.fallback)
+        val keyText = KeymapUtil.getKeystrokeText(stroke)
+
+        val p = JPanel(BorderLayout(JBUI.scale(12), 0))
+        p.isOpaque = false
+        p.maximumSize = Dimension(Int.MAX_VALUE, p.preferredSize.height)
+        p.alignmentX = Component.LEFT_ALIGNMENT
+        p.add(KeyBadge(keyText), BorderLayout.WEST)
+        p.add(
+            JBLabel(row.description).apply {
+                font = JBUI.Fonts.smallFont()
+                foreground = UIUtil.getLabelForeground()
+            },
+            BorderLayout.CENTER
+        )
+        return p
+    }
+}

--- a/plugin-core/src/main/resources/META-INF/plugin.xml
+++ b/plugin-core/src/main/resources/META-INF/plugin.xml
@@ -303,5 +303,11 @@ GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, and Ope
             description="Queue the prompt to be sent after the agent finishes current work">
       <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift ENTER"/>
     </action>
+    <action id="AgentBridge.Prompt.ShowShortcuts"
+            class="com.github.catatafishen.agentbridge.ui.PromptShortcutAction"
+            text="Show Keyboard Shortcuts"
+            description="Show all available chat prompt keyboard shortcuts">
+      <keyboard-shortcut keymap="$default" first-keystroke="ctrl SLASH"/>
+    </action>
   </actions>
 </idea-plugin>


### PR DESCRIPTION
## Summary

Adds a **Ctrl+/** keyboard shortcut that shows a floating cheat-sheet popup listing all available chat prompt shortcuts — the same pattern used by Slack, GitHub, and VS Code.

## Changes

- **`KeyBadge.kt`** — extracted the key-cap badge component from `PromptShortcutHintPanel` into a shared top-level class (eliminates duplication)
- **`ShortcutCheatSheetPopup.kt`** — new singleton that builds and shows the popup via `JBPopupFactory`; lists all 5 shortcuts with keymap-aware bindings (respects user's custom keymap)
- **`PromptShortcutAction.java`** — adds `SHOW_SHORTCUTS_ID` constant
- **`plugin.xml`** — registers `AgentBridge.Prompt.ShowShortcuts` action with default binding `Ctrl+/` (customizable via Settings → Keymap)
- **`ChatToolWindowContent.kt`** — wires `registerShowShortcutsPopup()` into the prompt key bindings

## Behavior

- Press **Ctrl+/** while the chat prompt has focus → popup appears above the input
- Popup lists: Send, New Line, Stop and Send, Queue, Show Shortcuts
- Key badges reflect the user's active keymap customizations
- Non-focusable, movable popup — dismisses on click outside or Escape