### PR TITLE
fix: limit PSI node traversal in checkSyntaxErrors to 10k nodes

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/WriteFileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/WriteFileTool.java
@@ -518,7 +518,8 @@ public class WriteFileTool extends FileTool {
             if (psiFile == null) return "";
 
             List<String> errors = new ArrayList<>();
-            collectPsiErrors(psiFile, doc, errors);
+            int[] nodeCount = {0};
+            collectPsiErrors(psiFile, doc, errors, nodeCount);
 
             if (errors.isEmpty()) return "";
             int count = Math.min(errors.size(), 5);
@@ -531,14 +532,18 @@ public class WriteFileTool extends FileTool {
         }
     }
 
+    private static final int MAX_PSI_NODES = 10_000;
+
     private static void collectPsiErrors(com.intellij.psi.PsiElement element, Document doc,
-                                         List<String> errors) {
+                                         List<String> errors, int[] nodeCount) {
+        if (nodeCount[0]++ >= MAX_PSI_NODES) return;
         if (element instanceof PsiErrorElement err) {
             int line = doc != null ? doc.getLineNumber(err.getTextOffset()) + 1 : -1;
             errors.add("  Line " + line + ": " + err.getErrorDescription());
         }
         for (var child = element.getFirstChild(); child != null; child = child.getNextSibling()) {
-            collectPsiErrors(child, doc, errors);
+            if (nodeCount[0] >= MAX_PSI_NODES) break;
+            collectPsiErrors(child, doc, errors, nodeCount);
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/WriteFileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/WriteFileTool.java
@@ -532,10 +532,10 @@ public class WriteFileTool extends FileTool {
         }
     }
 
-    private static final int MAX_PSI_NODES = 10_000;
+    static final int MAX_PSI_NODES = 10_000;
 
-    private static void collectPsiErrors(com.intellij.psi.PsiElement element, Document doc,
-                                         List<String> errors, int[] nodeCount) {
+    static void collectPsiErrors(com.intellij.psi.PsiElement element, Document doc,
+                                 List<String> errors, int[] nodeCount) {
         if (nodeCount[0]++ >= MAX_PSI_NODES) return;
         if (element instanceof PsiErrorElement err) {
             int line = doc != null ? doc.getLineNumber(err.getTextOffset()) + 1 : -1;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
@@ -45,7 +45,9 @@ public final class SearchTextTool extends NavigationTool {
                                  int startOffset, int endOffset) {
     }
 
-    /** Hard cap on total output bytes — prevents 50+ MB responses from broad searches. */
+    /**
+     * Hard cap on total output bytes — prevents 50+ MB responses from broad searches.
+     */
     private static final int MAX_OUTPUT_BYTES = 256 * 1024; // 256 KB
 
     private record SearchParams(Pattern pattern, String basePath, String filePattern,

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/WriteFileToolCollectPsiErrorsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/file/WriteFileToolCollectPsiErrorsTest.java
@@ -1,0 +1,196 @@
+package com.github.catatafishen.agentbridge.psi.tools.file;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiErrorElement;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link WriteFileTool#collectPsiErrors} — specifically the node-count limit
+ * that caps PSI tree traversal at {@link WriteFileTool#MAX_PSI_NODES}.
+ * <p>
+ * Uses JDK dynamic proxies to create lightweight mock PSI elements without needing
+ * the full IntelliJ platform.
+ */
+@DisplayName("WriteFileTool.collectPsiErrors node limit")
+class WriteFileToolCollectPsiErrorsTest {
+
+    private static PsiElement mockElement(PsiElement... children) {
+        return (PsiElement) Proxy.newProxyInstance(
+            PsiElement.class.getClassLoader(),
+            new Class[]{PsiElement.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "getFirstChild" -> children.length > 0 ? children[0] : null;
+                case "getNextSibling" -> null;
+                case "equals" -> proxy == args[0];
+                case "hashCode" -> System.identityHashCode(proxy);
+                case "toString" -> "MockPsiElement";
+                default -> null;
+            });
+    }
+
+    private static PsiErrorElement mockError(int offset, String description) {
+        return (PsiErrorElement) Proxy.newProxyInstance(
+            PsiErrorElement.class.getClassLoader(),
+            new Class[]{PsiErrorElement.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "getTextOffset" -> offset;
+                case "getErrorDescription" -> description;
+                case "getFirstChild", "getNextSibling" -> null;
+                case "equals" -> proxy == args[0];
+                case "hashCode" -> System.identityHashCode(proxy);
+                case "toString" -> "MockPsiError(" + description + ")";
+                default -> null;
+            });
+    }
+
+    private static Document mockDocument() {
+        return (Document) Proxy.newProxyInstance(
+            Document.class.getClassLoader(),
+            new Class[]{Document.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "getLineNumber" -> 0;
+                case "equals" -> proxy == args[0];
+                case "hashCode" -> System.identityHashCode(proxy);
+                default -> null;
+            });
+    }
+
+    /**
+     * Builds a flat tree: a root element with N leaf children linked via getNextSibling.
+     */
+    private static PsiElement flatTree(int size) {
+        PsiElement[] children = new PsiElement[size];
+        for (int i = size - 1; i >= 0; i--) {
+            int idx = i;
+            PsiElement next = (i < size - 1) ? children[i + 1] : null;
+            children[i] = (PsiElement) Proxy.newProxyInstance(
+                PsiElement.class.getClassLoader(),
+                new Class[]{PsiElement.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getFirstChild" -> null;
+                    case "getNextSibling" -> next;
+                    case "equals" -> proxy == args[0];
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "toString" -> "Leaf-" + idx;
+                    default -> null;
+                });
+        }
+        PsiElement firstChild = children[0];
+        return (PsiElement) Proxy.newProxyInstance(
+            PsiElement.class.getClassLoader(),
+            new Class[]{PsiElement.class},
+            (proxy, method, args) -> switch (method.getName()) {
+                case "getFirstChild" -> firstChild;
+                case "getNextSibling" -> null;
+                case "equals" -> proxy == args[0];
+                case "hashCode" -> System.identityHashCode(proxy);
+                case "toString" -> "Root(" + size + " children)";
+                default -> null;
+            });
+    }
+
+    @Test
+    @DisplayName("MAX_PSI_NODES is 10,000")
+    void maxPsiNodesConstant() {
+        assertEquals(10_000, WriteFileTool.MAX_PSI_NODES);
+    }
+
+    @Nested
+    @DisplayName("collectPsiErrors")
+    class CollectPsiErrors {
+
+        @Test
+        @DisplayName("collects error from a single PsiErrorElement")
+        void singleError() {
+            PsiErrorElement error = mockError(0, "unexpected token");
+            Document doc = mockDocument();
+
+            List<String> errors = new ArrayList<>();
+            int[] nodeCount = {0};
+            WriteFileTool.collectPsiErrors(error, doc, errors, nodeCount);
+
+            assertEquals(1, errors.size());
+            assertTrue(errors.getFirst().contains("unexpected token"));
+            assertEquals(1, nodeCount[0]);
+        }
+
+        @Test
+        @DisplayName("collects no errors from a non-error element")
+        void noErrors() {
+            PsiElement element = mockElement();
+            Document doc = mockDocument();
+
+            List<String> errors = new ArrayList<>();
+            int[] nodeCount = {0};
+            WriteFileTool.collectPsiErrors(element, doc, errors, nodeCount);
+
+            assertTrue(errors.isEmpty());
+            assertEquals(1, nodeCount[0]);
+        }
+
+        @Test
+        @DisplayName("handles null document gracefully (line = -1)")
+        void nullDocument() {
+            PsiErrorElement error = mockError(10, "syntax error");
+
+            List<String> errors = new ArrayList<>();
+            int[] nodeCount = {0};
+            WriteFileTool.collectPsiErrors(error, null, errors, nodeCount);
+
+            assertEquals(1, errors.size());
+            assertTrue(errors.getFirst().contains("Line -1"));
+        }
+
+        @Test
+        @DisplayName("stops traversal at MAX_PSI_NODES")
+        void stopsAtNodeLimit() {
+            int overLimit = WriteFileTool.MAX_PSI_NODES + 100;
+            PsiElement root = flatTree(overLimit);
+            Document doc = mockDocument();
+
+            List<String> errors = new ArrayList<>();
+            int[] nodeCount = {0};
+            WriteFileTool.collectPsiErrors(root, doc, errors, nodeCount);
+
+            assertTrue(nodeCount[0] <= WriteFileTool.MAX_PSI_NODES + 1,
+                "Node count should not exceed MAX_PSI_NODES + 1, was " + nodeCount[0]);
+        }
+
+        @Test
+        @DisplayName("traverses all nodes when under the limit")
+        void traversesAllUnderLimit() {
+            PsiElement root = flatTree(100);
+            Document doc = mockDocument();
+
+            List<String> errors = new ArrayList<>();
+            int[] nodeCount = {0};
+            WriteFileTool.collectPsiErrors(root, doc, errors, nodeCount);
+
+            // root (1) + 100 children = 101
+            assertEquals(101, nodeCount[0]);
+        }
+
+        @Test
+        @DisplayName("pre-incremented nodeCount at limit skips processing")
+        void preIncrementedNodeCount() {
+            PsiElement element = mockElement();
+            Document doc = mockDocument();
+
+            List<String> errors = new ArrayList<>();
+            int[] nodeCount = {WriteFileTool.MAX_PSI_NODES};
+            WriteFileTool.collectPsiErrors(element, doc, errors, nodeCount);
+
+            assertTrue(errors.isEmpty());
+            assertEquals(WriteFileTool.MAX_PSI_NODES + 1, nodeCount[0]);
+        }
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextToolStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextToolStaticMethodsTest.java
@@ -8,7 +8,11 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Method;
 import java.util.regex.Pattern;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Pure-unit tests for the private static
@@ -25,7 +29,7 @@ class SearchTextToolStaticMethodsTest {
     @BeforeAll
     static void setUp() throws NoSuchMethodException {
         compileSearchPattern = SearchTextTool.class.getDeclaredMethod(
-                "compileSearchPattern", String.class, boolean.class, boolean.class);
+            "compileSearchPattern", String.class, boolean.class, boolean.class);
         compileSearchPattern.setAccessible(true);
     }
 
@@ -35,7 +39,7 @@ class SearchTextToolStaticMethodsTest {
      * @return the compiled {@link Pattern}, or {@code null} when the method returns null
      */
     private static Pattern compile(String query, boolean isRegex, boolean caseSensitive)
-            throws ReflectiveOperationException {
+        throws ReflectiveOperationException {
         return (Pattern) compileSearchPattern.invoke(null, query, isRegex, caseSensitive);
     }
 
@@ -71,7 +75,7 @@ class SearchTextToolStaticMethodsTest {
             assertNotNull(p);
             assertTrue(p.matcher("file.txt").find(), "Should match literal 'file.txt'");
             assertFalse(p.matcher("filextxt").find(),
-                    "Dot must NOT act as regex wildcard in literal mode");
+                "Dot must NOT act as regex wildcard in literal mode");
         }
 
         @Test
@@ -81,7 +85,7 @@ class SearchTextToolStaticMethodsTest {
             assertNotNull(p);
             assertTrue(p.matcher("a.*b").find(), "Should match the literal string 'a.*b'");
             assertFalse(p.matcher("aXXXb").find(),
-                    "'.*' must NOT act as regex wildcard in literal mode");
+                "'.*' must NOT act as regex wildcard in literal mode");
         }
     }
 
@@ -152,7 +156,7 @@ class SearchTextToolStaticMethodsTest {
             Pattern p = compile("", true, true);
             assertNotNull(p, "Empty regex should compile (matches empty string)");
             assertTrue(p.matcher("anything").find(),
-                    "Empty regex matches at every position");
+                "Empty regex matches at every position");
         }
 
         @Test
@@ -161,7 +165,7 @@ class SearchTextToolStaticMethodsTest {
             Pattern p = compile("", false, true);
             assertNotNull(p, "Empty literal should compile");
             assertTrue(p.matcher("anything").find(),
-                    "Empty literal matches at every position");
+                "Empty literal matches at every position");
         }
     }
 
@@ -177,7 +181,7 @@ class SearchTextToolStaticMethodsTest {
             Pattern p = compile("test", true, false);
             assertNotNull(p);
             assertTrue((p.flags() & Pattern.CASE_INSENSITIVE) != 0,
-                    "CASE_INSENSITIVE flag should be set");
+                "CASE_INSENSITIVE flag should be set");
         }
 
         @Test
@@ -186,7 +190,7 @@ class SearchTextToolStaticMethodsTest {
             Pattern p = compile("test", true, true);
             assertNotNull(p);
             assertEquals(0, p.flags() & Pattern.CASE_INSENSITIVE,
-                    "CASE_INSENSITIVE flag should NOT be set");
+                "CASE_INSENSITIVE flag should NOT be set");
         }
 
         @Test
@@ -195,7 +199,7 @@ class SearchTextToolStaticMethodsTest {
             Pattern p = compile("test", false, true);
             assertNotNull(p);
             assertTrue((p.flags() & Pattern.LITERAL) != 0,
-                    "LITERAL flag should be set when isRegex=false");
+                "LITERAL flag should be set when isRegex=false");
         }
 
         @Test
@@ -204,7 +208,7 @@ class SearchTextToolStaticMethodsTest {
             Pattern p = compile("test", true, true);
             assertNotNull(p);
             assertEquals(0, p.flags() & Pattern.LITERAL,
-                    "LITERAL flag should NOT be set when isRegex=true");
+                "LITERAL flag should NOT be set when isRegex=true");
         }
 
         @Test
@@ -213,9 +217,9 @@ class SearchTextToolStaticMethodsTest {
             Pattern p = compile("test", false, false);
             assertNotNull(p);
             assertTrue((p.flags() & Pattern.LITERAL) != 0,
-                    "LITERAL flag should be set");
+                "LITERAL flag should be set");
             assertTrue((p.flags() & Pattern.CASE_INSENSITIVE) != 0,
-                    "CASE_INSENSITIVE flag should be set");
+                "CASE_INSENSITIVE flag should be set");
         }
     }
 
@@ -241,7 +245,7 @@ class SearchTextToolStaticMethodsTest {
         void totalOutputBytesFieldExists() throws ReflectiveOperationException {
             // Verify the record has the totalOutputBytes component (added by this PR)
             var recordClass = Class.forName(
-                    "com.github.catatafishen.agentbridge.psi.tools.navigation.SearchTextTool$SearchParams");
+                "com.github.catatafishen.agentbridge.psi.tools.navigation.SearchTextTool$SearchParams");
             var field = recordClass.getDeclaredField("totalOutputBytes");
             assertNotNull(field, "SearchParams should have totalOutputBytes field");
             assertEquals(java.util.concurrent.atomic.AtomicInteger.class, field.getType());


### PR DESCRIPTION
## Problem

`checkSyntaxErrors()` calls `collectPsiErrors()` which recursively visits every PSI node in the file with no bound. On large files this causes significant latency.

Identified from `tool-stats.db`: `edit_text` avg duration 3.35s, with 45% of 228 calls taking >5s.

## Fix

Added `MAX_PSI_NODES = 10,000` counter passed as `int[]` through the recursion. Traversal exits early once the limit is hit — enough to catch errors in the typically edited region while preventing worst-case full-file scans on large generated or minified files.

```java
private static final int MAX_PSI_NODES = 10_000;

private static void collectPsiErrors(PsiElement element, Document doc,
                                     List<String> errors, int[] nodeCount) {
    if (nodeCount[0]++ >= MAX_PSI_NODES) return;
    // ...
    for (var child = element.getFirstChild(); child != null; child = child.getNextSibling()) {
        if (nodeCount[0] >= MAX_PSI_NODES) break;
        collectPsiErrors(child, doc, errors, nodeCount);
    }
}
```