### PR TITLE
feat: improve memory mining quality across the pipeline

### DIFF
--- a/docs/MEMORY-IMPROVEMENTS.md
+++ b/docs/MEMORY-IMPROVEMENTS.md
@@ -1,0 +1,284 @@
+# Memory System Improvement Plan
+
+Improvement plan for the semantic memory tools (drawers, knowledge graph, recall).
+Based on analysis of the mining pipeline, content quality, and tool outputs after
+the first full backfill run.
+
+## Current Architecture
+
+```
+Raw conversation (EntryData list)
+  → ExchangeChunker     (pair prompts with responses, extract tool evidence)
+  → QualityFilter        (reject short/status/tool-heavy exchanges)
+  → MemoryClassifier     (classify type: decision/problem/solution/context)
+  → RoomDetector         (classify room: codebase/debugging/workflow/decisions/preferences)
+  → EvidenceExtractor    (extract file paths, commit SHAs from tool results)
+  → EmbeddingService     (all-MiniLM-L6-v2, 384-dim, 256-token limit)
+  → MemoryStore          (Lucene KNN index, 0.9 cosine dedup)
+  → TripleExtractor      (10 regex rules → subject/predicate/object)
+  → KnowledgeGraph       (SQLite with temporal validity)
+```
+
+## What Works Well
+
+- **Thinking entries excluded** — `EntryData.Thinking` is skipped by `ExchangeChunker`
+- **Nudges excluded** — `EntryData.Nudge` is properly filtered out
+- **Semantic dedup** — 0.9 cosine threshold catches near-duplicate drawers
+- **Evidence propagation** — triples carry file/commit evidence from source drawers
+- **Temporal KG model** — `valid_from`/`valid_until` enables fact evolution tracking
+- **Good embedding model** — all-MiniLM-L6-v2 is well-suited for semantic similarity
+- **Room/type orthogonality** — separating "where to look" from "what kind" is sound
+- **Memory search** — KNN vector search with rich context in results
+
+---
+
+## P0 — Agent Narration Noise
+
+**Problem**: Agent operational text ("I'll use the read_file tool...", "Let me search
+for the implementation...") is stored as drawer content and fed to triple extraction.
+This produces bogus triples like `(project, uses, the read_file tool)` and pollutes
+search results with navigational noise rather than substantive knowledge.
+
+**Root cause**: `ExchangeChunker` includes the full assistant response without
+distinguishing operational narration from substantive content.
+
+### Fix: Pre-filter agent narration in ExchangeChunker
+
+Add a `NarrationFilter` that strips common agent operational patterns from
+response text before it enters the pipeline:
+
+```
+Patterns to strip (line-level):
+- "I'll/Let me/I need to [verb] the [tool/file]..."
+- "Now I'll/Next I'll/First I'll..."
+- "Looking at/Checking/Reading/Searching..."
+- "The output shows/I can see that..."
+- "Here's what I found/Let me explain..."
+- Lines that are pure tool-call narration (match known MCP tool names)
+```
+
+**Implementation**: New class `NarrationFilter` in `memory/mining/`. Applied in
+`ExchangeChunker.appendResponseText()` or as a pipeline step between chunking
+and quality filtering. Strip matching lines, then collapse consecutive newlines.
+
+**Scope**: ~100 lines. Regex-based, same approach as `QualityFilter`.
+
+**Risk**: Over-filtering could remove legitimate content. Use conservative patterns
+that specifically target agent MCP tool narration, not general conversational text.
+
+---
+
+## P0 — Tool Evidence Noise in Embeddings and Triples
+
+**Problem**: Tool result fragments (up to 500 chars) are appended to response text
+by `ExchangeChunker.appendToolResultEvidence()`. These raw search outputs, file
+listings, and outlines flow into embeddings and triple extraction, adding noise.
+
+**Root cause**: Evidence extraction (file paths, commit SHAs) is entangled with
+content enrichment. The evidence metadata is correctly extracted by `EvidenceExtractor`,
+but the raw tool output text is *also* concatenated into the response.
+
+### Fix: Separate evidence metadata from content text
+
+1. **Stop appending tool result text to response**. In `ExchangeChunker`, extract
+   file paths and commit SHAs into the `Exchange` metadata fields only — don't
+   concat raw output into `responseBuilder`.
+
+2. **Keep tool call *names* for classification signal** but not their output.
+   E.g., knowing the exchange involved `search_text` and `edit_file` helps
+   `RoomDetector` (→ codebase), but the actual search results are noise.
+
+**Implementation**: Modify `ExchangeChunker.appendToolResultEvidence()`:
+- Extract evidence metadata (paths, SHAs) as today → store in `Exchange` fields
+- Remove the `responseBuilder.append("[").append(toolName)...` block
+- Optionally add a `toolNames` field to `Exchange` for classification signal
+
+**Scope**: ~20 lines changed in `ExchangeChunker`.
+
+---
+
+## P1 — Triple Extraction Quality
+
+### Negation handling
+
+**Problem**: "Never use eval()" → `(project, uses, eval())`. Regex patterns don't
+detect negation words before the trigger.
+
+**Fix**: Add negation guard to each extraction rule. Before extracting, check if the
+sentence contains a negation modifier within N words of the trigger:
+
+```java
+private static final Pattern NEGATION = Pattern.compile(
+    "\\b(not|never|don't|doesn't|shouldn't|avoid|stop|no longer|removed)\\b",
+    Pattern.CASE_INSENSITIVE);
+```
+
+If negation is detected, either skip the triple or invert the predicate
+(e.g., `uses` → `avoids`). Start with skip — inversion is harder to get right.
+
+### Object over-capture
+
+**Problem**: Object capture groups grab the rest of the sentence. "We implemented a
+fix for the failing test which broke CI" → object is the entire tail.
+
+**Fix**: Tighten `MAX_OBJECT_WORDS` from 10 to 6, and add a stop-word boundary:
+objects ending with prepositions ("for", "with", "in", "to", "from", "by", "on")
+should be trimmed at that preposition.
+
+### Cross-run dedup
+
+**Problem**: Same triple extracted repeatedly from different mining runs. No
+uniqueness constraint in SQLite.
+
+**Fix**: Add `UNIQUE(subject, predicate, object)` constraint (ignoring case) on the
+`triples` table. On conflict, update `evidence` to merge evidence arrays rather
+than inserting a duplicate row. Migration:
+
+```sql
+-- Deduplicate existing triples, keeping the one with the most evidence
+DELETE FROM triples WHERE id NOT IN (
+    SELECT MIN(id) FROM triples
+    WHERE valid_until IS NULL
+    GROUP BY LOWER(subject), LOWER(predicate), LOWER(object)
+);
+ALTER TABLE triples ADD CONSTRAINT ... -- SQLite doesn't support ALTER ADD CONSTRAINT;
+-- Recreate table with constraint instead
+```
+
+---
+
+## P1 — Embedding Quality
+
+### Markdown stripping before embedding
+
+**Problem**: Raw markdown (code blocks, headers, bold markers, URLs) goes into the
+embedding model. The `stripMarkdown()` preprocessing used for triple extraction
+is NOT applied before embedding.
+
+**Fix**: Apply `TripleExtractor.stripMarkdown()` (or a shared utility version) to
+the combined text before passing it to `EmbeddingService.embed()`. Extract the
+method to a shared `TextPreprocessor` utility class.
+
+### Token budget allocation
+
+**Problem**: 256-token limit means the prompt often consumes the entire token budget,
+and the response (where the actual insight lives) is truncated.
+
+**Fix**: Two options (not mutually exclusive):
+1. **Response-first embedding**: Feed `response + "\n" + prompt` instead of
+   `prompt + "\n\n" + response`. The response typically contains the insight;
+   the prompt is context.
+2. **Increase token limit to 512**: The model supports it; inference time roughly
+   doubles but is still fast enough for background mining. Benchmark before
+   committing.
+3. **Separate embeddings**: Embed prompt and response independently, store both
+   vectors. Search can match against either. More complex but higher recall.
+
+Recommended: Start with option 1 (response-first), measure quality improvement.
+If insufficient, add option 2.
+
+---
+
+## P1 — Wake-up Quality
+
+### Room diversity
+
+**Problem**: Wake-up uses pure recency — if the last 15 drawers are all from one
+debugging session, the wake-up context is entirely debugging with no
+codebase/preference/decision coverage.
+
+**Fix**: Select top N drawers *per room* rather than globally. E.g., top 3 from
+each of {codebase, workflow, debugging, decisions, preferences}, capped at 15
+total. Rooms with fewer drawers contribute less.
+
+```java
+Map<String, List<DrawerDocument>> byRoom = allDrawers.stream()
+    .collect(Collectors.groupingBy(DrawerDocument::room));
+List<DrawerDocument> diverse = byRoom.values().stream()
+    .flatMap(drawers -> drawers.stream().limit(MAX_PER_ROOM))
+    .sorted(Comparator.comparing(DrawerDocument::filedAt).reversed())
+    .limit(MAX_DRAWERS)
+    .toList();
+```
+
+### Smarter snippets
+
+**Problem**: 200-char truncation often shows the user's question, not the answer.
+
+**Fix**: Extract the first substantive sentence from the *response* portion (not
+the combined text). If the drawer content starts with the prompt, skip to after
+the first `\n\n` (the response boundary) before taking the snippet.
+
+---
+
+## P1 — Classification Improvements
+
+### Weighted keywords
+
+**Problem**: Simple keyword counting with equal weights. "Interface" scores the
+same as "refactored" for the codebase room, but "refactored" is a much stronger
+signal.
+
+**Fix**: Assign weights to keywords. Core vocabulary (e.g., "refactored", "debugger",
+"deployment") gets weight 2; generic terms (e.g., "code", "file", "data") get
+weight 1 or 0.5. Use weighted sum instead of count.
+
+### Confidence threshold
+
+**Problem**: A single keyword match is enough to classify. An exchange mentioning
+"build" once gets classified as "workflow" even if it's really about architecture.
+
+**Fix**: Add a minimum score threshold (e.g., 3 weighted points). Below threshold,
+classify as `general` rather than the highest-scoring room.
+
+---
+
+## P2 — KG Schema and Naming
+
+### Rename `source_closet` → `source_drawer`
+
+The column is named `source_closet` (from the original MemPalace "closet"
+terminology) but the Java code uses `sourceDrawer`. Rename for consistency.
+
+### Add compound index
+
+```sql
+CREATE INDEX idx_triples_subj_pred_valid
+ON triples(subject, predicate, valid_until);
+```
+
+This covers the most common query pattern (filter by subject+predicate, exclude
+invalidated).
+
+---
+
+## P2 — Dedup Tuning
+
+### Content-length-aware threshold
+
+**Problem**: Fixed 0.9 cosine threshold behaves differently for short vs. long
+content. Short texts cluster more tightly in embedding space.
+
+**Fix**: Adjust threshold based on content length:
+- Content < 100 chars: threshold 0.95 (stricter — short texts need higher similarity)
+- Content 100–500 chars: threshold 0.90 (current default)
+- Content > 500 chars: threshold 0.85 (more lenient — long texts diverge more)
+
+---
+
+## Implementation Order
+
+| Phase | Items | Estimated Scope |
+|-------|-------|-----------------|
+| 1 | Agent narration filter + tool evidence separation | ~150 lines new code |
+| 2 | Triple negation guard + object trimming + cross-run dedup | ~80 lines changed |
+| 3 | Embedding: markdown strip + response-first ordering | ~30 lines changed |
+| 4 | Wake-up room diversity + smarter snippets | ~50 lines changed |
+| 5 | Classification weights + confidence threshold | ~40 lines changed |
+| 6 | KG schema fixes (rename, index, unique constraint) | ~30 lines migration |
+
+Phase 1 and 2 address the biggest quality issues (noisy content and bogus triples).
+Phase 3 and 4 improve recall and context quality. Phase 5 and 6 are refinements.
+
+After each phase, re-mine history and compare drawer/triple quality against a
+baseline sample to validate improvement.

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/kg/KnowledgeGraph.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/kg/KnowledgeGraph.java
@@ -62,12 +62,18 @@ public final class KnowledgeGraph implements Disposable {
 
     /**
      * Add a triple to the knowledge graph.
+     * Skips insertion if an identical valid triple (same subject, predicate, object)
+     * already exists, preventing cross-run duplication.
      *
-     * @return the auto-generated triple ID
+     * @return the auto-generated triple ID, or -1 if skipped as duplicate
      */
     public long addTriple(@NotNull KgTriple triple) throws IOException {
+        if (existsValidTriple(triple.subject(), triple.predicate(), triple.object())) {
+            return -1;
+        }
+
         String sql = """
-            INSERT INTO triples (subject, predicate, object, valid_from, valid_until, source_closet, created_at, evidence)
+            INSERT INTO triples (subject, predicate, object, valid_from, valid_until, source_drawer, created_at, evidence)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """;
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
@@ -98,6 +104,28 @@ public final class KnowledgeGraph implements Disposable {
     }
 
     /**
+     * Check if an identical valid triple already exists (same subject, predicate, object,
+     * and not invalidated). Used to prevent cross-run duplication when re-mining.
+     */
+    private boolean existsValidTriple(@NotNull String subject, @NotNull String predicate,
+                                      @NotNull String object) throws IOException {
+        String sql = """
+            SELECT COUNT(*) FROM triples
+            WHERE subject = ? AND predicate = ? AND object = ? AND valid_until IS NULL
+            """;
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, subject);
+            stmt.setString(2, predicate);
+            stmt.setString(3, object);
+            try (ResultSet rs = stmt.executeQuery()) {
+                return rs.getInt(1) > 0;
+            }
+        } catch (SQLException e) {
+            throw new IOException("Failed to check for existing triple", e);
+        }
+    }
+
+    /**
      * Query triples matching the given filters. All parameters are optional.
      * Only returns currently valid triples (valid_until is NULL or in the future).
      */
@@ -106,7 +134,7 @@ public final class KnowledgeGraph implements Disposable {
                                          @Nullable String object,
                                          int limit) throws IOException {
         StringBuilder sql = new StringBuilder(
-            "SELECT id, subject, predicate, object, valid_from, valid_until, source_closet, created_at, evidence FROM triples WHERE 1=1");
+            "SELECT id, subject, predicate, object, valid_from, valid_until, source_drawer, created_at, evidence FROM triples WHERE 1=1");
         List<Object> params = new ArrayList<>();
 
         if (subject != null && !subject.isEmpty()) {
@@ -207,7 +235,7 @@ public final class KnowledgeGraph implements Disposable {
      */
     public @NotNull List<KgTriple> getTimeline(@NotNull String subject, int limit) throws IOException {
         String sql = """
-            SELECT id, subject, predicate, object, valid_from, valid_until, source_closet, created_at, evidence
+            SELECT id, subject, predicate, object, valid_from, valid_until, source_drawer, created_at, evidence
             FROM triples WHERE subject = ?
             ORDER BY created_at DESC LIMIT ?
             """;
@@ -239,7 +267,7 @@ public final class KnowledgeGraph implements Disposable {
                     object      TEXT NOT NULL,
                     valid_from  TEXT,
                     valid_until TEXT,
-                    source_closet TEXT,
+                    source_drawer TEXT,
                     created_at  TEXT NOT NULL
                 )
                 """);
@@ -251,18 +279,31 @@ public final class KnowledgeGraph implements Disposable {
     }
 
     private static void migrateSchema(@NotNull java.sql.Statement stmt) throws SQLException {
+        boolean hasEvidence = false;
+        boolean hasSourceCloset = false;
+        boolean hasSourceDrawer = false;
+
         try (ResultSet rs = stmt.executeQuery("PRAGMA table_info(triples)")) {
-            boolean hasEvidence = false;
             while (rs.next()) {
-                if ("evidence".equals(rs.getString("name"))) {
-                    hasEvidence = true;
-                    break;
-                }
-            }
-            if (!hasEvidence) {
-                stmt.executeUpdate("ALTER TABLE triples ADD COLUMN evidence TEXT DEFAULT ''");
+                String colName = rs.getString("name");
+                if ("evidence".equals(colName)) hasEvidence = true;
+                if ("source_closet".equals(colName)) hasSourceCloset = true;
+                if ("source_drawer".equals(colName)) hasSourceDrawer = true;
             }
         }
+
+        if (!hasEvidence) {
+            stmt.executeUpdate("ALTER TABLE triples ADD COLUMN evidence TEXT DEFAULT ''");
+        }
+
+        // Rename legacy "source_closet" column to "source_drawer" (MemPalace terminology → ours)
+        if (hasSourceCloset && !hasSourceDrawer) {
+            stmt.executeUpdate("ALTER TABLE triples RENAME COLUMN source_closet TO source_drawer");
+        }
+
+        // Compound index for dedup lookups and common query patterns
+        stmt.executeUpdate(
+            "CREATE INDEX IF NOT EXISTS idx_spo_valid ON triples(subject, predicate, object, valid_until)");
     }
 
     private @NotNull List<KgTriple> executeQuery(@NotNull String sql, @NotNull List<Object> params) throws IOException {
@@ -297,7 +338,7 @@ public final class KnowledgeGraph implements Disposable {
             .object(rs.getString("object"))
             .validFrom(parseNullableInstant(rs.getString("valid_from")))
             .validUntil(parseNullableInstant(rs.getString("valid_until")))
-            .sourceDrawer(rs.getString("source_closet"))
+            .sourceDrawer(rs.getString("source_drawer"))
             .createdAt(Instant.parse(rs.getString("created_at")))
             .evidence(getNullableString(rs, "evidence"))
             .build();

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractor.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractor.java
@@ -28,7 +28,7 @@ public final class TripleExtractor {
     private static final int MAX_OBJECT_LENGTH = 120;
     private static final int MAX_TRIPLES_PER_TEXT = 8;
     private static final int MIN_OBJECT_LENGTH = 3;
-    private static final int MAX_OBJECT_WORDS = 10;
+    private static final int MAX_OBJECT_WORDS = 8;
 
     private static final List<ExtractionRule> RULES = buildRules();
 
@@ -53,6 +53,26 @@ public final class TripleExtractor {
 
     private TripleExtractor() {
     }
+
+    /**
+     * Negation words that appear before a verb phrase and invert its meaning.
+     * When detected within 4 words before the pattern match, the triple is
+     * skipped entirely (e.g., "Never use eval()" should not produce
+     * {@code (project, uses, eval())}).
+     */
+    private static final Pattern NEGATION_PATTERN = Pattern.compile(
+        "\\b(never|don't|do not|doesn't|does not|should not|shouldn't|"
+            + "avoid|stop using|must not|mustn't|cannot|can't|won't|will not)\\b",
+        Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Trailing words that weaken an extracted object and should be trimmed.
+     * E.g., "JWT for authentication and" → "JWT for authentication".
+     */
+    private static final Set<String> TRAILING_TRIM_WORDS = Set.of(
+        "and", "or", "but", "so", "then", "because", "since", "when",
+        "where", "which", "that", "to", "for", "with", "from", "by",
+        "as", "at", "on", "in", "of");
 
     /**
      * Extract structured triples from exchange text.
@@ -93,38 +113,11 @@ public final class TripleExtractor {
     }
 
     /**
-     * Strip markdown formatting and tool-call fragments from text,
-     * preserving the underlying conversational words.
-     * Code blocks are removed entirely (code is not conversational prose).
-     * Bold/italic markers are unwrapped, keeping the emphasized text.
-     * Tool evidence brackets {@code [tool:...]} and {@code [...result:...]}
-     * are removed to prevent false pattern matches on operational metadata.
+     * Strip markdown formatting and tool-call fragments from text.
+     * Delegates to {@link com.github.catatafishen.agentbridge.memory.mining.TextPreprocessor#stripMarkdown(String)}.
      */
     static @NotNull String stripMarkdown(@NotNull String text) {
-        // Remove fenced code blocks entirely (content is code, not prose)
-        String result = text.replaceAll("```[\\s\\S]*?```", " ");
-        // Remove inline code spans
-        result = result.replaceAll("`[^`]+`", " ");
-        // Remove tool evidence brackets: [tool:...], [...result:...]
-        result = result.replaceAll("\\[tool:[^]]*]", " ");
-        result = result.replaceAll("\\[[^]]{0,40} result:[^]]*]", " ");
-        // Unwrap bold/italic — keep the text, remove the markers
-        result = result.replaceAll("\\*{1,3}([^*]+)\\*{1,3}", "$1");
-        result = result.replaceAll("_{1,3}([^_]+)_{1,3}", "$1");
-        // Remove header markers
-        result = result.replaceAll("(?m)^#{1,6}\\s+", "");
-        // Remove bullet/list markers
-        result = result.replaceAll("(?m)^\\s*[-*+]\\s+", "");
-        result = result.replaceAll("(?m)^\\s*\\d+\\.\\s+", "");
-        // Unwrap markdown links: [text](url) → text
-        result = result.replaceAll("\\[([^]]+)]\\([^)]+\\)", "$1");
-        // Remove bare URLs
-        result = result.replaceAll("https?://\\S+", "");
-        // Remove blockquote markers
-        result = result.replaceAll("(?m)^>+\\s*", "");
-        // Normalize runs of horizontal whitespace (preserve newlines for splitting)
-        result = result.replaceAll("[ \\t]+", " ");
-        return result.strip();
+        return com.github.catatafishen.agentbridge.memory.mining.TextPreprocessor.stripMarkdown(text);
     }
 
     /**
@@ -191,6 +184,10 @@ public final class TripleExtractor {
         Matcher matcher = rule.pattern.matcher(sentence);
         if (!matcher.find()) return null;
 
+        // Negation guard: check if the sentence contains negation before the match
+        String prefix = sentence.substring(0, matcher.start());
+        if (hasNegation(prefix) || hasNegation(sentence)) return null;
+
         String rawObject = matcher.group(rule.objectGroup).strip();
         String object = cleanObject(rawObject);
         if (!isQualityObject(object)) return null;
@@ -202,6 +199,14 @@ public final class TripleExtractor {
 
         if (isDuplicate(existing, rule.predicate, object)) return null;
         return new ExtractedTriple(subject, rule.predicate, object, drawerId);
+    }
+
+    /**
+     * Check whether a text fragment contains negation that would invert the
+     * meaning of an extraction rule match (e.g. "don't use eval").
+     */
+    private static boolean hasNegation(@NotNull String text) {
+        return NEGATION_PATTERN.matcher(text).find();
     }
 
     private static boolean isDuplicate(@NotNull List<ExtractedTriple> existing,
@@ -222,7 +227,30 @@ public final class TripleExtractor {
                 cleaned = cleaned.substring(0, MAX_OBJECT_LENGTH);
             }
         }
+        cleaned = trimTrailingWeakWords(cleaned);
         return cleaned;
+    }
+
+    /**
+     * Remove trailing prepositions and conjunctions from an extracted object.
+     * These are captured by the greedy regex but add no semantic value.
+     * E.g., "JWT for authentication and" → "JWT for authentication".
+     */
+    private static @NotNull String trimTrailingWeakWords(@NotNull String text) {
+        String result = text;
+        boolean trimmed = true;
+        while (trimmed) {
+            trimmed = false;
+            int lastSpace = result.lastIndexOf(' ');
+            if (lastSpace > 0) {
+                String lastWord = result.substring(lastSpace + 1).toLowerCase();
+                if (TRAILING_TRIM_WORDS.contains(lastWord)) {
+                    result = result.substring(0, lastSpace).strip();
+                    trimmed = true;
+                }
+            }
+        }
+        return result;
     }
 
     private static @NotNull String cleanSubject(@NotNull String raw) {
@@ -238,8 +266,10 @@ public final class TripleExtractor {
     }
 
     private static List<ExtractionRule> buildRules() {
-        // Object terminator: sentence-ending punctuation or end of string
-        String end = "(?=[.,;!?\\n]|$)";
+        // Object terminator: sentence-ending punctuation, clause boundary, or end of string.
+        // Clause boundaries ("by", "instead", "because", etc.) prevent over-capturing
+        // subordinate clauses as part of the object.
+        String end = "(?=[.,;!?\\n]|\\s+(?:by|because|since|when|instead|rather|although|while|so that)\\b|$)";
         List<ExtractionRule> rules = new ArrayList<>();
 
         // Decision: "decided to use X", "chose X", "went with X"

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/layers/EssentialStoryLayer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/layers/EssentialStoryLayer.java
@@ -45,7 +45,7 @@ public final class EssentialStoryLayer implements MemoryStack {
     @Override
     public @NotNull String render(@NotNull String wing, @Nullable String query) {
         try {
-            List<DrawerDocument> drawers = store.getTopDrawers(wing, maxDrawers);
+            List<DrawerDocument> drawers = store.getTopDrawersDiverse(wing, maxDrawers);
             if (drawers.isEmpty()) return "";
 
             StringBuilder sb = new StringBuilder("## Essential Story\n\n");

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/ExchangeChunker.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/ExchangeChunker.java
@@ -74,10 +74,13 @@ public final class ExchangeChunker {
 
     private static void appendResponseText(String raw, StringBuilder response) {
         if (!raw.isBlank()) {
-            if (!response.isEmpty()) {
-                response.append('\n');
+            String filtered = NarrationFilter.filter(raw);
+            if (!filtered.isEmpty()) {
+                if (!response.isEmpty()) {
+                    response.append('\n');
+                }
+                response.append(filtered);
             }
-            response.append(raw);
         }
     }
 
@@ -97,33 +100,17 @@ public final class ExchangeChunker {
 
     /**
      * Append evidence-relevant fragments from a tool call result.
-     * Includes the file path reference (if available) and the tool name context,
-     * but NOT the full result text (which can be very large for file reads/diffs).
+     * Only includes the file path reference — NOT the full result text.
+     * Raw tool output is noisy (search results, file listings, diffs) and
+     * degrades embedding quality and triple extraction.
      * The {@link com.github.catatafishen.agentbridge.memory.validation.EvidenceExtractor}
-     * will pick up file paths and FQN patterns from these fragments.
+     * picks up file paths and FQN patterns from these fragments.
      */
     static void appendToolResultEvidence(EntryData.ToolCall tc, StringBuilder response) {
         String filePath = tc.getFilePath();
         if (filePath != null && !filePath.isEmpty()) {
             appendResponseText("[tool:" + tc.getTitle() + " file:" + filePath + "]", response);
         }
-
-        String result = tc.getResult();
-        if (result == null || result.isEmpty()) return;
-
-        // For search/list tools, the result contains file paths worth capturing.
-        // Limit to first 500 chars to avoid bloating the combined text.
-        String toolName = tc.getTitle();
-        if (isEvidenceRichTool(toolName)) {
-            String fragment = result.length() > 500 ? result.substring(0, 500) : result;
-            appendResponseText("[" + toolName + " result: " + fragment + "]", response);
-        }
-    }
-
-    private static boolean isEvidenceRichTool(String toolName) {
-        return toolName.contains("search") || toolName.contains("find")
-            || toolName.contains("list") || toolName.contains("grep")
-            || toolName.contains("glob") || toolName.contains("outline");
     }
 
     /**
@@ -143,10 +130,13 @@ public final class ExchangeChunker {
         @NotNull List<String> commitHashes
     ) {
         /**
-         * Get the combined text (prompt + response) for classification and embedding.
+         * Get the preprocessed text for classification and embedding.
+         * Uses response-first ordering with markdown stripped.
+         *
+         * @see TextPreprocessor#forEmbedding(String, String)
          */
         public @NotNull String combinedText() {
-            return prompt + "\n\n" + response;
+            return TextPreprocessor.forEmbedding(prompt, response);
         }
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/MemoryClassifier.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/MemoryClassifier.java
@@ -22,6 +22,12 @@ import java.util.regex.Pattern;
  */
 public final class MemoryClassifier {
 
+    /**
+     * Minimum weighted score required to confidently classify a type.
+     * A single marker match (score 1) is too ambiguous — falls back to general.
+     */
+    private static final int MIN_CONFIDENCE = 2;
+
     private static final Map<String, List<Pattern>> TYPE_MARKERS = buildTypeMarkers();
 
     private MemoryClassifier() {
@@ -29,6 +35,9 @@ public final class MemoryClassifier {
 
     /**
      * Classify the combined prompt + response text into a memory type.
+     * Requires at least {@code MIN_CONFIDENCE} marker matches to classify;
+     * otherwise falls back to "general". Multi-word patterns score higher
+     * (weight 2) than single-word patterns (weight 1) since they're more specific.
      *
      * @param text combined text of the exchange chunk
      * @return one of the DrawerDocument.TYPE_* constants
@@ -43,7 +52,10 @@ public final class MemoryClassifier {
             int score = 0;
             for (Pattern pattern : entry.getValue()) {
                 if (pattern.matcher(lowerText).find()) {
-                    score++;
+                    // Multi-word patterns are more diagnostic → higher weight
+                    String patternStr = pattern.pattern();
+                    boolean isMultiWord = patternStr.contains(" ") || patternStr.contains("\\s");
+                    score += isMultiWord ? 2 : 1;
                 }
             }
             if (score > bestScore) {
@@ -52,7 +64,7 @@ public final class MemoryClassifier {
             }
         }
 
-        return bestType;
+        return bestScore >= MIN_CONFIDENCE ? bestType : DrawerDocument.TYPE_GENERAL;
     }
 
     private static Map<String, List<Pattern>> buildTypeMarkers() {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/NarrationFilter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/NarrationFilter.java
@@ -1,0 +1,100 @@
+package com.github.catatafishen.agentbridge.memory.mining;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Strips agent operational narration from response text before it enters the
+ * mining pipeline. Lines matching common agent patterns ("I'll use...",
+ * "Let me search...", "Looking at...") are removed because they carry no
+ * substantive knowledge — only navigation/tool-invocation commentary.
+ *
+ * <p>Applied in {@link ExchangeChunker} so that downstream stages
+ * (classification, embedding, triple extraction) see only meaningful content.
+ */
+public final class NarrationFilter {
+
+    /**
+     * Patterns that match entire lines of agent operational narration.
+     * Each pattern is anchored to the start of a trimmed line.
+     */
+    private static final List<Pattern> LINE_PATTERNS = List.of(
+        // "I'll read the file", "I need to check", "Let me search for"
+        Pattern.compile(
+            "^(I'll|I need to|I'm going to|Let me|Now I'll|Next I'll|First I'll|Now let me)\\s+\\w+",
+            Pattern.CASE_INSENSITIVE),
+        // "Looking at the code", "Checking the tests", "Reading the file"
+        Pattern.compile(
+            "^(Looking at|Checking|Reading|Searching|Examining|Investigating|Inspecting|Scanning|Exploring)\\s+",
+            Pattern.CASE_INSENSITIVE),
+        // "The output shows...", "I can see that..."
+        Pattern.compile(
+            "^(The output shows|I can see that|I see that|From the output|Based on the output)\\b",
+            Pattern.CASE_INSENSITIVE),
+        // "Here's what I found", "Let me explain"
+        Pattern.compile(
+            "^(Here's what|Here is what|Let me explain|I found that|I noticed that)\\b",
+            Pattern.CASE_INSENSITIVE),
+        // "Good — no compilation errors", "Clean build", "All tests pass"
+        Pattern.compile(
+            "^(Good\\s*\\p{Pd}|Clean build|All \\d+ tests pass|Tests pass|Build succeeded|No compilation errors)",
+            Pattern.CASE_INSENSITIVE),
+        // "Now let me also...", "Let me also..."
+        Pattern.compile(
+            "^(Now let me also|Let me also|I should also|I also need to)\\b",
+            Pattern.CASE_INSENSITIVE)
+    );
+
+    private NarrationFilter() {
+    }
+
+    /**
+     * Remove lines of agent operational narration from response text.
+     *
+     * @param response raw assistant response text
+     * @return filtered text with narration lines removed
+     */
+    public static @NotNull String filter(@NotNull String response) {
+        String[] lines = response.split("\n");
+        StringBuilder result = new StringBuilder(response.length());
+        boolean prevBlank = false;
+
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty()) {
+                if (!prevBlank && !result.isEmpty()) {
+                    result.append('\n');
+                    prevBlank = true;
+                }
+                continue;
+            }
+
+            if (isNarration(trimmed)) {
+                continue;
+            }
+
+            if (!result.isEmpty() && !prevBlank) {
+                result.append('\n');
+            }
+            result.append(line);
+            prevBlank = false;
+        }
+
+        return result.toString().strip();
+    }
+
+    /**
+     * Check if a trimmed line is agent narration.
+     * Package-private for testing.
+     */
+    static boolean isNarration(@NotNull String trimmedLine) {
+        for (Pattern pattern : LINE_PATTERNS) {
+            if (pattern.matcher(trimmedLine).find()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/RoomDetector.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/RoomDetector.java
@@ -21,6 +21,12 @@ import java.util.Map;
 public final class RoomDetector {
 
     /**
+     * Minimum weighted score required to confidently assign a room.
+     * A single keyword match (score 1) is too ambiguous — falls back to general.
+     */
+    private static final int MIN_CONFIDENCE = 2;
+
+    /**
      * Keywords per room. Each match adds 1 to that room's score.
      */
     private static final Map<String, List<String>> ROOM_KEYWORDS = buildRoomKeywords();
@@ -30,6 +36,9 @@ public final class RoomDetector {
 
     /**
      * Detect the best-fit room for the given text.
+     * Requires at least {@code MIN_CONFIDENCE} keyword matches to classify;
+     * otherwise falls back to "general". Multi-word phrases score higher
+     * (weight 2) than single-word matches (weight 1) since they're more specific.
      *
      * @param text combined prompt + response text
      * @return room name (lowercase, suitable for use as DrawerDocument.room)
@@ -44,7 +53,8 @@ public final class RoomDetector {
             int score = 0;
             for (String keyword : entry.getValue()) {
                 if (lowerText.contains(keyword)) {
-                    score++;
+                    // Multi-word phrases are more specific → higher weight
+                    score += keyword.contains(" ") ? 2 : 1;
                 }
             }
             if (score > bestScore) {
@@ -53,7 +63,7 @@ public final class RoomDetector {
             }
         }
 
-        return bestRoom;
+        return bestScore >= MIN_CONFIDENCE ? bestRoom : DrawerDocument.ROOM_GENERAL;
     }
 
     private static Map<String, List<String>> buildRoomKeywords() {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/TextPreprocessor.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/TextPreprocessor.java
@@ -1,0 +1,68 @@
+package com.github.catatafishen.agentbridge.memory.mining;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Shared text preprocessing for the mining pipeline. Provides markdown
+ * stripping and combined-text construction used by both the embedding
+ * path (in {@link ExchangeChunker.Exchange}) and the triple extraction
+ * path (in {@link com.github.catatafishen.agentbridge.memory.kg.TripleExtractor}).
+ */
+public final class TextPreprocessor {
+
+    private TextPreprocessor() {
+    }
+
+    /**
+     * Strip markdown formatting and tool-call fragments from text,
+     * preserving the underlying conversational words.
+     *
+     * <p>Code blocks are removed entirely (code is not conversational prose).
+     * Bold/italic markers are unwrapped, keeping the emphasized text.
+     * Tool evidence brackets {@code [tool:...]} and {@code [...result:...]}
+     * are removed to prevent false pattern matches.
+     */
+    public static @NotNull String stripMarkdown(@NotNull String text) {
+        // Remove fenced code blocks entirely (content is code, not prose)
+        String result = text.replaceAll("```[\\s\\S]*?```", " ");
+        // Remove inline code spans
+        result = result.replaceAll("`[^`]+`", " ");
+        // Remove tool evidence brackets: [tool:...], [...result:...]
+        result = result.replaceAll("\\[tool:[^]]*]", " ");
+        result = result.replaceAll("\\[[^]]{0,40} result:[^]]*]", " ");
+        // Unwrap bold/italic — keep the text, remove the markers
+        result = result.replaceAll("\\*{1,3}([^*]+)\\*{1,3}", "$1");
+        result = result.replaceAll("_{1,3}([^_]+)_{1,3}", "$1");
+        // Remove header markers
+        result = result.replaceAll("(?m)^#{1,6}\\s+", "");
+        // Remove bullet/list markers
+        result = result.replaceAll("(?m)^\\s*[-*+]\\s+", "");
+        result = result.replaceAll("(?m)^\\s*\\d+\\.\\s+", "");
+        // Unwrap markdown links: [text](url) → text
+        result = result.replaceAll("\\[([^]]+)]\\([^)]+\\)", "$1");
+        // Remove bare URLs
+        result = result.replaceAll("https?://\\S+", "");
+        // Remove blockquote markers
+        result = result.replaceAll("(?m)^>+\\s*", "");
+        // Normalize runs of horizontal whitespace (preserve newlines for splitting)
+        result = result.replaceAll("[ \\t]+", " ");
+        return result.strip();
+    }
+
+    /**
+     * Build the combined text for embedding and classification.
+     * Uses response-first ordering because the response typically contains
+     * more information-dense content (decisions, explanations) than the
+     * prompt (short commands/questions). Embedding models weight earlier
+     * tokens more heavily due to truncation, so response-first maximizes
+     * information retained within the 256-token limit.
+     *
+     * <p>Markdown is stripped before combining so that formatting artifacts
+     * don't consume embedding token budget.
+     */
+    public static @NotNull String forEmbedding(@NotNull String prompt, @NotNull String response) {
+        String cleanResponse = stripMarkdown(response);
+        String cleanPrompt = stripMarkdown(prompt);
+        return cleanResponse + "\n\n" + cleanPrompt;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/store/MemoryStore.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/store/MemoryStore.java
@@ -249,6 +249,47 @@ public final class MemoryStore implements Disposable {
     }
 
     /**
+     * Get top N drawers with per-room diversity, ensuring wake-up context
+     * spans multiple topic areas rather than being dominated by the most
+     * recent session's room.
+     *
+     * <p>Strategy: fetches recent drawers, groups by room, then round-robin
+     * selects from each room to fill the quota. This guarantees at least one
+     * drawer per room (when available) before any room gets a second.
+     *
+     * @param wing       project wing
+     * @param maxDrawers maximum drawers to return
+     * @return drawers with room diversity, most recent first within each room
+     */
+    public List<DrawerDocument> getTopDrawersDiverse(@NotNull String wing, int maxDrawers) throws IOException {
+        // Fetch a larger pool to have enough diversity candidates
+        List<DrawerDocument> pool = getTopDrawers(wing, maxDrawers * 3);
+        if (pool.size() <= maxDrawers) return pool;
+
+        // Group by room, preserving recency order within each group
+        java.util.LinkedHashMap<String, List<DrawerDocument>> byRoom = new java.util.LinkedHashMap<>();
+        for (DrawerDocument d : pool) {
+            byRoom.computeIfAbsent(d.room(), k -> new ArrayList<>()).add(d);
+        }
+
+        // Round-robin across rooms
+        List<DrawerDocument> result = new ArrayList<>(maxDrawers);
+        int round = 0;
+        while (result.size() < maxDrawers) {
+            boolean added = false;
+            for (List<DrawerDocument> roomDrawers : byRoom.values()) {
+                if (round < roomDrawers.size() && result.size() < maxDrawers) {
+                    result.add(roomDrawers.get(round));
+                    added = true;
+                }
+            }
+            if (!added) break;
+            round++;
+        }
+        return result;
+    }
+
+    /**
      * Get total number of drawers in the index.
      */
     public int getDrawerCount() throws IOException {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/memory/MemoryWakeUpTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/memory/MemoryWakeUpTool.java
@@ -72,7 +72,7 @@ public final class MemoryWakeUpTool extends Tool {
         }
 
         String wing = memoryService.getEffectiveWing();
-        List<DrawerDocument> topDrawers = store.getTopDrawers(wing, MAX_DRAWERS);
+        List<DrawerDocument> topDrawers = store.getTopDrawersDiverse(wing, MAX_DRAWERS);
 
         // Skip stale memories — wake-up context should be reliable
         List<DrawerDocument> reliable = topDrawers.stream()

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/kg/TripleExtractorTest.java
@@ -380,6 +380,78 @@ class TripleExtractorTest {
 
     // ── Helper ────────────────────────────────────────────────────────────
 
+    // ── Negation guard tests ──────────────────────────────────────────────
+
+    @Test
+    void negation_neverUse_skipsTriple() {
+        String text = "Never use eval() in production code.";
+        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
+
+        assertTrue(triples.isEmpty(),
+            "Negated usage should not produce a triple: " + triples);
+    }
+
+    @Test
+    void negation_dontUse_skipsTriple() {
+        String text = "Don't use global variables for configuration.";
+        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
+
+        assertTrue(triples.isEmpty(),
+            "Negated usage should not produce a triple: " + triples);
+    }
+
+    @Test
+    void negation_shouldNotDepend_skipsTriple() {
+        String text = "The module should not depend on external services.";
+        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
+
+        assertTrue(triples.isEmpty(),
+            "Negated dependency should not produce a triple: " + triples);
+    }
+
+    @Test
+    void negation_avoid_skipsTriple() {
+        String text = "Avoid using deprecated APIs in the codebase.";
+        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
+
+        assertTrue(triples.isEmpty(),
+            "Avoidance should not produce a 'uses' triple: " + triples);
+    }
+
+    // ── Object trimming tests ─────────────────────────────────────────────
+
+    @Test
+    void objectTrimming_clauseBoundary_stopsAtBy() {
+        String text = "I fixed the classloader issue by loading the driver explicitly.";
+        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
+
+        assertContainsTriple(triples, "resolved", "classloader issue");
+        assertFalse(triples.getFirst().object().contains("loading"),
+            "Object should not extend past 'by' clause: " + triples.getFirst().object());
+    }
+
+    @Test
+    void objectTrimming_clauseBoundary_stopsAtInstead() {
+        String text = "I chose PostgreSQL instead of MySQL for the database.";
+        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
+
+        assertContainsTriple(triples, "decided", "PostgreSQL");
+        assertFalse(triples.getFirst().object().contains("MySQL"),
+            "Object should not extend past 'instead': " + triples.getFirst().object());
+    }
+
+    @Test
+    void objectTrimming_trailingPreposition_removed() {
+        String text = "We decided to use Gradle for";
+        List<TripleExtractor.ExtractedTriple> triples = TripleExtractor.extract(text, WING, DRAWER_ID);
+
+        // "Gradle for" should trim trailing "for"
+        if (!triples.isEmpty()) {
+            assertFalse(triples.getFirst().object().endsWith("for"),
+                "Trailing preposition should be trimmed: " + triples.getFirst().object());
+        }
+    }
+
     private static void assertContainsTriple(List<TripleExtractor.ExtractedTriple> triples,
                                              String predicate, String objectSubstring) {
         boolean found = triples.stream().anyMatch(t ->

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/layers/EssentialStoryLayerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/layers/EssentialStoryLayerTest.java
@@ -48,7 +48,7 @@ class EssentialStoryLayerTest {
 
     @Test
     void renderWithEmptyDrawersReturnsEmpty() throws IOException {
-        when(store.getTopDrawers(eq(WING), anyInt())).thenReturn(Collections.emptyList());
+        when(store.getTopDrawersDiverse(eq(WING), anyInt())).thenReturn(Collections.emptyList());
 
         EssentialStoryLayer layer = new EssentialStoryLayer(store);
         String result = layer.render(WING, null);
@@ -67,7 +67,7 @@ class EssentialStoryLayerTest {
             .filedAt(Instant.parse("2024-01-15T10:30:00Z"))
             .build();
 
-        when(store.getTopDrawers(eq(WING), anyInt())).thenReturn(List.of(drawer));
+        when(store.getTopDrawersDiverse(eq(WING), anyInt())).thenReturn(List.of(drawer));
 
         EssentialStoryLayer layer = new EssentialStoryLayer(store);
         String result = layer.render(WING, null);
@@ -91,7 +91,7 @@ class EssentialStoryLayerTest {
             .filedAt(Instant.now())
             .build();
 
-        when(store.getTopDrawers(eq(WING), anyInt())).thenReturn(List.of(drawer));
+        when(store.getTopDrawersDiverse(eq(WING), anyInt())).thenReturn(List.of(drawer));
 
         EssentialStoryLayer layer = new EssentialStoryLayer(store);
         String result = layer.render(WING, null);
@@ -112,7 +112,7 @@ class EssentialStoryLayerTest {
             .filedAt(Instant.now())
             .build();
 
-        when(store.getTopDrawers(eq(WING), anyInt())).thenReturn(List.of(drawer));
+        when(store.getTopDrawersDiverse(eq(WING), anyInt())).thenReturn(List.of(drawer));
 
         EssentialStoryLayer layer = new EssentialStoryLayer(store);
         String result = layer.render(WING, null);
@@ -131,7 +131,7 @@ class EssentialStoryLayerTest {
             .filedAt(Instant.now())
             .build();
 
-        when(store.getTopDrawers(eq(WING), anyInt())).thenReturn(List.of(drawer));
+        when(store.getTopDrawersDiverse(eq(WING), anyInt())).thenReturn(List.of(drawer));
 
         EssentialStoryLayer layer = new EssentialStoryLayer(store);
         String withQuery = layer.render(WING, "some search query");
@@ -142,7 +142,7 @@ class EssentialStoryLayerTest {
 
     @Test
     void renderWhenStoreThrowsIOExceptionReturnsEmpty() throws IOException {
-        when(store.getTopDrawers(anyString(), anyInt())).thenThrow(new IOException("disk failure"));
+        when(store.getTopDrawersDiverse(anyString(), anyInt())).thenThrow(new IOException("disk failure"));
 
         EssentialStoryLayer layer = new EssentialStoryLayer(store);
         String result = layer.render(WING, null);
@@ -153,11 +153,11 @@ class EssentialStoryLayerTest {
     @Test
     void customMaxDrawersLimitIsPassedToStore() throws IOException {
         int customLimit = 5;
-        when(store.getTopDrawers(eq(WING), eq(customLimit))).thenReturn(Collections.emptyList());
+        when(store.getTopDrawersDiverse(eq(WING), eq(customLimit))).thenReturn(Collections.emptyList());
 
         EssentialStoryLayer layer = new EssentialStoryLayer(store, customLimit);
         layer.render(WING, null);
 
-        verify(store).getTopDrawers(WING, customLimit);
+        verify(store).getTopDrawersDiverse(WING, customLimit);
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/ExchangeChunkerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/ExchangeChunkerTest.java
@@ -156,9 +156,10 @@ class ExchangeChunkerTest {
     }
 
     @Test
-    void toolCall_searchTool_includesResultFragment() {
+    void toolCall_searchTool_includesFilePathOnly() {
         EntryData.ToolCall tc = new EntryData.ToolCall("search_text");
         tc.setResult("Found 3 matches:\nplugin-core/src/main/java/Bar.java:42 match");
+        tc.setFilePath("plugin-core/src/main/java/Bar.java");
         List<EntryData> entries = List.of(
             new EntryData.Prompt("Find Bar"),
             tc,
@@ -168,7 +169,9 @@ class ExchangeChunkerTest {
         List<ExchangeChunker.Exchange> result = ExchangeChunker.chunk(entries);
         assertEquals(1, result.size());
         assertTrue(result.get(0).response().contains("Bar.java"),
-            "Search tool result should appear in response: " + result.get(0).response());
+            "File path should appear in response: " + result.get(0).response());
+        assertFalse(result.get(0).response().contains("Found 3 matches"),
+            "Raw tool result text should NOT appear: " + result.get(0).response());
     }
 
     @Test
@@ -234,10 +237,14 @@ class ExchangeChunkerTest {
     // --- Exchange.combinedText() ---
 
     @Test
-    void combinedText_format() {
+    void combinedText_responseFirst() {
         ExchangeChunker.Exchange ex = new ExchangeChunker.Exchange(
             "my prompt", "my response", "", "", List.of());
 
-        assertEquals("my prompt\n\nmy response", ex.combinedText());
+        String combined = ex.combinedText();
+        assertTrue(combined.startsWith("my response"),
+            "Response should come first for embedding quality: " + combined);
+        assertTrue(combined.contains("my prompt"),
+            "Prompt should still be included: " + combined);
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/NarrationFilterTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/NarrationFilterTest.java
@@ -1,0 +1,96 @@
+package com.github.catatafishen.agentbridge.memory.mining;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NarrationFilterTest {
+
+    @Test
+    void isNarration_detectsToolNarration() {
+        assertTrue(NarrationFilter.isNarration("I'll read the file to understand the issue"));
+        assertTrue(NarrationFilter.isNarration("Let me search for the implementation"));
+        assertTrue(NarrationFilter.isNarration("Now I'll check the tests"));
+        assertTrue(NarrationFilter.isNarration("I need to check the build output"));
+        assertTrue(NarrationFilter.isNarration("I'm going to fix the failing test"));
+    }
+
+    @Test
+    void isNarration_detectsObservationNarration() {
+        assertTrue(NarrationFilter.isNarration("Looking at the code, it seems"));
+        assertTrue(NarrationFilter.isNarration("Checking the test results"));
+        assertTrue(NarrationFilter.isNarration("Reading the error output"));
+        assertTrue(NarrationFilter.isNarration("Searching for references"));
+        assertTrue(NarrationFilter.isNarration("Examining the stack trace"));
+    }
+
+    @Test
+    void isNarration_detectsOutputCommentary() {
+        assertTrue(NarrationFilter.isNarration("The output shows that the test passed"));
+        assertTrue(NarrationFilter.isNarration("I can see that the fix works"));
+        assertTrue(NarrationFilter.isNarration("Here's what I found in the codebase"));
+    }
+
+    @Test
+    void isNarration_detectsBuildStatusNarration() {
+        assertTrue(NarrationFilter.isNarration("Good — no compilation errors"));
+        assertTrue(NarrationFilter.isNarration("Clean build. Let me continue"));
+        assertTrue(NarrationFilter.isNarration("All 47 tests pass"));
+        assertTrue(NarrationFilter.isNarration("Tests pass. Moving on"));
+    }
+
+    @Test
+    void isNarration_preservesSubstantiveContent() {
+        assertFalse(NarrationFilter.isNarration("The root cause was a race condition"));
+        assertFalse(NarrationFilter.isNarration("We use JWT for authentication"));
+        assertFalse(NarrationFilter.isNarration("The fix replaces async with sync"));
+        assertFalse(NarrationFilter.isNarration("This class handles binary detection"));
+        assertFalse(NarrationFilter.isNarration("Fixed the encoding issue on Windows"));
+    }
+
+    @Test
+    void filter_removesNarrationLines() {
+        String input = """
+            The root cause was encoding mismatch.
+            Let me search for the implementation.
+            On Windows, cmd.exe uses OEM code page.
+            I'll read the file to verify.""";
+
+        String filtered = NarrationFilter.filter(input);
+
+        assertTrue(filtered.contains("root cause was encoding mismatch"));
+        assertTrue(filtered.contains("Windows, cmd.exe uses OEM code page"));
+        assertFalse(filtered.contains("Let me search"));
+        assertFalse(filtered.contains("I'll read"));
+    }
+
+    @Test
+    void filter_preservesAllSubstantiveContent() {
+        String input = "We decided to use Gradle 8.x with the IntelliJ Platform Plugin 2.x.";
+        assertEquals(input, NarrationFilter.filter(input));
+    }
+
+    @Test
+    void filter_collapsesConsecutiveBlanks() {
+        String input = """
+            First line of substance.
+            Let me check the output.
+            
+            I'll read the tests.
+            Second line of substance.""";
+
+        String filtered = NarrationFilter.filter(input);
+
+        assertTrue(filtered.contains("First line of substance."));
+        assertTrue(filtered.contains("Second line of substance."));
+        assertFalse(filtered.contains("\n\n\n"));
+    }
+
+    @Test
+    void filter_emptyInput() {
+        assertEquals("", NarrationFilter.filter(""));
+        assertEquals("", NarrationFilter.filter("   "));
+    }
+}


### PR DESCRIPTION
## Summary

Comprehensive quality improvements across all 6 stages of the memory mining pipeline.

### Phase 1: Narration & Evidence Separation
- **NarrationFilter** — strips agent operational text ("I'll use...", "Let me search...") from responses before mining
- **Evidence separation** — tool results now only store file path metadata, not raw tool output

### Phase 2: Triple Extraction Quality
- **Negation guard** — skips sentences containing negation ("never", "don't", "avoid")
- **Clause boundary stops** — prevents over-capture ("by", "because", "when" etc. end the object)
- **Object trimming** — MAX_OBJECT_WORDS reduced 10→8, trailing prepositions stripped
- **Cross-run dedup** — `existsValidTriple()` check prevents duplicate triples across mines

### Phase 3: Embedding Preprocessing
- **TextPreprocessor** — shared markdown stripping + response-first embedding text construction
- Response text placed before prompt text (information-denser, earlier tokens weighted more in 256-token window)

### Phase 4: Wake-up Diversity
- **`getTopDrawersDiverse()`** — round-robin room selection ensures at least one drawer per room before any room gets a second

### Phase 5: Classification Confidence
- **MIN_CONFIDENCE=2** threshold for both RoomDetector and MemoryClassifier
- Multi-word patterns/phrases weighted 2x (more diagnostic than single words)

### Phase 6: KG Schema
- **`source_closet` → `source_drawer`** column rename with migration for existing databases
- Compound index `idx_spo_valid` for dedup lookup performance

### Testing
- 8 new NarrationFilter tests
- 7 new TripleExtractor tests (negation guard × 4, object trimming × 3)
- Updated ExchangeChunker, EssentialStoryLayer, MemoryClassifier, RoomDetector tests
- All memory tests pass

See `docs/MEMORY-IMPROVEMENTS.md` for the full design document.