### PR TITLE
fix: resolve Windows binary detection failure for non-ASCII usernames

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
@@ -1137,7 +1137,8 @@ public abstract class AcpClient extends AbstractAgentClient {
         String binaryName = command.getFirst();
 
         // Already an absolute or relative path — no resolution needed
-        if (binaryName.startsWith("/") || binaryName.startsWith("./")) return command;
+        if (binaryName.startsWith("/") || binaryName.startsWith("./")
+            || (binaryName.length() > 1 && binaryName.charAt(1) == ':')) return command;
 
         // Use AgentBinaryResolver — the same resolution logic used by the settings page.
         // This ensures binary detection is consistent between settings and connect.

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/BinaryDetector.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/BinaryDetector.java
@@ -5,9 +5,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -16,6 +18,9 @@ import java.util.concurrent.TimeUnit;
  */
 public class BinaryDetector {
     private static final Logger LOG = Logger.getInstance(BinaryDetector.class);
+
+    private static final String DEFAULT_PATHEXT =
+        ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC";
 
     private BinaryDetector() {
     }
@@ -60,22 +65,96 @@ public class BinaryDetector {
     /**
      * Find the absolute path to a binary using the captured shell environment.
      *
+     * <p>On Windows, scans the {@code PATH} directories directly using Java's {@link File}
+     * API to avoid encoding issues. The {@code where.exe} approach fails for users whose PATH
+     * contains non-ASCII characters (e.g. accented characters in the Windows username) because
+     * the console output uses the OEM code page while Java reads it as UTF-8, mangling the path.
+     *
      * @param binaryName Name of the binary to find
      * @return Absolute path, or null if not found
      */
     @Nullable
     public static String findBinaryPath(@NotNull String binaryName) {
-        String os = System.getProperty("os.name", "").toLowerCase();
-        List<String> cmd = os.contains("win")
-            ? List.of("cmd.exe", "/c", "where " + binaryName)
-            : List.of("sh", "-c", "command -v " + binaryName);
+        if (isWindows()) {
+            return findBinaryOnWindowsPath(binaryName);
+        }
 
+        List<String> cmd = List.of("sh", "-c", "command -v " + binaryName);
         String output = runCommand(cmd, 3);
         if (output == null || output.isBlank()) return null;
 
         String path = output.trim().split("\n")[0].trim();
-        LOG.info("Found " + binaryName + " at: " + path);
+        logFound(binaryName, path);
         return path;
+    }
+
+    /**
+     * Scans the Windows {@code PATH} directories for a binary, respecting {@code PATHEXT}.
+     * Uses Java's {@link File} API directly — no subprocess, no encoding issues.
+     */
+    @Nullable
+    private static String findBinaryOnWindowsPath(@NotNull String binaryName) {
+        Map<String, String> env = ShellEnvironment.getEnvironment();
+        String pathVar = env.getOrDefault("PATH", env.getOrDefault("Path", ""));
+        String pathext = env.getOrDefault("PATHEXT", DEFAULT_PATHEXT);
+
+        String[] dirs = pathVar.split(";");
+        String[] extensions = pathext.split(";");
+
+        // If the name already has a recognized extension, check it directly first
+        if (hasExtension(binaryName, extensions)) {
+            String found = scanDirs(dirs, binaryName);
+            if (found != null) {
+                logFound(binaryName, found);
+                return found;
+            }
+        }
+
+        // Search with each PATHEXT extension appended
+        for (String ext : extensions) {
+            String found = scanDirs(dirs, binaryName + ext);
+            if (found != null) {
+                logFound(binaryName, found);
+                return found;
+            }
+        }
+
+        LOG.debug("Binary '" + binaryName + "' not found on Windows PATH");
+        return null;
+    }
+
+    /**
+     * Scans a list of directories for a file with the given name.
+     *
+     * @return the absolute path if found, or {@code null}
+     */
+    @Nullable
+    private static String scanDirs(@NotNull String[] dirs, @NotNull String fileName) {
+        for (String dir : dirs) {
+            String trimmed = dir.trim();
+            if (trimmed.isEmpty()) continue;
+            File f = new File(trimmed, fileName);
+            if (f.isFile()) {
+                return f.getAbsolutePath();
+            }
+        }
+        return null;
+    }
+
+    private static boolean hasExtension(@NotNull String name, @NotNull String[] extensions) {
+        String lower = name.toLowerCase();
+        for (String ext : extensions) {
+            if (lower.endsWith(ext.toLowerCase())) return true;
+        }
+        return false;
+    }
+
+    private static void logFound(@NotNull String binaryName, @NotNull String path) {
+        LOG.info("Found " + binaryName + " at: " + path);
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase().contains("win");
     }
 
     /**

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/settings/BinaryDetectorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/settings/BinaryDetectorTest.java
@@ -1,10 +1,17 @@
 package com.github.catatafishen.agentbridge.settings;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BinaryDetectorTest {
 
@@ -72,11 +79,90 @@ class BinaryDetectorTest {
         assertEquals("1.0.0", invokeParseVersion(output));
     }
 
+    // ── scanDirs (private static) ───────────────────────────────────────
+
+    @Test
+    void scanDirs_findsExistingFile(@TempDir Path tempDir) throws Exception {
+        Files.createFile(tempDir.resolve("copilot.exe"));
+        String[] dirs = {tempDir.toString()};
+        String result = invokeScanDirs(dirs, "copilot.exe");
+        assertNotNull(result);
+        assertTrue(result.endsWith("copilot.exe"));
+    }
+
+    @Test
+    void scanDirs_returnsNullForMissingFile(@TempDir Path tempDir) throws Exception {
+        String[] dirs = {tempDir.toString()};
+        assertNull(invokeScanDirs(dirs, "nonexistent.exe"));
+    }
+
+    @Test
+    void scanDirs_skipsEmptyDirEntries(@TempDir Path tempDir) throws Exception {
+        Files.createFile(tempDir.resolve("copilot.exe"));
+        String[] dirs = {"", "  ", tempDir.toString()};
+        String result = invokeScanDirs(dirs, "copilot.exe");
+        assertNotNull(result);
+    }
+
+    @Test
+    void scanDirs_returnsFirstMatch(@TempDir Path tempDir) throws Exception {
+        Path dir1 = tempDir.resolve("dir1");
+        Path dir2 = tempDir.resolve("dir2");
+        Files.createDirectories(dir1);
+        Files.createDirectories(dir2);
+        Files.createFile(dir1.resolve("tool.exe"));
+        Files.createFile(dir2.resolve("tool.exe"));
+        String[] dirs = {dir1.toString(), dir2.toString()};
+        String result = invokeScanDirs(dirs, "tool.exe");
+        assertNotNull(result);
+        assertTrue(result.startsWith(dir1.toString()));
+    }
+
+    @Test
+    void scanDirs_handlesNonAsciiPath(@TempDir Path tempDir) throws Exception {
+        Path unicodeDir = tempDir.resolve("MajaFredströmWestergård");
+        Files.createDirectories(unicodeDir);
+        Files.createFile(unicodeDir.resolve("copilot.cmd"));
+        String[] dirs = {unicodeDir.toString()};
+        String result = invokeScanDirs(dirs, "copilot.cmd");
+        assertNotNull(result, "Should find binary in path with non-ASCII characters");
+        assertTrue(result.contains("MajaFredströmWestergård"));
+    }
+
+    // ── hasExtension (private static) ───────────────────────────────────
+
+    @Test
+    void hasExtension_matchesCaseInsensitive() throws Exception {
+        String[] exts = {".EXE", ".CMD", ".BAT"};
+        assertTrue(invokeHasExtension("copilot.exe", exts));
+        assertTrue(invokeHasExtension("copilot.EXE", exts));
+        assertTrue(invokeHasExtension("copilot.Cmd", exts));
+    }
+
+    @Test
+    void hasExtension_returnsFalseForNoMatch() throws Exception {
+        String[] exts = {".EXE", ".CMD"};
+        assertFalse(invokeHasExtension("copilot", exts));
+        assertFalse(invokeHasExtension("copilot.sh", exts));
+    }
+
     // ── Reflection helpers ──────────────────────────────────────────────
 
     private static String invokeParseVersion(String output) throws Exception {
         Method m = BinaryDetector.class.getDeclaredMethod("parseVersion", String.class);
         m.setAccessible(true);
         return (String) m.invoke(null, output);
+    }
+
+    private static String invokeScanDirs(String[] dirs, String fileName) throws Exception {
+        Method m = BinaryDetector.class.getDeclaredMethod("scanDirs", String[].class, String.class);
+        m.setAccessible(true);
+        return (String) m.invoke(null, dirs, fileName);
+    }
+
+    private static boolean invokeHasExtension(String name, String[] extensions) throws Exception {
+        Method m = BinaryDetector.class.getDeclaredMethod("hasExtension", String.class, String[].class);
+        m.setAccessible(true);
+        return (Boolean) m.invoke(null, name, extensions);
     }
 }


### PR DESCRIPTION
## Problem

On Windows, `BinaryDetector.findBinaryPath()` used `where.exe` to locate binaries. The `where` command outputs paths in the console's OEM code page (e.g. CP437/CP850), but Java reads the output as UTF-8. For users whose PATH contains non-ASCII characters (e.g. accented letters in Windows usernames like "MajaFredströmWestergård"), the path gets mangled and `File.exists()` returns false.

**Symptom**: Settings page shows binary as detected (green ✓), but ACP connection fails with "binary not found". The settings page was unaffected because it calls `--version` which returns ASCII output, while the connection path calls `where` which returns the full filesystem path containing non-ASCII characters.

## Fix

1. **Replace `where.exe` with direct PATH scanning** — On Windows, scan `PATH` directories using Java's `File` API (respects `PATHEXT`). No subprocess = no encoding mismatch.

2. **Recognize Windows drive-letter paths in `AcpClient.resolveCommand()`** — Paths like `C:\copilot\copilot.exe` were being treated as bare names and re-resolved. Now recognized as absolute paths.

## Tests

- 7 new tests for `scanDirs` (including non-ASCII path test with "MajaFredströmWestergård") and `hasExtension`
- All existing `BinaryDetectorTest` and `AcpClientTest` tests pass

Fixes the issue reported by user with non-ASCII characters in Windows username where both Copilot and Claude showed green in settings but failed on ACP connection.