### PR TITLE
fix: auto-detect tensor name prefix in BertWeights for safetensors compatibility

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/BertWeights.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/embedding/BertWeights.java
@@ -134,41 +134,67 @@ public final class BertWeights {
     }
 
     /**
-     * Loads all 101 tensors of the all-MiniLM-L6-v2 model from a safetensors file.
+     * Auto-detects the tensor name prefix by probing the reader for a known tensor.
+     *
+     * <p>PyTorch checkpoints use {@code "bert."} prefix (e.g., {@code bert.embeddings.*}),
+     * while HuggingFace safetensors exports omit it (e.g., {@code embeddings.*}).
+     *
+     * @return {@code "bert."} or {@code ""} depending on the model file
+     * @throws IOException if neither prefix resolves to a valid tensor
+     */
+    private static String detectPrefix(@NotNull SafetensorsReader reader) throws IOException {
+        String probeTensor = "embeddings.word_embeddings.weight";
+        if (reader.hasTensor("bert." + probeTensor)) {
+            return "bert.";
+        }
+        if (reader.hasTensor(probeTensor)) {
+            return "";
+        }
+        throw new IOException("Cannot detect tensor prefix: neither 'bert." + probeTensor
+            + "' nor '" + probeTensor + "' found in safetensors metadata");
+    }
+
+    /**
+     * Loads all tensors of the all-MiniLM-L6-v2 model from a safetensors file.
+     *
+     * <p>Supports both PyTorch-style naming ({@code bert.embeddings.*}) and
+     * HuggingFace safetensors naming ({@code embeddings.*}). The prefix is
+     * auto-detected from the first tensor.
      *
      * @param reader an open {@link SafetensorsReader} positioned on the model file
      * @throws IOException if any tensor cannot be read from the file
      */
     public BertWeights(@NotNull SafetensorsReader reader) throws IOException {
+        String prefix = detectPrefix(reader);
+
         // ---- Embeddings ---------------------------------------------------------
-        // sentence-transformers/all-MiniLM-L6-v2 safetensors omit the "bert." prefix
-        wordEmbeddings = reader.loadTensor("embeddings.word_embeddings.weight");
-        positionEmbeddings = reader.loadTensor("embeddings.position_embeddings.weight");
-        tokenTypeEmbeddings = reader.loadTensor("embeddings.token_type_embeddings.weight");
-        embeddingLayerNormWeight = reader.loadTensor("embeddings.LayerNorm.weight");
-        embeddingLayerNormBias = reader.loadTensor("embeddings.LayerNorm.bias");
+        wordEmbeddings = reader.loadTensor(prefix + "embeddings.word_embeddings.weight");
+        positionEmbeddings = reader.loadTensor(prefix + "embeddings.position_embeddings.weight");
+        tokenTypeEmbeddings = reader.loadTensor(prefix + "embeddings.token_type_embeddings.weight");
+        embeddingLayerNormWeight = reader.loadTensor(prefix + "embeddings.LayerNorm.weight");
+        embeddingLayerNormBias = reader.loadTensor(prefix + "embeddings.LayerNorm.bias");
 
         // ---- Encoder layers -----------------------------------------------------
         layers = new LayerWeights[NUM_LAYERS];
         for (int i = 0; i < NUM_LAYERS; i++) {
-            String prefix = "encoder.layer." + i + ".";
+            String layerPrefix = prefix + "encoder.layer." + i + ".";
             layers[i] = new LayerWeights(
-                reader.loadTensor(prefix + "attention.self.query.weight"),
-                reader.loadTensor(prefix + "attention.self.query.bias"),
-                reader.loadTensor(prefix + "attention.self.key.weight"),
-                reader.loadTensor(prefix + "attention.self.key.bias"),
-                reader.loadTensor(prefix + "attention.self.value.weight"),
-                reader.loadTensor(prefix + "attention.self.value.bias"),
-                reader.loadTensor(prefix + "attention.output.dense.weight"),
-                reader.loadTensor(prefix + "attention.output.dense.bias"),
-                reader.loadTensor(prefix + "attention.output.LayerNorm.weight"),
-                reader.loadTensor(prefix + "attention.output.LayerNorm.bias"),
-                reader.loadTensor(prefix + "intermediate.dense.weight"),
-                reader.loadTensor(prefix + "intermediate.dense.bias"),
-                reader.loadTensor(prefix + "output.dense.weight"),
-                reader.loadTensor(prefix + "output.dense.bias"),
-                reader.loadTensor(prefix + "output.LayerNorm.weight"),
-                reader.loadTensor(prefix + "output.LayerNorm.bias")
+                reader.loadTensor(layerPrefix + "attention.self.query.weight"),
+                reader.loadTensor(layerPrefix + "attention.self.query.bias"),
+                reader.loadTensor(layerPrefix + "attention.self.key.weight"),
+                reader.loadTensor(layerPrefix + "attention.self.key.bias"),
+                reader.loadTensor(layerPrefix + "attention.self.value.weight"),
+                reader.loadTensor(layerPrefix + "attention.self.value.bias"),
+                reader.loadTensor(layerPrefix + "attention.output.dense.weight"),
+                reader.loadTensor(layerPrefix + "attention.output.dense.bias"),
+                reader.loadTensor(layerPrefix + "attention.output.LayerNorm.weight"),
+                reader.loadTensor(layerPrefix + "attention.output.LayerNorm.bias"),
+                reader.loadTensor(layerPrefix + "intermediate.dense.weight"),
+                reader.loadTensor(layerPrefix + "intermediate.dense.bias"),
+                reader.loadTensor(layerPrefix + "output.dense.weight"),
+                reader.loadTensor(layerPrefix + "output.dense.bias"),
+                reader.loadTensor(layerPrefix + "output.LayerNorm.weight"),
+                reader.loadTensor(layerPrefix + "output.LayerNorm.bias")
             );
         }
 
@@ -181,6 +207,8 @@ public final class BertWeights {
         for (LayerWeights layer : layers) {
             totalParams += layer.parameterCount();
         }
-        LOG.info("Loaded BertWeights: " + totalParams + " parameters from 101 tensors");
+        int tensorCount = 5 + NUM_LAYERS * 16;
+        LOG.info("Loaded BertWeights: " + totalParams + " parameters from " + tensorCount
+            + " tensors (prefix: " + (prefix.isEmpty() ? "<none>" : "'" + prefix + "'") + ")");
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/BertWeightsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/embedding/BertWeightsTest.java
@@ -35,6 +35,16 @@ class BertWeightsTest {
     }
 
     @Test
+    void constructorLoadsNoPrefixTensors() throws IOException {
+        Path modelFile = buildMinimalModelFileNoPrefix(tempDir);
+        try (SafetensorsReader reader = new SafetensorsReader(modelFile)) {
+            BertWeights weights = new BertWeights(reader);
+            assertNotNull(weights.layers, "layers must not be null");
+            assertEquals(6, weights.layers.length, "model must have 6 encoder layers");
+        }
+    }
+
+    @Test
     void layerWeightsParameterCountWithSingleFloatArrays() {
         float[] one = {1.0f};
         BertWeights.LayerWeights layer = new BertWeights.LayerWeights(
@@ -94,6 +104,69 @@ class BertWeightsTest {
     private static List<String> buildTensorNames() {
         List<String> names = new ArrayList<>(101);
         // sentence-transformers/all-MiniLM-L6-v2 safetensors omit the "bert." prefix
+        names.add("embeddings.word_embeddings.weight");
+        names.add("embeddings.position_embeddings.weight");
+        names.add("embeddings.token_type_embeddings.weight");
+        names.add("embeddings.LayerNorm.weight");
+        names.add("embeddings.LayerNorm.bias");
+        for (int i = 0; i < 6; i++) {
+            String p = "encoder.layer." + i + ".";
+            names.add(p + "attention.self.query.weight");
+            names.add(p + "attention.self.query.bias");
+            names.add(p + "attention.self.key.weight");
+            names.add(p + "attention.self.key.bias");
+            names.add(p + "attention.self.value.weight");
+            names.add(p + "attention.self.value.bias");
+            names.add(p + "attention.output.dense.weight");
+            names.add(p + "attention.output.dense.bias");
+            names.add(p + "attention.output.LayerNorm.weight");
+            names.add(p + "attention.output.LayerNorm.bias");
+            names.add(p + "intermediate.dense.weight");
+            names.add(p + "intermediate.dense.bias");
+            names.add(p + "output.dense.weight");
+            names.add(p + "output.dense.bias");
+            names.add(p + "output.LayerNorm.weight");
+            names.add(p + "output.LayerNorm.bias");
+        }
+        return names;
+    }
+
+    /**
+     * Like {@link #buildMinimalModelFile(Path)} but without the "bert." prefix,
+     * matching the HuggingFace safetensors export format.
+     */
+    private static Path buildMinimalModelFileNoPrefix(Path dir) throws IOException {
+        List<String> names = buildTensorNamesNoPrefix();
+
+        StringBuilder json = new StringBuilder("{");
+        int dataOffset = 0;
+        for (int i = 0; i < names.size(); i++) {
+            if (i > 0) json.append(",");
+            json.append("\"").append(names.get(i)).append("\":");
+            json.append("{\"dtype\":\"F32\",\"shape\":[1],");
+            json.append("\"data_offsets\":[").append(dataOffset).append(",").append(dataOffset + 4).append("]}");
+            dataOffset += 4;
+        }
+        json.append("}");
+
+        byte[] headerBytes = json.toString().getBytes(StandardCharsets.UTF_8);
+        long headerLen = headerBytes.length;
+        int totalData = names.size() * 4;
+
+        ByteBuffer buf = ByteBuffer.allocate(8 + headerBytes.length + totalData).order(ByteOrder.LITTLE_ENDIAN);
+        buf.putLong(headerLen);
+        buf.put(headerBytes);
+        for (int i = 0; i < names.size(); i++) {
+            buf.putFloat(1.0f);
+        }
+
+        Path file = dir.resolve("model-noprefix.safetensors");
+        Files.write(file, buf.array());
+        return file;
+    }
+
+    private static List<String> buildTensorNamesNoPrefix() {
+        List<String> names = new ArrayList<>(101);
         names.add("embeddings.word_embeddings.weight");
         names.add("embeddings.position_embeddings.weight");
         names.add("embeddings.token_type_embeddings.weight");


### PR DESCRIPTION
## Problem

`BertWeights` hardcoded the `bert.` prefix for tensor names (e.g., `bert.embeddings.word_embeddings.weight`), but the HuggingFace safetensors export of all-MiniLM-L6-v2 uses **no prefix** (e.g., `embeddings.word_embeddings.weight`). This broke:

- `memory_search` — semantic search threw `Tensor not found` errors
- Mining could silently fail on embedding if the model was re-downloaded

## Fix

Auto-detect the tensor prefix by probing the safetensors metadata for a known tensor name. Supports both:
- PyTorch format: `bert.embeddings.*`, `bert.encoder.*`
- HuggingFace format: `embeddings.*`, `encoder.*`

## Changes

- `BertWeights.java`: Added `detectPrefix()` method, updated constructor to use dynamic prefix
- `BertWeightsTest.java`: Added test for no-prefix format, helper to build no-prefix model file

## Testing

All 3 BertWeightsTest cases pass. Build clean.