### PR TITLE
fix: preserve chat prompt focus during agent tool execution

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -445,24 +445,41 @@ public final class PsiBridgeService implements Disposable {
     /**
      * Checks if the AgentBridge chat tool window is currently active (has focus).
      * <p>
-     * Thread-safe: reads a volatile cache that is refreshed asynchronously on the EDT.
-     * The cached value may lag by one tool call — acceptable for focus-restoration heuristics.
+     * Thread-safe: on the EDT the check is performed synchronously (no stale cache).
+     * Off the EDT, a blocking {@code invokeLater} with a short timeout is used so callers
+     * get a fresh value rather than one that may lag by several tool calls.
      */
     public static boolean isChatToolWindowActive(@NotNull Project project) {
         PsiBridgeService service = getInstance(project);
         if (service == null) return false;
-        // Refresh cache asynchronously — result available for the next caller
-        ApplicationManager.getApplication().invokeLater(() -> {
+
+        var app = ApplicationManager.getApplication();
+        if (app.isDispatchThread()) {
+            refreshChatToolWindowCache(project, service);
+        } else {
+            java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
+            app.invokeLater(() -> {
+                refreshChatToolWindowCache(project, service);
+                latch.countDown();
+            });
             try {
-                com.intellij.openapi.wm.ToolWindowManager twm =
-                    com.intellij.openapi.wm.ToolWindowManager.getInstance(project);
-                com.intellij.openapi.wm.ToolWindow tw = twm.getToolWindow("AgentBridge");
-                service.chatToolWindowActiveCache = tw != null && tw.isActive();
-            } catch (Exception e) {
-                LOG.debug("Failed to refresh chat tool window state", e);
+                latch.await(100, java.util.concurrent.TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
             }
-        });
+        }
         return service.chatToolWindowActiveCache;
+    }
+
+    private static void refreshChatToolWindowCache(@NotNull Project project, @NotNull PsiBridgeService service) {
+        try {
+            com.intellij.openapi.wm.ToolWindowManager twm =
+                com.intellij.openapi.wm.ToolWindowManager.getInstance(project);
+            com.intellij.openapi.wm.ToolWindow tw = twm.getToolWindow("AgentBridge");
+            service.chatToolWindowActiveCache = tw != null && tw.isActive();
+        } catch (Exception e) {
+            LOG.debug("Failed to refresh chat tool window state", e);
+        }
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/Tool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/Tool.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.psi.tools;
 
 import com.github.catatafishen.agentbridge.psi.EdtUtil;
+import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
 import com.github.catatafishen.agentbridge.psi.ToolUtils;
 import com.github.catatafishen.agentbridge.services.AgentTabTracker;
 import com.github.catatafishen.agentbridge.services.ToolDefinition;
@@ -193,11 +194,14 @@ public abstract class Tool implements ToolDefinition {
             }
         });
 
+        // Don't activate (focus) the Run panel when the chat prompt has focus
+        boolean activateRunPanel = !PsiBridgeService.isChatToolWindowActive(project);
+
         EdtUtil.invokeLater(() -> {
             try {
                 new RunContentExecutor(project, processHandler)
                     .withTitle(title)
-                    .withActivateToolWindow(true)
+                    .withActivateToolWindow(activateRunPanel)
                     .run();
             } catch (Exception e) {
                 // RunContentExecutor.run() may have already called startNotify() before

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editor/CreateScratchFileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editor/CreateScratchFileTool.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.psi.tools.editor;
 
 import com.github.catatafishen.agentbridge.psi.EdtUtil;
+import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
 import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
 import com.github.catatafishen.agentbridge.psi.tools.file.FileTool;
 import com.github.catatafishen.agentbridge.services.AgentScratchTracker;
@@ -117,7 +118,8 @@ public final class CreateScratchFileTool extends EditorTool {
             );
 
             if (resultFile[0] != null) {
-                boolean focusScratch = ToolLayerSettings.getInstance(project).getFollowAgentFiles();
+                boolean focusScratch = ToolLayerSettings.getInstance(project).getFollowAgentFiles()
+                    && !PsiBridgeService.isChatToolWindowActive(project);
                 FileEditorManager.getInstance(project).openFile(resultFile[0], focusScratch);
                 AgentScratchTracker.getInstance(project).trackScratchFile(resultFile[0].getPath());
             }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
@@ -215,10 +215,13 @@ public abstract class FileTool extends Tool {
     /**
      * Selects the given file in the Project View tree without requesting focus.
      * Throttled to avoid excessive tree navigation during rapid file access.
+     * Skipped entirely when the chat prompt has focus to prevent any focus side-effects
+     * from showing a previously hidden tool window.
      */
     private static void selectInProjectView(Project project, VirtualFile vf) {
         long now = System.currentTimeMillis();
         if (now - lastProjectViewSelectMs < PROJECT_VIEW_COOLDOWN_MS) return;
+        if (PsiBridgeService.isChatToolWindowActive(project)) return;
         lastProjectViewSelectMs = now;
 
         try {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.psi.tools.git;
 
 import com.github.catatafishen.agentbridge.psi.EdtUtil;
+import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
 import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
 import com.github.catatafishen.agentbridge.ui.renderers.GitCommitRenderer;
 import com.google.gson.JsonObject;
@@ -91,12 +92,17 @@ public final class GitCommitTool extends GitTool {
             return hint.toString();
         }
 
-        // Open VCS tool window in follow mode
+        // Show VCS tool window in follow mode without stealing focus from chat prompt
         if (ToolLayerSettings.getInstance(project).getFollowAgentFiles()) {
             EdtUtil.invokeLater(() -> {
                 var tw = com.intellij.openapi.wm.ToolWindowManager.getInstance(project)
                     .getToolWindow(com.intellij.openapi.wm.ToolWindowId.VCS);
-                if (tw != null) tw.activate(null);
+                if (tw == null) return;
+                if (PsiBridgeService.isChatToolWindowActive(project)) {
+                    tw.show();
+                } else {
+                    tw.activate(null);
+                }
             });
         }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
@@ -382,6 +382,8 @@ public abstract class GitTool extends Tool {
 
     /**
      * After a successful commit, open the Git Log tab and navigate to HEAD.
+     * Uses {@code tw.show()} instead of {@code tw.activate()} when the chat prompt has focus,
+     * preventing keystroke leaks to the VCS tool window.
      */
     protected void showNewCommitInLog() {
         if (!ToolLayerSettings.getInstance(project).getFollowAgentFiles()) return;
@@ -392,10 +394,14 @@ public abstract class GitTool extends Tool {
                 if (fullHash.length() != 40) return;
 
                 EdtUtil.invokeLater(() -> {
-                    if (!PsiBridgeService.isChatToolWindowActive(project)) {
-                        var twm = com.intellij.openapi.wm.ToolWindowManager.getInstance(project);
-                        var tw = twm.getToolWindow(com.intellij.openapi.wm.ToolWindowId.VCS);
-                        if (tw != null) tw.activate(null);
+                    var twm = com.intellij.openapi.wm.ToolWindowManager.getInstance(project);
+                    var tw = twm.getToolWindow(com.intellij.openapi.wm.ToolWindowId.VCS);
+                    if (tw != null) {
+                        if (PsiBridgeService.isChatToolWindowActive(project)) {
+                            tw.show();
+                        } else {
+                            tw.activate(null);
+                        }
                     }
 
                     PlatformApiCompat.showRevisionInLogAfterRefresh(project, fullHash);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/project/BuildProjectTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/project/BuildProjectTool.java
@@ -1,5 +1,6 @@
 package com.github.catatafishen.agentbridge.psi.tools.project;
 
+import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
 import com.github.catatafishen.agentbridge.ui.renderers.BuildResultRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
@@ -73,11 +74,16 @@ public final class BuildProjectTool extends ProjectTool {
 
         String moduleName = args.has(JSON_MODULE) ? args.get(JSON_MODULE).getAsString() : "";
 
-        // Open Build tool window in follow mode
+        // Show Build tool window in follow mode without stealing focus from chat prompt
         if (com.github.catatafishen.agentbridge.psi.ToolLayerSettings.getInstance(project).getFollowAgentFiles()) {
             com.github.catatafishen.agentbridge.psi.EdtUtil.invokeLater(() -> {
                 var tw = com.intellij.openapi.wm.ToolWindowManager.getInstance(project).getToolWindow("Build");
-                if (tw != null) tw.activate(null);
+                if (tw == null) return;
+                if (PsiBridgeService.isChatToolWindowActive(project)) {
+                    tw.show();
+                } else {
+                    tw.activate(null);
+                }
             });
         }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -120,18 +120,20 @@ class ChatToolWindowContent(
     /**
      * Subscribes to focus restore events published by PsiBridgeService after tool calls complete.
      * Restores keyboard focus to the chat input after files are opened in follow mode.
+     *
+     * Uses a short delay (150ms) to ensure the restore fires AFTER any secondary focus changes
+     * triggered by tool window activations, navigate() calls, or showDiff() events that
+     * may themselves use invokeLater internally.
      */
     private fun subscribeToFocusRestoreEvents() {
+        val alarm = com.intellij.util.Alarm(com.intellij.util.Alarm.ThreadToUse.SWING_THREAD, project)
         val connection = project.messageBus.connect()
         connection.subscribe(
             com.github.catatafishen.agentbridge.psi.PsiBridgeService.FOCUS_RESTORE_TOPIC,
             com.github.catatafishen.agentbridge.psi.PsiBridgeService.FocusRestoreListener {
-                // Only triggered when chat was active before tool call, so just request focus
-                // Must run on EDT since EditorTextField.requestFocusInWindow() requires it
                 if (::promptTextArea.isInitialized) {
-                    ApplicationManager.getApplication().invokeLater {
-                        promptTextArea.requestFocusInWindow()
-                    }
+                    alarm.cancelAllRequests()
+                    alarm.addRequest({ promptTextArea.requestFocusInWindow() }, 150)
                 }
             }
         )


### PR DESCRIPTION
## Problem

The chat input prompt loses focus when the agent performs actions like editing text, opening the git tool window, or navigating in the project explorer. This causes typed text to end up in source code editors instead of the chat prompt — corrupting code and confusing the agent.

## Root Cause

`isChatToolWindowActive()` used an asynchronous cache refresh via `invokeLater`, always returning the **previous** cached value. When called from the EDT (e.g., inside `followFileIfEnabled`), the cache was never refreshed synchronously, so the method returned `false` even when the chat was active — causing `navigate()` and `tw.activate()` to steal focus.

Additionally, several tool execution paths (`executeInRunPanel`, `BuildProjectTool`, `selectInProjectView`, `CreateScratchFileTool`) had no focus protection at all.

## Fix

**1. Make `isChatToolWindowActive()` reliable** (PsiBridgeService)
- On EDT: check `ToolWindow.isActive()` synchronously (no stale cache)
- Off EDT: blocking `invokeLater` with 100ms timeout instead of fire-and-forget

**2. Guard all focus-stealing locations:**
- `BuildProjectTool`: `tw.show()` instead of `tw.activate()` when chat is active
- `GitCommitTool` / `GitTool.showNewCommitInLog`: same `tw.show()` guard for VCS window
- `Tool.executeInRunPanel`: `withActivateToolWindow(false)` when chat is active
- `FileTool.selectInProjectView`: skip entirely when chat is active
- `CreateScratchFileTool`: add focus guard to `openFile`

**3. Robust focus restore** (ChatToolWindowContent)
- Use `Alarm(150ms)` delay instead of bare `invokeLater` so the restore fires after any secondary EDT runnables from navigate/showDiff internals

## Files Changed (8)
- `PsiBridgeService.java` — synchronous `isChatToolWindowActive`, extracted `refreshChatToolWindowCache`
- `Tool.java` — conditional `withActivateToolWindow`
- `CreateScratchFileTool.java` — focus guard on scratch file open
- `FileTool.java` — skip Project View selection when chat active
- `GitCommitTool.java` — `tw.show()` guard for VCS window
- `GitTool.java` — `tw.show()` guard in `showNewCommitInLog`
- `BuildProjectTool.java` — `tw.show()` guard for Build window
- `ChatToolWindowContent.kt` — Alarm-based delayed focus restore