### PR TITLE
fix: correct embedding tensor names and improve KG triple extraction

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/BertWeights.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/BertWeights.java
@@ -20,13 +20,11 @@ public final class BertWeights {
 
     // ---- Architecture constants for all-MiniLM-L6-v2 ----------------------------
 
-    public static final int VOCAB_SIZE = 30522;
     public static final int HIDDEN_DIM = 384;
     public static final int NUM_HEADS = 12;
     public static final int HEAD_DIM = 32;
     public static final int INTERMEDIATE_DIM = 1536;
     public static final int NUM_LAYERS = 6;
-    public static final int MAX_POSITION_EMBEDDINGS = 512;
 
     // ---- Embedding weights ------------------------------------------------------
 
@@ -143,16 +141,17 @@ public final class BertWeights {
      */
     public BertWeights(@NotNull SafetensorsReader reader) throws IOException {
         // ---- Embeddings ---------------------------------------------------------
-        wordEmbeddings = reader.loadTensor("bert.embeddings.word_embeddings.weight");
-        positionEmbeddings = reader.loadTensor("bert.embeddings.position_embeddings.weight");
-        tokenTypeEmbeddings = reader.loadTensor("bert.embeddings.token_type_embeddings.weight");
-        embeddingLayerNormWeight = reader.loadTensor("bert.embeddings.LayerNorm.weight");
-        embeddingLayerNormBias = reader.loadTensor("bert.embeddings.LayerNorm.bias");
+        // sentence-transformers/all-MiniLM-L6-v2 safetensors omit the "bert." prefix
+        wordEmbeddings = reader.loadTensor("embeddings.word_embeddings.weight");
+        positionEmbeddings = reader.loadTensor("embeddings.position_embeddings.weight");
+        tokenTypeEmbeddings = reader.loadTensor("embeddings.token_type_embeddings.weight");
+        embeddingLayerNormWeight = reader.loadTensor("embeddings.LayerNorm.weight");
+        embeddingLayerNormBias = reader.loadTensor("embeddings.LayerNorm.bias");
 
         // ---- Encoder layers -----------------------------------------------------
         layers = new LayerWeights[NUM_LAYERS];
         for (int i = 0; i < NUM_LAYERS; i++) {
-            String prefix = "bert.encoder.layer." + i + ".";
+            String prefix = "encoder.layer." + i + ".";
             layers[i] = new LayerWeights(
                 reader.loadTensor(prefix + "attention.self.query.weight"),
                 reader.loadTensor(prefix + "attention.self.query.bias"),

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractor.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractor.java
@@ -67,8 +67,8 @@ public final class TripleExtractor {
      * @return list of extracted triples (may be empty, never null)
      */
     public static @NotNull List<ExtractedTriple> extract(@NotNull String text,
-                                                          @NotNull String wing,
-                                                          @NotNull String drawerId) {
+                                                         @NotNull String wing,
+                                                         @NotNull String drawerId) {
         String cleaned = stripMarkdown(text);
         List<String> sentences = splitSentences(cleaned);
         List<ExtractedTriple> triples = new ArrayList<>();
@@ -93,15 +93,21 @@ public final class TripleExtractor {
     }
 
     /**
-     * Strip markdown formatting from text, preserving the underlying words.
+     * Strip markdown formatting and tool-call fragments from text,
+     * preserving the underlying conversational words.
      * Code blocks are removed entirely (code is not conversational prose).
      * Bold/italic markers are unwrapped, keeping the emphasized text.
+     * Tool evidence brackets {@code [tool:...]} and {@code [...result:...]}
+     * are removed to prevent false pattern matches on operational metadata.
      */
     static @NotNull String stripMarkdown(@NotNull String text) {
         // Remove fenced code blocks entirely (content is code, not prose)
         String result = text.replaceAll("```[\\s\\S]*?```", " ");
         // Remove inline code spans
         result = result.replaceAll("`[^`]+`", " ");
+        // Remove tool evidence brackets: [tool:...], [...result:...]
+        result = result.replaceAll("\\[tool:[^]]*]", " ");
+        result = result.replaceAll("\\[[^]]{0,40} result:[^]]*]", " ");
         // Unwrap bold/italic — keep the text, remove the markers
         result = result.replaceAll("\\*{1,3}([^*]+)\\*{1,3}", "$1");
         result = result.replaceAll("_{1,3}([^_]+)_{1,3}", "$1");
@@ -166,29 +172,40 @@ public final class TripleExtractor {
     }
 
     private static void extractFromSentence(@NotNull String sentence, @NotNull String wing,
-                                             @NotNull String drawerId,
-                                             @NotNull List<ExtractedTriple> triples) {
+                                            @NotNull String drawerId,
+                                            @NotNull List<ExtractedTriple> triples) {
         for (ExtractionRule rule : RULES) {
-            if (triples.size() >= MAX_TRIPLES_PER_TEXT) break;
-            Matcher matcher = rule.pattern.matcher(sentence);
-            if (matcher.find()) {
-                String rawObject = matcher.group(rule.objectGroup).strip();
-                String object = cleanObject(rawObject);
-                if (!isQualityObject(object)) continue;
-
-                String subject = rule.subjectGroup > 0
-                    ? cleanSubject(matcher.group(rule.subjectGroup))
-                    : wing;
-
-                if (isDuplicate(triples, rule.predicate, object)) continue;
-
-                triples.add(new ExtractedTriple(subject, rule.predicate, object, drawerId));
+            if (triples.size() >= MAX_TRIPLES_PER_TEXT) return;
+            ExtractedTriple triple = tryMatchRule(rule, sentence, wing, drawerId, triples);
+            if (triple != null) {
+                triples.add(triple);
             }
         }
     }
 
+    private static ExtractedTriple tryMatchRule(@NotNull ExtractionRule rule,
+                                                @NotNull String sentence,
+                                                @NotNull String wing,
+                                                @NotNull String drawerId,
+                                                @NotNull List<ExtractedTriple> existing) {
+        Matcher matcher = rule.pattern.matcher(sentence);
+        if (!matcher.find()) return null;
+
+        String rawObject = matcher.group(rule.objectGroup).strip();
+        String object = cleanObject(rawObject);
+        if (!isQualityObject(object)) return null;
+
+        String subject = rule.subjectGroup > 0
+            ? cleanSubject(matcher.group(rule.subjectGroup))
+            : wing;
+        if (subject.isEmpty()) subject = wing;
+
+        if (isDuplicate(existing, rule.predicate, object)) return null;
+        return new ExtractedTriple(subject, rule.predicate, object, drawerId);
+    }
+
     private static boolean isDuplicate(@NotNull List<ExtractedTriple> existing,
-                                        @NotNull String predicate, @NotNull String object) {
+                                       @NotNull String predicate, @NotNull String object) {
         String objectLower = object.toLowerCase();
         return existing.stream().anyMatch(t ->
             t.predicate().equals(predicate)
@@ -221,53 +238,69 @@ public final class TripleExtractor {
     }
 
     private static List<ExtractionRule> buildRules() {
+        // Object terminator: sentence-ending punctuation or end of string
+        String end = "(?=[.,;!?\\n]|$)";
         List<ExtractionRule> rules = new ArrayList<>();
 
-        // Decision patterns: "decided to use X", "went with X", "chose X"
+        // Decision: "decided to use X", "chose X", "went with X"
         rules.add(new ExtractionRule(
-            Pattern.compile("(?:we |i )?(?:decided to|chose|went with|going with)\\s+(.+?)(?:\\s+(?:because|since|due to|for|instead|and|but)|[.\\n])",
+            Pattern.compile("(?:decided to|chose|went with|going with)\\s+(.+?)" + end,
                 Pattern.CASE_INSENSITIVE),
             "decided", 0, 1));
 
-        // Usage patterns: "we use X", "project uses X", "using X for"
+        // Usage with subject: "The auth module uses JWT" → auth-module → uses → JWT
+        // Requires "the" or "our" prefix to avoid matching pronouns as subjects
         rules.add(new ExtractionRule(
-            Pattern.compile("(?:we |project |it )?(?:uses?|using)\\s+(.+?)(?:\\s+(?:for|to|in|because|since|which|that|and|but)|[.,\\n])",
+            Pattern.compile("(?:the |our )(\\w[\\w -]{1,25})\\s+uses?\\s+(.+?)" + end,
+                Pattern.CASE_INSENSITIVE),
+            "uses", 1, 2));
+
+        // Usage without subject: "we use X", "using X"
+        rules.add(new ExtractionRule(
+            Pattern.compile("(?:we |i )?(?:use|using)\\s+(.+?)" + end,
                 Pattern.CASE_INSENSITIVE),
             "uses", 0, 1));
 
-        // Preference patterns: "prefer X", "always use X"
+        // Preference: "prefer X", "always use X"
         rules.add(new ExtractionRule(
-            Pattern.compile("(?:we |i )?(?:prefer|prefers|always use|always do)\\s+(.+?)(?:\\s+(?:over|instead|because|since|for|and|but)|[.,\\n])",
+            Pattern.compile("(?:we |i )?(?:prefer|prefers|always use)\\s+(.+?)" + end,
                 Pattern.CASE_INSENSITIVE),
             "prefers", 0, 1));
 
-        // Dependency patterns: "depends on X", "requires X"
+        // Dependency with subject: "The plugin depends on X"
+        // Requires "the" or "our" prefix to avoid matching pronouns as subjects
         rules.add(new ExtractionRule(
-            Pattern.compile("(?:it |this )?(?:depends on|requires|needs)\\s+(.+?)(?:\\s+(?:for|to|because|in order|and|but)|[.,\\n])",
+            Pattern.compile("(?:the |our )(\\w[\\w -]{1,25})\\s+(?:depends on|requires|needs)\\s+(.+?)" + end,
+                Pattern.CASE_INSENSITIVE),
+            "depends-on", 1, 2));
+
+        // Dependency without subject: "depends on X"
+        rules.add(new ExtractionRule(
+            Pattern.compile("(?:depends on|requires|needs)\\s+(.+?)" + end,
                 Pattern.CASE_INSENSITIVE),
             "depends-on", 0, 1));
 
-        // Implementation patterns: "implemented X", "created X", "added X"
+        // Implementation: "implemented X", "created X", "added X"
         rules.add(new ExtractionRule(
-            Pattern.compile("(?:we |i )?(?:implemented|created|added|built)\\s+(?:the |a |an )?(.+?)(?:\\s+(?:for|to|in|using|that|which|with|and|but)|[.,\\n])",
+            Pattern.compile("(?:implemented|created|added|built)\\s+(?:the |a |an )?(.+?)" + end,
                 Pattern.CASE_INSENSITIVE),
             "implemented", 0, 1));
 
-        // Resolution patterns: "fixed X", "resolved X", "solved X"
+        // Resolution: "fixed X", "resolved X", "solved X"
         rules.add(new ExtractionRule(
-            Pattern.compile("(?:we |i )?(?:fixed|resolved|solved)\\s+(?:the |a |an )?(.+?)(?:\\s+(?:by|with|using|via|and|but)|[.,\\n])",
+            Pattern.compile("(?:fixed|resolved|solved)\\s+(?:the |a |an )?(.+?)" + end,
                 Pattern.CASE_INSENSITIVE),
             "resolved", 0, 1));
 
-        // Root cause patterns: "root cause was X", "caused by X"
+        // Root cause: "root cause was X", "caused by X"
         rules.add(new ExtractionRule(
-            Pattern.compile("(?:root cause (?:is|was)|caused by|due to)\\s+(.+?)(?:\\s+(?:which|that|so|and|but)|[.,\\n])",
+            Pattern.compile("(?:root cause (?:is|was)|caused by|due to)\\s+(.+?)" + end,
                 Pattern.CASE_INSENSITIVE),
             "caused-by", 0, 1));
 
         // Technology stack: "written in X", "built with X"
         rules.add(new ExtractionRule(
-            Pattern.compile("(?:written in|built with|powered by|runs on)\\s+(.+?)(?:\\s+(?:and|with|for|using|but)|[.,\\n])",
+            Pattern.compile("(?:written in|built with|powered by|runs on)\\s+(.+?)" + end,
                 Pattern.CASE_INSENSITIVE),
             "built-with", 0, 1));
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/BertWeightsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/BertWeightsTest.java
@@ -93,13 +93,14 @@ class BertWeightsTest {
 
     private static List<String> buildTensorNames() {
         List<String> names = new ArrayList<>(101);
-        names.add("bert.embeddings.word_embeddings.weight");
-        names.add("bert.embeddings.position_embeddings.weight");
-        names.add("bert.embeddings.token_type_embeddings.weight");
-        names.add("bert.embeddings.LayerNorm.weight");
-        names.add("bert.embeddings.LayerNorm.bias");
+        // sentence-transformers/all-MiniLM-L6-v2 safetensors omit the "bert." prefix
+        names.add("embeddings.word_embeddings.weight");
+        names.add("embeddings.position_embeddings.weight");
+        names.add("embeddings.token_type_embeddings.weight");
+        names.add("embeddings.LayerNorm.weight");
+        names.add("embeddings.LayerNorm.bias");
         for (int i = 0; i < 6; i++) {
-            String p = "bert.encoder.layer." + i + ".";
+            String p = "encoder.layer." + i + ".";
             names.add(p + "attention.self.query.weight");
             names.add(p + "attention.self.query.bias");
             names.add(p + "attention.self.key.weight");

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractorTest.java
@@ -35,11 +35,13 @@ class TripleExtractorTest {
     }
 
     @Test
-    void usagePattern() {
+    void usagePatternWithSubject() {
         String text = "The project uses Gradle for building.";
         List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
 
         assertContainsTriple(triples, "uses", "Gradle");
+        assertEquals("project", triples.getFirst().subject(),
+            "Subject should be extracted from 'The project uses ...'");
     }
 
     @Test
@@ -51,11 +53,13 @@ class TripleExtractorTest {
     }
 
     @Test
-    void dependencyPattern() {
+    void dependencyPatternWithSubject() {
         String text = "The plugin depends on Lucene for vector search.";
         List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
 
         assertContainsTriple(triples, "depends-on", "Lucene");
+        assertEquals("plugin", triples.getFirst().subject(),
+            "Subject should be extracted from 'The plugin depends on ...'");
     }
 
     @Test
@@ -105,15 +109,6 @@ class TripleExtractorTest {
         List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
 
         assertTrue(triples.isEmpty());
-    }
-
-    @Test
-    void subjectDefaultsToWing() {
-        String text = "We use Gradle for building.";
-        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
-
-        assertFalse(triples.isEmpty());
-        assertEquals(WING, triples.getFirst().subject());
     }
 
     @Test
@@ -217,7 +212,69 @@ class TripleExtractorTest {
         assertTrue(result.contains("Architecture"));
     }
 
-    // ── Quality filtering tests ───────────────────────────────────────────
+    @Test
+    void toolEvidenceBracketsAreStripped() {
+        String result = TripleExtractor.stripMarkdown(
+            "I read the file.\n[tool:read_file file:src/main/java/Foo.java]\nThe class uses Gradle.");
+
+        assertFalse(result.contains("[tool:"), "Tool bracket should be stripped: " + result);
+        assertFalse(result.contains("read_file"), "Tool name should be stripped: " + result);
+        assertTrue(result.contains("uses Gradle"));
+    }
+
+    @Test
+    void searchResultEvidenceIsStripped() {
+        String result = TripleExtractor.stripMarkdown(
+            "Found the issue.\n[search_text result: Found 3 matches in Bar.java:42]\nFixed it.");
+
+        assertFalse(result.contains("[search_text"), "Search result bracket should be stripped: " + result);
+        assertFalse(result.contains("Bar.java"), "Search result content should be stripped: " + result);
+    }
+
+    @Test
+    void toolFragmentsDoNotProduceFalseTriples() {
+        String text = """
+            [tool:search_text file:src/main/java/Foo.java]
+            [search_text result: Found uses of HashMap in 3 files]
+            We use Gradle for building.""";
+        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
+
+        assertContainsTriple(triples, "uses", "Gradle");
+        for (TripleExtractor.ExtractedTriple triple : triples) {
+            assertFalse(triple.object().contains("HashMap"),
+                "Extracted from tool fragment: " + triple.object());
+        }
+    }
+
+    // ── Subject extraction tests ──────────────────────────────────────────
+
+    @Test
+    void subjectExtractedFromUsagePattern() {
+        String text = "The auth module uses JWT tokens.";
+        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
+
+        assertContainsTriple(triples, "uses", "JWT tokens");
+        assertEquals("auth-module", triples.getFirst().subject());
+    }
+
+    @Test
+    void subjectExtractedFromDependencyPattern() {
+        String text = "The API depends on Lucene.";
+        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
+
+        assertContainsTriple(triples, "depends-on", "Lucene");
+        assertEquals("api", triples.getFirst().subject());
+    }
+
+    @Test
+    void subjectFallsBackToWingWithoutExplicitSubject() {
+        String text = "We use Gradle for building.";
+        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
+
+        assertFalse(triples.isEmpty());
+        assertEquals(WING, triples.getFirst().subject(),
+            "Subject should default to wing when no explicit subject in sentence");
+    }
 
     @Test
     void rejectsAllStopwordObjects() {
@@ -286,11 +343,12 @@ class TripleExtractorTest {
 
     @Test
     void duplicatePredicateObjectIsSkipped() {
-        String text = "We use Gradle for building.\nThe project uses Gradle for compilation.";
+        // Same tool mentioned twice in different sentences — should deduplicate
+        String text = "We use Gradle.\nWe also use Gradle.";
         List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
 
         long gradleCount = triples.stream()
-            .filter(t -> t.predicate().equals("uses") && t.object().equals("Gradle"))
+            .filter(t -> t.predicate().equals("uses") && t.object().equalsIgnoreCase("Gradle"))
             .count();
         assertEquals(1, gradleCount, "Duplicate Gradle triple should be deduplicated");
     }


### PR DESCRIPTION
## Problem

Two bugs in the memory system:

1. **`memory_search` completely broken** — semantic search fails with `Tensor not found in safetensors metadata: 'bert.embeddings.word_embeddings.weight'`
2. **Knowledge graph triples are low quality** — extracted triples are fragmented sentences instead of clean subject→predicate→object facts (e.g., `agentbridge → uses → the current agent seen`)

## Root Causes

### Embedding model (Bug 1)
The `sentence-transformers/all-MiniLM-L6-v2` safetensors file stores tensors **without** a `bert.` prefix, but `BertWeights.java` requested them with the prefix. The test passed because it built synthetic tensor names with the same wrong prefix.

### KG extraction (Bug 2)
Three compounding issues:
- **Tool evidence brackets** (`[tool:...]`, `[...result:...]`) in the input text caused false regex matches on operational metadata
- **No subject extraction** — all 8 regex rules defaulted to the project name as subject
- **Aggressive terminators** — mid-sentence words like "for", "to", "in" truncated objects to meaningless fragments

## Changes

| File | Change |
|---|---|
| `BertWeights.java` | Remove `bert.` prefix from all 101 tensor names; remove unused constants |
| `TripleExtractor.java` | Strip tool fragments; add subject extraction to `uses`/`depends-on` patterns; simplify terminators to sentence-ending punctuation; extract `tryMatchRule()` helper |
| `BertWeightsTest.java` | Fix tensor names in test helper |
| `TripleExtractorTest.java` | Add 7 new tests for tool stripping, subject extraction, and wing fallback |

## Testing
- All `BertWeightsTest` and `TripleExtractorTest` pass
- Gradle clean compile passes