### PR TITLE
fix: add exchange-level progress reporting to memory mining backfill

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemorySettingsConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemorySettingsConfigurable.java
@@ -206,11 +206,18 @@ public final class MemorySettingsConfigurable implements Configurable {
 
                 BackfillMiner backfillMiner = new BackfillMiner(project);
                 backfillMiner.run(progress -> {
-                    int current = parseCurrentSession(progress, total);
-                    if (current > 0) {
-                        indicator.setFraction((double) current / total);
+                    double fraction = parseFraction(progress, total);
+                    if (fraction >= 0) {
+                        indicator.setFraction(fraction);
                     }
-                    indicator.setText(progress);
+                    String exchangeDetail = parseExchangeDetail(progress);
+                    if (exchangeDetail != null) {
+                        indicator.setText(stripExchangeDetail(progress));
+                        indicator.setText2(exchangeDetail);
+                    } else {
+                        indicator.setText(progress);
+                        indicator.setText2("");
+                    }
                     ApplicationManager.getApplication().invokeLater(() ->
                         backfillStatusLabel.setText(progress));
                 }).whenComplete((result, error) ->
@@ -227,8 +234,24 @@ public final class MemorySettingsConfigurable implements Configurable {
         });
     }
 
-    private static int parseCurrentSession(String progress, int total) {
-        if (total <= 0 || !progress.startsWith("Mining session ")) return -1;
+    /**
+     * Parse a progress string into a fraction (0.0–1.0) for the progress bar.
+     * Handles both session-level ("Mining session 3 of 16: label") and
+     * exchange-level ("Mining session 3 of 16 (embedding 2/8): label") formats.
+     *
+     * @return fraction in [0.0, 1.0], or -1 if the string doesn't match
+     */
+    static double parseFraction(String progress, int totalSessions) {
+        if (totalSessions <= 0 || !progress.startsWith("Mining session ")) return -1;
+
+        int session = parseSessionNumber(progress);
+        if (session < 1) return -1;
+
+        double exchangeFraction = parseExchangeFraction(progress);
+        return (session - 1 + exchangeFraction) / totalSessions;
+    }
+
+    private static int parseSessionNumber(String progress) {
         int ofIndex = progress.indexOf(" of ");
         if (ofIndex < 0) return -1;
         try {
@@ -236,6 +259,72 @@ public final class MemorySettingsConfigurable implements Configurable {
         } catch (NumberFormatException e) {
             return -1;
         }
+    }
+
+    /**
+     * Extract the exchange fraction from a progress string containing "(phase N/M)".
+     * Returns 0.0 if no exchange detail is present (session-start message).
+     */
+    private static double parseExchangeFraction(String progress) {
+        int parenOpen = progress.indexOf('(');
+        int parenClose = progress.indexOf(')', parenOpen + 1);
+        if (parenOpen < 0 || parenClose < 0) return 0.0;
+
+        String detail = progress.substring(parenOpen + 1, parenClose);
+        int slashIdx = detail.indexOf('/');
+        if (slashIdx < 0) return 0.0;
+
+        String afterPhase = detail.contains(" ") ? detail.substring(detail.lastIndexOf(' ') + 1) : detail;
+        int slashInAfter = afterPhase.indexOf('/');
+        if (slashInAfter < 0) return 0.0;
+
+        try {
+            int current = Integer.parseInt(afterPhase.substring(0, slashInAfter));
+            int total = Integer.parseInt(afterPhase.substring(slashInAfter + 1));
+            return total > 0 ? (double) current / total : 0.0;
+        } catch (NumberFormatException e) {
+            return 0.0;
+        }
+    }
+
+    /**
+     * Extract a human-readable exchange detail string for indicator.setText2().
+     * Input: "Mining session 3 of 16 (embedding 2/8): Fix auth bug"
+     * Output: "Embedding exchange 2 of 8"
+     *
+     * @return detail string, or null if no exchange detail is present
+     */
+    static String parseExchangeDetail(String progress) {
+        int parenOpen = progress.indexOf('(');
+        int parenClose = progress.indexOf(')', parenOpen + 1);
+        if (parenOpen < 0 || parenClose < 0) return null;
+
+        String detail = progress.substring(parenOpen + 1, parenClose);
+        int spaceIdx = detail.indexOf(' ');
+        if (spaceIdx < 0) return null;
+
+        String phase = detail.substring(0, spaceIdx);
+        String fraction = detail.substring(spaceIdx + 1);
+        int slashIdx = fraction.indexOf('/');
+        if (slashIdx < 0) return null;
+
+        String current = fraction.substring(0, slashIdx);
+        String total = fraction.substring(slashIdx + 1);
+        String capitalizedPhase = Character.toUpperCase(phase.charAt(0)) + phase.substring(1);
+        return capitalizedPhase + " exchange " + current + " of " + total;
+    }
+
+    /**
+     * Strip the exchange detail "(phase N/M)" from a progress string for indicator.setText().
+     * Input: "Mining session 3 of 16 (embedding 2/8): Fix auth bug"
+     * Output: "Mining session 3 of 16: Fix auth bug"
+     */
+    static String stripExchangeDetail(String progress) {
+        int parenOpen = progress.indexOf('(');
+        int parenClose = progress.indexOf(')', parenOpen + 1);
+        if (parenOpen < 0 || parenClose < 0) return progress;
+        return progress.substring(0, parenOpen).stripTrailing()
+            + progress.substring(parenClose + 1);
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/BackfillMiner.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/BackfillMiner.java
@@ -52,12 +52,10 @@ public final class BackfillMiner {
         List<EntryData> load(String sessionId);
     }
 
-    /**
-     * Mines a list of entries for a session, returning the result synchronously.
-     */
     @FunctionalInterface
     interface MineFunction {
-        TurnMiner.MineResult mine(List<EntryData> entries, String sessionId, String agent);
+        TurnMiner.MineResult mine(List<EntryData> entries, String sessionId, String agent,
+                                  Consumer<String> exchangeProgress);
     }
 
     private BackfillResult doBackfill(Consumer<String> progressCallback) {
@@ -73,16 +71,13 @@ public final class BackfillMiner {
 
         TurnMiner miner = new TurnMiner(project);
         EntryLoader loader = sessionId -> sessionStore.loadEntriesBySessionId(basePath, sessionId);
-        MineFunction mineFn = (entries, sid, agent) -> miner.mineTurn(entries, sid, agent).join();
+        MineFunction mineFn = miner::mineTurnSync;
 
         BackfillResult result = executeBackfill(sessions, loader, mineFn, progressCallback);
         MemorySettings.getInstance(project).setBackfillCompleted(true);
         return result;
     }
 
-    /**
-     * Package-private for testing — runs the backfill iteration with explicit dependencies.
-     */
     BackfillResult executeBackfill(List<SessionStoreV2.SessionRecord> sessions,
                                    EntryLoader entryLoader,
                                    MineFunction miner,
@@ -108,7 +103,11 @@ public final class BackfillMiner {
                 List<EntryData> entries = entryLoader.load(session.id());
                 if (entries == null || entries.isEmpty()) continue;
 
-                TurnMiner.MineResult result = miner.mine(entries, session.id(), session.agent());
+                int sessionNum = processedSessions;
+                TurnMiner.MineResult result = miner.mine(entries, session.id(), session.agent(),
+                    exchangeDetail -> progressCallback.accept(
+                        "Mining session " + sessionNum + " of " + totalSessions
+                            + " (" + exchangeDetail + "): " + sessionLabel));
                 totalStored += result.stored();
                 totalFiltered += result.filtered();
                 totalDuplicates += result.duplicates();

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/TurnMiner.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/TurnMiner.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 /**
  * Orchestrates the mining pipeline: extracts Q+A pairs from conversation entries,
@@ -46,25 +47,32 @@ public final class TurnMiner {
         this.project = project;
     }
 
-    /**
-     * Mine a completed turn's entries into the memory store.
-     * Returns a future that completes with the mining result.
-     *
-     * @param entries   conversation entries for this turn
-     * @param sessionId current session ID
-     * @param agentName name of the active agent
-     * @return future completing with mine result
-     */
     public CompletableFuture<MineResult> mineTurn(@NotNull List<EntryData> entries,
                                                   @NotNull String sessionId,
                                                   @NotNull String agentName) {
         return CompletableFuture.supplyAsync(
-            () -> doMine(entries, sessionId, agentName),
+            () -> doMine(entries, sessionId, agentName, ignored -> {
+            }),
             AppExecutorUtil.getAppExecutorService()
         );
     }
 
-    private MineResult doMine(List<EntryData> entries, String sessionId, String agentName) {
+    /**
+     * Mine a turn synchronously with exchange-level progress reporting.
+     * Used by {@link BackfillMiner} to report finer-grained progress during batch mining.
+     *
+     * @param exchangeProgress receives strings like {@code "embedding 2/8"} before each
+     *                         embedding computation
+     */
+    public MineResult mineTurnSync(@NotNull List<EntryData> entries,
+                                   @NotNull String sessionId,
+                                   @NotNull String agentName,
+                                   @NotNull Consumer<String> exchangeProgress) {
+        return doMine(entries, sessionId, agentName, exchangeProgress);
+    }
+
+    private MineResult doMine(List<EntryData> entries, String sessionId, String agentName,
+                              Consumer<String> exchangeProgress) {
         MemoryService memoryService = MemoryService.getInstance(project);
         MemoryStore store = memoryService.getStore();
         Embedder embedding = memoryService.getEmbeddingService();
@@ -78,7 +86,8 @@ public final class TurnMiner {
         QualityFilter filter = new QualityFilter(project);
         KnowledgeGraph kg = memoryService.getKnowledgeGraph();
 
-        return executePipeline(entries, sessionId, agentName, store, embedding, filter, maxDrawers, wing, kg);
+        return executePipeline(entries, sessionId, agentName, store, embedding, filter,
+            maxDrawers, wing, kg, exchangeProgress);
     }
 
     /**
@@ -93,6 +102,21 @@ public final class TurnMiner {
     MineResult executePipeline(List<EntryData> entries, String sessionId, String agentName,
                                MemoryStore store, Embedder embedder, QualityFilter filter,
                                int maxDrawers, String wing, @Nullable KnowledgeGraph kg) {
+        return executePipeline(entries, sessionId, agentName, store, embedder, filter,
+            maxDrawers, wing, kg, ignored -> {
+            });
+    }
+
+    /**
+     * Full pipeline with exchange-level progress reporting.
+     *
+     * @param exchangeProgress receives strings like {@code "embedding 2/8"} before each
+     *                         embedding computation, allowing callers to show sub-session progress
+     */
+    MineResult executePipeline(List<EntryData> entries, String sessionId, String agentName,
+                               MemoryStore store, Embedder embedder, QualityFilter filter,
+                               int maxDrawers, String wing, @Nullable KnowledgeGraph kg,
+                               @NotNull Consumer<String> exchangeProgress) {
         List<ExchangeChunker.Exchange> exchanges = ExchangeChunker.chunk(entries);
         if (exchanges.isEmpty()) {
             return MineResult.EMPTY;
@@ -101,9 +125,12 @@ public final class TurnMiner {
         int stored = 0;
         int filtered = 0;
         int duplicates = 0;
+        int totalExchanges = exchanges.size();
 
-        for (int i = 0; i < exchanges.size(); i++) {
+        for (int i = 0; i < totalExchanges; i++) {
             if (stored >= maxDrawers) break;
+
+            exchangeProgress.accept("embedding " + (i + 1) + "/" + totalExchanges);
 
             ExchangeChunker.Exchange exchange = exchanges.get(i);
             int turnIndex = i + 1;
@@ -115,8 +142,8 @@ public final class TurnMiner {
         }
 
         LOG.info("TurnMiner: stored=" + stored + " filtered=" + filtered
-            + " duplicates=" + duplicates + " exchanges=" + exchanges.size());
-        return new MineResult(stored, filtered, duplicates, exchanges.size());
+            + " duplicates=" + duplicates + " exchanges=" + totalExchanges);
+        return new MineResult(stored, filtered, duplicates, totalExchanges);
     }
 
     private record MineExchangeResult(int stored, int filtered, int duplicates) {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/MemorySettingsConfigurableTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/MemorySettingsConfigurableTest.java
@@ -1,0 +1,84 @@
+package com.github.catatafishen.agentbridge.memory;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the progress parsing methods in {@link MemorySettingsConfigurable}.
+ */
+class MemorySettingsConfigurableTest {
+
+    @Test
+    void parseFractionSessionOnly() {
+        double fraction = MemorySettingsConfigurable.parseFraction(
+            "Mining session 3 of 16: Fix auth bug", 16);
+        assertEquals(2.0 / 16, fraction, 0.001);
+    }
+
+    @Test
+    void parseFractionWithExchangeDetail() {
+        double fraction = MemorySettingsConfigurable.parseFraction(
+            "Mining session 3 of 16 (embedding 4/8): Fix auth bug", 16);
+        // (3-1 + 4/8) / 16 = 2.5 / 16
+        assertEquals(2.5 / 16, fraction, 0.001);
+    }
+
+    @Test
+    void parseFractionNonMiningMessage() {
+        double fraction = MemorySettingsConfigurable.parseFraction(
+            "Found 16 sessions to mine.", 16);
+        assertEquals(-1, fraction);
+    }
+
+    @Test
+    void parseFractionZeroSessions() {
+        double fraction = MemorySettingsConfigurable.parseFraction(
+            "Mining session 1 of 0: test", 0);
+        assertEquals(-1, fraction);
+    }
+
+    @Test
+    void parseExchangeDetailPresent() {
+        String detail = MemorySettingsConfigurable.parseExchangeDetail(
+            "Mining session 3 of 16 (embedding 2/8): Fix auth");
+        assertEquals("Embedding exchange 2 of 8", detail);
+    }
+
+    @Test
+    void parseExchangeDetailAbsent() {
+        String detail = MemorySettingsConfigurable.parseExchangeDetail(
+            "Mining session 3 of 16: Fix auth");
+        assertNull(detail);
+    }
+
+    @Test
+    void stripExchangeDetailPresent() {
+        String stripped = MemorySettingsConfigurable.stripExchangeDetail(
+            "Mining session 3 of 16 (embedding 2/8): Fix auth");
+        assertEquals("Mining session 3 of 16: Fix auth", stripped);
+    }
+
+    @Test
+    void stripExchangeDetailAbsent() {
+        String stripped = MemorySettingsConfigurable.stripExchangeDetail(
+            "Mining session 3 of 16: Fix auth");
+        assertEquals("Mining session 3 of 16: Fix auth", stripped);
+    }
+
+    @Test
+    void parseFractionFirstExchange() {
+        double fraction = MemorySettingsConfigurable.parseFraction(
+            "Mining session 1 of 4 (embedding 1/3): Session A", 4);
+        // (1-1 + 1/3) / 4 = 0.333/4
+        assertEquals(1.0 / 12, fraction, 0.001);
+    }
+
+    @Test
+    void parseFractionLastExchangeOfLastSession() {
+        double fraction = MemorySettingsConfigurable.parseFraction(
+            "Mining session 4 of 4 (embedding 5/5): Session D", 4);
+        // (4-1 + 5/5) / 4 = 4/4 = 1.0
+        assertEquals(1.0, fraction, 0.001);
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/BackfillMinerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/BackfillMinerTest.java
@@ -8,7 +8,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link BackfillMiner} — backfill iteration logic and result aggregation.
@@ -70,7 +72,7 @@ class BackfillMinerTest {
         );
 
         List<String> progress = new ArrayList<>();
-        BackfillMiner.MineFunction miner = (entries, sessionId, agent) ->
+        BackfillMiner.MineFunction miner = (entries, sessionId, agent, exchangeProgress) ->
             new TurnMiner.MineResult(2, 1, 0, 3);
         BackfillMiner.EntryLoader loader = sessionId -> List.of(
             prompt("How to fix the auth bug?"),
@@ -99,7 +101,7 @@ class BackfillMinerTest {
             session("s3", "copilot", "Refactor DB")
         );
 
-        BackfillMiner.MineFunction miner = (entries, sessionId, agent) ->
+        BackfillMiner.MineFunction miner = (entries, sessionId, agent, exchangeProgress) ->
             new TurnMiner.MineResult(1, 0, 0, 1);
         BackfillMiner.EntryLoader loader = sessionId -> List.of(
             prompt("Some prompt text about the task at hand"),
@@ -124,7 +126,7 @@ class BackfillMinerTest {
             session("s2", "copilot", "Empty session")
         );
 
-        BackfillMiner.MineFunction miner = (entries, sessionId, agent) ->
+        BackfillMiner.MineFunction miner = (entries, sessionId, agent, exchangeProgress) ->
             new TurnMiner.MineResult(1, 0, 0, 1);
         BackfillMiner.EntryLoader loader = sessionId ->
             "s1".equals(sessionId) ? List.of(
@@ -147,7 +149,7 @@ class BackfillMinerTest {
             session("s1", "copilot", "Null entries")
         );
 
-        BackfillMiner.MineFunction miner = (entries, sessionId, agent) ->
+        BackfillMiner.MineFunction miner = (entries, sessionId, agent, exchangeProgress) ->
             new TurnMiner.MineResult(1, 0, 0, 1);
         BackfillMiner.EntryLoader loader = sessionId -> null;
 
@@ -168,7 +170,7 @@ class BackfillMinerTest {
             session("s3", "copilot", "Good session 2")
         );
 
-        BackfillMiner.MineFunction miner = (entries, sessionId, agent) -> {
+        BackfillMiner.MineFunction miner = (entries, sessionId, agent, exchangeProgress) -> {
             if ("s2".equals(sessionId)) throw new RuntimeException("Mining failed");
             return new TurnMiner.MineResult(1, 0, 0, 1);
         };
@@ -193,7 +195,7 @@ class BackfillMinerTest {
             session("s2", "copilot", "Session 2")
         );
 
-        BackfillMiner.MineFunction miner = (entries, sessionId, agent) -> {
+        BackfillMiner.MineFunction miner = (entries, sessionId, agent, exchangeProgress) -> {
             if ("s1".equals(sessionId)) return new TurnMiner.MineResult(3, 2, 1, 6);
             return new TurnMiner.MineResult(2, 1, 0, 3);
         };
@@ -220,7 +222,7 @@ class BackfillMinerTest {
         );
 
         List<String> progress = new ArrayList<>();
-        BackfillMiner.MineFunction miner = (entries, sessionId, agent) ->
+        BackfillMiner.MineFunction miner = (entries, sessionId, agent, exchangeProgress) ->
             new TurnMiner.MineResult(0, 0, 0, 0);
         BackfillMiner.EntryLoader loader = sessionId -> Collections.emptyList();
 
@@ -238,7 +240,7 @@ class BackfillMinerTest {
         );
 
         List<String> progress = new ArrayList<>();
-        BackfillMiner.MineFunction miner = (entries, sessionId, agent) ->
+        BackfillMiner.MineFunction miner = (entries, sessionId, agent, exchangeProgress) ->
             new TurnMiner.MineResult(5, 2, 1, 8);
         BackfillMiner.EntryLoader loader = sessionId -> List.of(
             prompt("Question"), response("Answer with sufficient length for the test.")
@@ -261,7 +263,7 @@ class BackfillMinerTest {
             session("s2", "copilot", "Session 2")
         );
 
-        BackfillMiner.MineFunction miner = (entries, sessionId, agent) ->
+        BackfillMiner.MineFunction miner = (entries, sessionId, agent, exchangeProgress) ->
             new TurnMiner.MineResult(1, 0, 0, 1);
         BackfillMiner.EntryLoader loader = sessionId -> {
             if ("s1".equals(sessionId)) throw new RuntimeException("IO error");
@@ -281,6 +283,33 @@ class BackfillMinerTest {
     }
 
     @Test
+    void executeBackfillReportsExchangeProgress() {
+        List<SessionStoreV2.SessionRecord> sessions = List.of(
+            session("s1", "copilot", "Fix auth")
+        );
+
+        List<String> progress = new ArrayList<>();
+        BackfillMiner.MineFunction miner = (entries, sessionId, agent, exchangeProgress) -> {
+            exchangeProgress.accept("embedding 1/2");
+            exchangeProgress.accept("embedding 2/2");
+            return new TurnMiner.MineResult(2, 0, 0, 2);
+        };
+        BackfillMiner.EntryLoader loader = sessionId -> List.of(
+            prompt("How to fix auth?"),
+            response("Check token validation and error handling in the auth flow.")
+        );
+
+        BackfillMiner backfillMiner = new BackfillMiner();
+        backfillMiner.executeBackfill(sessions, loader, miner, progress::add);
+
+        // Session-level progress
+        assertTrue(progress.stream().anyMatch(p -> p.contains("Mining session 1 of 1: Fix auth")));
+        // Exchange-level progress
+        assertTrue(progress.stream().anyMatch(p -> p.contains("(embedding 1/2)")));
+        assertTrue(progress.stream().anyMatch(p -> p.contains("(embedding 2/2)")));
+    }
+
+    @Test
     void executeBackfillShortSessionIdTruncation() {
         // Session ID shorter than 8 chars, empty name → should truncate correctly
         List<SessionStoreV2.SessionRecord> sessions = List.of(
@@ -288,7 +317,7 @@ class BackfillMinerTest {
         );
 
         List<String> progress = new ArrayList<>();
-        BackfillMiner.MineFunction miner = (entries, sessionId, agent) ->
+        BackfillMiner.MineFunction miner = (entries, sessionId, agent, exchangeProgress) ->
             new TurnMiner.MineResult(0, 0, 0, 0);
         BackfillMiner.EntryLoader loader = sessionId -> Collections.emptyList();
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/TurnMinerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/TurnMinerTest.java
@@ -172,6 +172,28 @@ class TurnMinerTest {
     }
 
     @Test
+    void exchangeProgressCallbackFires() {
+        List<EntryData> entries = List.of(
+            prompt("How should we handle authentication in the microservices architecture?"),
+            response("Use OAuth 2.0 with a centralized auth server. " +
+                "Each service validates tokens independently via JWT verification."),
+            prompt("What about the database design for the user management service?"),
+            response("Use PostgreSQL with proper indexing on email and username columns. " +
+                "Implement soft deletes for GDPR compliance and audit trail.")
+        );
+
+        List<String> progressMessages = new java.util.ArrayList<>();
+        TurnMiner miner = new TurnMiner();
+        miner.executePipeline(
+            entries, SESSION_ID, AGENT, store, fakeEmbedder, filter, 10, WING, null,
+            progressMessages::add);
+
+        assertEquals(2, progressMessages.size());
+        assertEquals("embedding 1/2", progressMessages.get(0));
+        assertEquals("embedding 2/2", progressMessages.get(1));
+    }
+
+    @Test
     void embedderExceptionHandledGracefully() {
         Embedder failingEmbedder = text -> {
             throw new RuntimeException("Embedding engine crash");


### PR DESCRIPTION
## Problem

The backfill mining progress indicator only updated once per session ("Mining session 1 of 16"), making it appear stuck during long-running sessions where BERT inference takes 20-60 seconds per embedding.

## Solution

Thread exchange-level progress callbacks through the mining pipeline so the progress bar updates **per-exchange** instead of per-session:

- **TurnMiner**: Added `exchangeProgress` callback to `executePipeline()` that reports `"embedding N/M"` before each embedding computation. Added `mineTurnSync()` for synchronous mining with progress.
- **BackfillMiner**: Threads exchange progress through `MineFunction`, composing it with session info: `"Mining session X of Y (embedding A/B): label"`
- **MemorySettingsConfigurable**: Parses exchange detail from progress strings. Uses `indicator.setText2()` for sub-progress ("Embedding exchange 2 of 8") and computes fine-grained fractions: `(session-1 + exchange/totalExchanges) / totalSessions`

## Result

The IDE footer progress bar now:
- Updates every few seconds instead of every few minutes
- Shows main text: "Mining session 3 of 16: Fix auth bug"  
- Shows detail text: "Embedding exchange 2 of 8"
- Progress bar moves smoothly through each session

## Tests

- `TurnMinerTest.exchangeProgressCallbackFires()` — verifies callback invocation
- `BackfillMinerTest.executeBackfillReportsExchangeProgress()` — verifies composed messages
- `MemorySettingsConfigurableTest` — 9 tests for `parseFraction()`, `parseExchangeDetail()`, `stripExchangeDetail()`

6 files changed, 291 insertions(+), 41 deletions(-).