### PR TITLE
fix: dispatch WriteAction to EDT in WriteFileTool.createNewFile()

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/WriteFileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/WriteFileTool.java
@@ -217,12 +217,13 @@ public class WriteFileTool extends FileTool {
             resultFuture.complete("Error creating file: " + e.getMessage());
             return;
         }
-        // VFS refresh after file is on disk — no write lock held during I/O
+        // VFS refresh must run on EDT with write lock — dispatch even if called from background thread.
+        // EdtUtil.invokeAndWait() is safe here: it detects if already on EDT and runs directly.
         String finalFullPath = fullPath;
-        WriteAction.run(() -> {
+        EdtUtil.invokeAndWait(() -> WriteAction.run(() -> {
             LocalFileSystem.getInstance().refreshAndFindFileByPath(finalFullPath);
             CodeChangeTracker.recordChange(CodeChangeTracker.countLines(content), 0);
-        });
+        }));
         resultFuture.complete("Created: " + pathStr);
     }
 


### PR DESCRIPTION
## Problem

`WriteFileTool.createNewFile()` was calling `WriteAction.run()` directly on the `mcp-http` background thread. IntelliJ requires all WriteActions and VFS modifications to run on the Event Dispatch Thread (EDT).

Identified from `tool-stats.db`: `write_file` had intermittent failures with EDT assertion errors.

## Fix

Wrap the `WriteAction.run()` call inside `EdtUtil.invokeAndWait()` in `createNewFile()`, which safely dispatches to the EDT (and runs inline if already on EDT, avoiding deadlocks).

```java
// Before
WriteAction.run(() -> {
    LocalFileSystem.getInstance().refreshAndFindFileByPath(finalFullPath);
    CodeChangeTracker.recordChange(CodeChangeTracker.countLines(content), 0);
});

// After
EdtUtil.invokeAndWait(() -> WriteAction.run(() -> {
    LocalFileSystem.getInstance().refreshAndFindFileByPath(finalFullPath);
    CodeChangeTracker.recordChange(CodeChangeTracker.countLines(content), 0);
}));
```