### PR TITLE
fix: git_commit stages all files by default and shows committed file list

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
@@ -71,8 +71,7 @@ public final class GitCommitTool extends GitTool {
             return "Error: 'message' parameter is required";
         }
 
-        // Default to staging everything (all: true) unless explicitly disabled
-        boolean commitAll = !args.has("all") || args.get("all").getAsBoolean();
+        boolean commitAll = resolveCommitAll(args);
 
         if (commitAll) {
             // Stage all changes including new untracked files (equivalent to git add -A)
@@ -135,6 +134,13 @@ public final class GitCommitTool extends GitTool {
         }
 
         return result + getBranchContext();
+    }
+
+    /**
+     * Resolves the "all" parameter: defaults to true (stage everything) unless explicitly set to false.
+     */
+    static boolean resolveCommitAll(JsonObject args) {
+        return !args.has("all") || args.get("all").getAsBoolean();
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
@@ -36,9 +36,11 @@ public final class GitCommitTool extends GitTool {
 
     @Override
     public @NotNull String description() {
-        return "Commit staged changes with a message. Returns the commit result along with "
-            + "branch context: current branch, tracking status, ahead/behind counts, "
-            + "total commits on the branch, and remaining uncommitted changes.";
+        return "Commit staged changes with a message. By default stages ALL changes first "
+            + "(modified, deleted, and new untracked files) — equivalent to 'git add -A && git commit'. "
+            + "Set all: false to commit only what is already staged. "
+            + "Returns the commit result with the list of committed files, branch, tracking status, "
+            + "ahead/behind counts, total commits on the branch, and remaining uncommitted changes.";
     }
 
     @Override
@@ -57,7 +59,7 @@ public final class GitCommitTool extends GitTool {
             Param.required(PARAM_MESSAGE, TYPE_STRING, "Commit message (use conventional commit format)"),
             Param.optional(PARAM_AMEND, TYPE_BOOLEAN, "If true, amend the previous commit instead of creating a new one"),
             Param.optional(PARAM_AUTHOR, TYPE_STRING, "Override the commit author (e.g. 'Name <email@example.com>')"),
-            Param.optional("all", TYPE_BOOLEAN, "If true, automatically stage all modified and deleted files")
+            Param.optional("all", TYPE_BOOLEAN, "Stage all changes (modified, deleted, and new untracked files) before committing. Default: true. Set false to commit only already-staged changes.")
         );
     }
 
@@ -69,25 +71,25 @@ public final class GitCommitTool extends GitTool {
             return "Error: 'message' parameter is required";
         }
 
-        boolean commitAll = args.has("all") && args.get("all").getAsBoolean();
+        // Default to staging everything (all: true) unless explicitly disabled
+        boolean commitAll = !args.has("all") || args.get("all").getAsBoolean();
 
-        // Pre-commit check: verify there are staged changes (unless --all is used)
-        if (!commitAll) {
-            String staged = runGitQuiet("diff", "--cached", "--name-only");
-            if (staged != null && staged.isEmpty()) {
-                String unstaged = runGitQuiet("diff", "--name-only");
-                String untracked = runGitQuiet("ls-files", "--others", "--exclude-standard");
-                StringBuilder hint = new StringBuilder("Error: nothing staged for commit.");
-                if (unstaged != null && !unstaged.isEmpty()) {
-                    hint.append(" There are unstaged changes — use git_stage first,")
-                        .append(" or pass all: true to auto-stage modified files.");
-                } else if (untracked != null && !untracked.isEmpty()) {
-                    hint.append(" There are untracked files — use git_stage to add them first.");
-                } else {
-                    hint.append(" The working tree is clean — there is nothing to commit.");
-                }
-                return hint.toString();
+        if (commitAll) {
+            // Stage all changes including new untracked files (equivalent to git add -A)
+            runGit("add", "-A");
+        }
+
+        // Pre-commit check: verify there are staged changes
+        String staged = runGitQuiet("diff", "--cached", "--name-only");
+        if (staged != null && staged.isEmpty()) {
+            String unstaged = runGitQuiet("diff", "--name-only");
+            StringBuilder hint = new StringBuilder("Error: nothing to commit.");
+            if (unstaged != null && !unstaged.isEmpty()) {
+                hint.append(" There are unstaged changes not picked up by --all (e.g. ignored files).");
+            } else {
+                hint.append(" The working tree is clean.");
             }
+            return hint.toString();
         }
 
         // Open VCS tool window in follow mode
@@ -106,10 +108,6 @@ public final class GitCommitTool extends GitTool {
             cmdArgs.add("--amend");
         }
 
-        if (commitAll) {
-            cmdArgs.add("--all");
-        }
-
         if (args.has(PARAM_AUTHOR) && !args.get(PARAM_AUTHOR).getAsString().isEmpty()) {
             cmdArgs.add("--author");
             cmdArgs.add(args.get(PARAM_AUTHOR).getAsString());
@@ -122,6 +120,12 @@ public final class GitCommitTool extends GitTool {
         showNewCommitInLog();
 
         if (result.startsWith("Error")) return result;
+
+        // Append committed file list so agent can verify what was included
+        String fileStats = runGitQuiet("show", "--stat", "--format=", "HEAD");
+        if (fileStats != null && !fileStats.isBlank()) {
+            result += "\n\nCommitted files:\n" + fileStats.trim();
+        }
 
         // Warn if committing directly to default branch
         String branch = runGitQuiet("rev-parse", "--abbrev-ref", "HEAD");

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitToolStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitToolStaticMethodsTest.java
@@ -1,0 +1,52 @@
+package com.github.catatafishen.agentbridge.psi.tools.git;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for static helper methods in {@link GitCommitTool}.
+ */
+@DisplayName("GitCommitTool static methods")
+class GitCommitToolStaticMethodsTest {
+
+    @Nested
+    @DisplayName("resolveCommitAll")
+    class ResolveCommitAll {
+
+        @Test
+        @DisplayName("defaults to true when 'all' param is absent")
+        void defaultsToTrue() {
+            assertTrue(GitCommitTool.resolveCommitAll(new JsonObject()));
+        }
+
+        @Test
+        @DisplayName("returns true when 'all' is explicitly true")
+        void explicitlyTrue() {
+            JsonObject args = new JsonObject();
+            args.addProperty("all", true);
+            assertTrue(GitCommitTool.resolveCommitAll(args));
+        }
+
+        @Test
+        @DisplayName("returns false when 'all' is explicitly false")
+        void explicitlyFalse() {
+            JsonObject args = new JsonObject();
+            args.addProperty("all", false);
+            assertFalse(GitCommitTool.resolveCommitAll(args));
+        }
+
+        @Test
+        @DisplayName("other args don't affect result")
+        void otherArgsIgnored() {
+            JsonObject args = new JsonObject();
+            args.addProperty("message", "test commit");
+            args.addProperty("amend", true);
+            assertTrue(GitCommitTool.resolveCommitAll(args));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Two usability issues identified from tool-stats.db analysis:

1. **"nothing staged" errors (2x)**: Agent called `git_commit` before staging, causing failures. The error message already suggested `all: true` — so the default should just be true.

2. **No visibility into what was committed**: Agent had no way to verify exactly which files were included without a separate `git_show` call.

## Changes

### Default `all: true`
Runs `git add -A` before committing so new/modified/deleted files are all staged automatically. Agents no longer need a separate `git_stage` call for the normal case. Pass `all: false` to commit only pre-staged changes.

### Committed file list in response
Appends `git show --stat HEAD` output after each successful commit:
```
Committed files:
 src/Foo.java | 10 +++++-----
 src/Bar.java |  2 +-
 2 files changed, 6 insertions(+), 6 deletions(-)
```

This lets the agent immediately catch if unexpected files were included or expected files were missed.