### PR TITLE
fix: use IntelliJ Git4Idea API for branch create/switch/delete

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
@@ -568,20 +568,8 @@ public final class PlatformApiCompat {
         git4idea.commands.GitCommand command = IDE_GIT_COMMAND_MAP.get(args[0]);
         if (command == null) return null;
 
-        java.util.List<git4idea.repo.GitRepository> repos =
-            git4idea.repo.GitRepositoryManager.getInstance(project).getRepositories();
-        if (repos.isEmpty()) return null;
-
-        git4idea.repo.GitRepository repo = repos.getFirst();
-        String basePath = project.getBasePath();
-        if (basePath != null && repos.size() > 1) {
-            for (git4idea.repo.GitRepository r : repos) {
-                if (r.getRoot().getPath().equals(basePath)) {
-                    repo = r;
-                    break;
-                }
-            }
-        }
+        git4idea.repo.GitRepository repo = getRepository(project);
+        if (repo == null) return null;
 
         git4idea.commands.GitLineHandler handler =
             new git4idea.commands.GitLineHandler(project, repo.getRoot(), command);
@@ -600,6 +588,81 @@ public final class PlatformApiCompat {
         if (result.success()) {
             return result.getOutputAsJoinedString();
         }
+        return formatGitCommandError(result.getExitCode(), result.getErrorOutputAsJoinedString());
+    }
+
+    /**
+     * Returns the primary GitRepository for the project, preferring the repo rooted at
+     * the project base path when multiple repos exist (e.g. submodules).
+     * Returns null if Git4Idea is unavailable or no repositories are registered.
+     */
+    public static @Nullable git4idea.repo.GitRepository getRepository(@NotNull Project project) {
+        java.util.List<git4idea.repo.GitRepository> repos =
+            git4idea.repo.GitRepositoryManager.getInstance(project).getRepositories();
+        if (repos.isEmpty()) return null;
+
+        git4idea.repo.GitRepository repo = repos.getFirst();
+        String basePath = project.getBasePath();
+        if (basePath != null && repos.size() > 1) {
+            for (git4idea.repo.GitRepository r : repos) {
+                if (r.getRoot().getPath().equals(basePath)) return r;
+            }
+        }
+        return repo;
+    }
+
+    /**
+     * Switches to an existing branch using Git4Idea's high-level checkout API.
+     * Uses IntelliJ's configured git executable and properly refreshes the GitRepository state.
+     * Returns null to signal that the caller should fall back to CLI.
+     */
+    public static @Nullable String ideCheckout(@NotNull Project project, @NotNull String branchName) {
+        git4idea.repo.GitRepository repo = getRepository(project);
+        if (repo == null) return null;
+        git4idea.commands.GitCommandResult result =
+            git4idea.commands.Git.getInstance().checkout(repo, branchName, null, false, false);
+        if (result.success()) return "";
+        return formatGitCommandError(result.getExitCode(), result.getErrorOutputAsJoinedString());
+    }
+
+    /**
+     * Creates a new branch and switches to it using Git4Idea's high-level API.
+     * When base is null, creates from HEAD. When base is specified, falls back to CLI
+     * (Git4Idea's checkoutNewBranch has no start-point parameter).
+     * Returns null to signal that the caller should fall back to CLI.
+     */
+    public static @Nullable String ideCheckoutNewBranch(@NotNull Project project,
+                                                        @NotNull String branchName,
+                                                        @Nullable String base) {
+        git4idea.repo.GitRepository repo = getRepository(project);
+        if (repo == null) return null;
+        git4idea.commands.GitCommandResult result;
+        if (base == null) {
+            result = git4idea.commands.Git.getInstance().checkoutNewBranch(repo, branchName, null);
+        } else {
+            // branchCreate(repo, name, startPoint) creates without switching; then checkout
+            result = git4idea.commands.Git.getInstance().branchCreate(repo, branchName, base);
+            if (!result.success()) {
+                return formatGitCommandError(result.getExitCode(), result.getErrorOutputAsJoinedString());
+            }
+            result = git4idea.commands.Git.getInstance().checkout(repo, branchName, null, false, false);
+        }
+        if (result.success()) return "";
+        return formatGitCommandError(result.getExitCode(), result.getErrorOutputAsJoinedString());
+    }
+
+    /**
+     * Deletes a branch using Git4Idea's high-level API.
+     * Returns null to signal that the caller should fall back to CLI.
+     */
+    public static @Nullable String ideDeleteBranch(@NotNull Project project,
+                                                   @NotNull String branchName,
+                                                   boolean force) {
+        git4idea.repo.GitRepository repo = getRepository(project);
+        if (repo == null) return null;
+        git4idea.commands.GitCommandResult result =
+            git4idea.commands.Git.getInstance().branchDelete(repo, branchName, force);
+        if (result.success()) return "";
         return formatGitCommandError(result.getExitCode(), result.getErrorOutputAsJoinedString());
     }
 
@@ -630,8 +693,10 @@ public final class PlatformApiCompat {
         java.util.Map.entry("push", git4idea.commands.GitCommand.PUSH),
         java.util.Map.entry("rebase", git4idea.commands.GitCommand.REBASE),
         java.util.Map.entry("remote", git4idea.commands.GitCommand.REMOTE),
+        java.util.Map.entry("ls-files", git4idea.commands.GitCommand.LS_FILES),
         java.util.Map.entry("reset", git4idea.commands.GitCommand.RESET),
         java.util.Map.entry("restore", git4idea.commands.GitCommand.RESTORE),
+        java.util.Map.entry("rev-list", git4idea.commands.GitCommand.REV_LIST),
         java.util.Map.entry("rev-parse", git4idea.commands.GitCommand.REV_PARSE),
         java.util.Map.entry("revert", git4idea.commands.GitCommand.REVERT),
         java.util.Map.entry("show", git4idea.commands.GitCommand.SHOW),

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitBranchTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitBranchTool.java
@@ -1,5 +1,6 @@
 package com.github.catatafishen.agentbridge.psi.tools.git;
 
+import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
 import com.github.catatafishen.agentbridge.ui.renderers.GitBranchRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
@@ -75,18 +76,14 @@ public final class GitBranchTool extends GitTool {
                 String base = args.has(PARAM_BASE) && !args.get(PARAM_BASE).getAsString().isEmpty()
                     ? args.get(PARAM_BASE).getAsString()
                     : null;
-                // Use `git checkout -b` — `git switch -c` is not supported by Git4Idea's
-                // command mapping (it maps "switch" → CHECKOUT, turning -c into an invalid flag)
-                String result = base != null
-                    ? runGit(CMD_CHECKOUT, "-b", name, base)
-                    : runGit(CMD_CHECKOUT, "-b", name);
+                String result = ideCreate(name, base);
                 if (result.startsWith("Error")) yield result;
                 yield "Created and switched to branch '" + name + "'\n" + getBranchContext();
             }
             case "switch", CMD_CHECKOUT -> {
                 String name = requireName(args);
                 if (name == null) yield "Error: 'name' parameter is required for 'switch'";
-                String result = runGit(CMD_CHECKOUT, name);
+                String result = ideSwitch(name);
                 if (result.startsWith("Error")) yield result;
                 yield "Switched to branch '" + name + "'\n" + getBranchContext();
             }
@@ -94,10 +91,61 @@ public final class GitBranchTool extends GitTool {
                 String name = requireName(args);
                 if (name == null) yield "Error: 'name' parameter is required for 'delete'";
                 boolean force = args.has(PARAM_FORCE) && args.get(PARAM_FORCE).getAsBoolean();
-                yield runGit(CMD_BRANCH, force ? "-D" : "-d", name);
+                yield ideDelete(name, force);
             }
             default -> "Error: unknown action '" + action + "'. Use: list, create, switch, delete";
         };
+    }
+
+    /**
+     * Create a new branch and switch to it. Prefers Git4Idea high-level API; falls back to CLI.
+     */
+    private String ideCreate(String name, @Nullable String base) throws Exception {
+        try {
+            String result = PlatformApiCompat.ideCheckoutNewBranch(project, name, base);
+            if (result != null) {
+                refreshVcsState();
+                return result;
+            }
+        } catch (NoClassDefFoundError ignored) {
+            // Git4Idea unavailable
+        }
+        // CLI fallback
+        return base != null
+            ? runGit(CMD_CHECKOUT, "-b", name, base)
+            : runGit(CMD_CHECKOUT, "-b", name);
+    }
+
+    /**
+     * Switch to an existing branch. Prefers Git4Idea high-level API; falls back to CLI.
+     */
+    private String ideSwitch(String name) throws Exception {
+        try {
+            String result = PlatformApiCompat.ideCheckout(project, name);
+            if (result != null) {
+                refreshVcsState();
+                return result;
+            }
+        } catch (NoClassDefFoundError ignored) {
+            // Git4Idea unavailable
+        }
+        return runGit(CMD_CHECKOUT, name);
+    }
+
+    /**
+     * Delete a branch. Prefers Git4Idea high-level API; falls back to CLI.
+     */
+    private String ideDelete(String name, boolean force) throws Exception {
+        try {
+            String result = PlatformApiCompat.ideDeleteBranch(project, name, force);
+            if (result != null) {
+                refreshVcsState();
+                return result;
+            }
+        } catch (NoClassDefFoundError ignored) {
+            // Git4Idea unavailable
+        }
+        return runGit(CMD_BRANCH, force ? "-D" : "-d", name);
     }
 
     private static @Nullable String requireName(JsonObject args) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
@@ -358,7 +358,7 @@ public abstract class GitTool extends Tool {
         return stdout;
     }
 
-    private void refreshVcsState() {
+    protected void refreshVcsState() {
         String basePath = project.getBasePath();
         if (basePath == null) return;
         EdtUtil.invokeLater(() -> {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompatPureLogicTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompatPureLogicTest.java
@@ -218,4 +218,44 @@ class PlatformApiCompatPureLogicTest {
             assertEquals("Plugin v", PlatformApiCompat.formatPluginVersionInfo("Plugin", ""));
         }
     }
+
+    // ── IDE_GIT_COMMAND_MAP ─────────────────────────────────────
+
+    @Nested
+    class IdeGitCommandMap {
+
+        @SuppressWarnings("unchecked")
+        private static java.util.Map<String, Object> getMap() throws ReflectiveOperationException {
+            var field = PlatformApiCompat.class.getDeclaredField("IDE_GIT_COMMAND_MAP");
+            field.setAccessible(true);
+            return (java.util.Map<String, Object>) field.get(null);
+        }
+
+        @Test
+        void containsLsFiles() throws ReflectiveOperationException {
+            var map = getMap();
+            org.junit.jupiter.api.Assertions.assertNotNull(map.get("ls-files"),
+                "IDE_GIT_COMMAND_MAP should map 'ls-files'");
+        }
+
+        @Test
+        void containsRevList() throws ReflectiveOperationException {
+            var map = getMap();
+            org.junit.jupiter.api.Assertions.assertNotNull(map.get("rev-list"),
+                "IDE_GIT_COMMAND_MAP should map 'rev-list'");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "add", "blame", "branch", "checkout", "cherry-pick", "commit",
+            "config", "diff", "fetch", "log", "merge", "pull", "push",
+            "rebase", "remote", "ls-files", "reset", "restore", "rev-list",
+            "rev-parse", "revert", "show", "stash", "status", "tag"
+        })
+        void containsAllExpectedCommands(String command) throws ReflectiveOperationException {
+            var map = getMap();
+            org.junit.jupiter.api.Assertions.assertNotNull(map.get(command),
+                "IDE_GIT_COMMAND_MAP should map '" + command + "'");
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Branch operations had two issues:
1. Several git metadata commands (`rev-list` for ahead/behind, `ls-files` for untracked checks) were missing from the IDE command map and fell back to the **system CLI git** — a different executable than IntelliJ's configured one (Settings > Version Control > Git)
2. Branch create/switch/delete used `GitLineHandler` which runs the git subprocess but doesn't notify `GitRepository` listeners — IntelliJ's in-memory branch model wouldn't update immediately

## Changes

### Missing commands added to `IDE_GIT_COMMAND_MAP`
- `rev-list` → `GitCommand.REV_LIST` (used for ahead/behind commit counts)
- `ls-files` → `GitCommand.LS_FILES` (used for untracked-file checks in git_commit)

### High-level Git4Idea API for branch operations
New methods in `PlatformApiCompat`:
- `ideCheckoutNewBranch(project, name, base)` — uses `Git.getInstance().checkoutNewBranch()` / `branchCreate() + checkout()`
- `ideCheckout(project, name)` — uses `Git.getInstance().checkout()`
- `ideDeleteBranch(project, name, force)` — uses `Git.getInstance().branchDelete()`

`GitBranchTool` prefers these with `NoClassDefFoundError` fallback to CLI for robustness when Git4Idea is disabled.

### `getRepository()` extracted as shared helper
Was duplicated in `runIdeGitCommand`. Now a standalone `public static` method for reuse.

### `refreshVcsState()` promoted to `protected`
So `GitBranchTool` can call it after IDE-level branch operations.