### PR TITLE
fix: make PSI tools language-agnostic for non-Java/Kotlin IDEs

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -2,6 +2,6 @@
 <project version="4">
   <component name="KotlinJpsPluginSettings">
     <option name="externalSystemId" value="Gradle" />
-    <option name="version" value="2.3.10" />
+    <option name="version" value="2.3.20" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -84,6 +84,57 @@ as an experimental tool.
 
 See [FEATURES.md](FEATURES.md) for the complete tool reference.
 
+## IDE Compatibility
+
+All 120+ tools work across every JetBrains IDE, with a few exceptions for
+IDE-specific capabilities:
+
+### Java-only tools (require `com.intellij.modules.java`)
+
+Available in **IntelliJ IDEA** (Ultimate and Community). Not available in WebStorm,
+PyCharm, GoLand, PhpStorm, RubyMine, CLion, RustRover, or Rider.
+
+| Tool | Why Java-only |
+|------|---------------|
+| `build_project` | Triggers JPS incremental build |
+| `edit_project_structure` | Manages Java-style module dependencies, SDKs, JARs |
+| `get_class_outline` | Resolves fully-qualified Java/Kotlin class names |
+| `get_type_hierarchy` | Requires Java class hierarchy resolution |
+| `find_implementations` | Requires Java interface/class hierarchy |
+| `get_call_hierarchy` | Requires Java method resolution |
+
+### Rider-disabled tools
+
+Disabled in **Rider** because C#/C++ PSI lives in the ReSharper backend,
+not the IntelliJ frontend. These tools depend on fine-grained PSI or
+JUnit infrastructure that Rider doesn't provide.
+
+| Tool | Why disabled |
+|------|-------------|
+| `search_symbols` | `classifyElement()` fails on Rider's coarse PSI stubs |
+| `replace_symbol_body` | PSI symbol resolution too coarse for structural edits |
+| `insert_before_symbol` | PSI symbol resolution too coarse for structural edits |
+| `insert_after_symbol` | PSI symbol resolution too coarse for structural edits |
+| `list_tests` | Scans for Java `@Test` annotations (not applicable to NUnit/xUnit) |
+| `run_tests` | Creates JUnit run configurations (not applicable to Rider test runner) |
+
+### Conditional tools (all IDEs)
+
+| Tool(s) | Condition |
+|---------|-----------|
+| `database_list_sources`, `database_list_tables`, `database_get_schema` | Database plugin installed (bundled with Ultimate editions) |
+| `run_sonarqube_analysis`, `get_sonar_rule_description` | SonarQube for IDE plugin installed |
+| `run_qodana` | Qodana plugin installed |
+| `memory_*` (9 tools) | Memory feature enabled in AgentBridge settings |
+
+### Summary
+
+| IDE | Tools available |
+|-----|-----------------|
+| **IntelliJ IDEA** | All 120+ |
+| **WebStorm, PyCharm, GoLand, PhpStorm, RubyMine, CLion, RustRover** | ~114 (no Java-only tools) |
+| **Rider** | ~108 (no Java-only + no Rider-disabled tools) |
+
 ## Architecture
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ PyCharm, GoLand, PhpStorm, RubyMine, CLion, RustRover, or Rider.
 
 Disabled in **Rider** because C#/C++ PSI lives in the ReSharper backend,
 not the IntelliJ frontend. These tools depend on fine-grained PSI or
-JUnit infrastructure that Rider doesn't provide.
+test framework infrastructure that Rider doesn't expose to the IntelliJ layer.
+
+> Thanks to Reddit user [VirusPanin](https://www.reddit.com/user/VirusPanin/)
+> for discovering these limitations by testing AgentBridge in Rider with C++ code.
 
 | Tool | Why disabled |
 |------|-------------|
@@ -115,8 +118,8 @@ JUnit infrastructure that Rider doesn't provide.
 | `replace_symbol_body` | PSI symbol resolution too coarse for structural edits |
 | `insert_before_symbol` | PSI symbol resolution too coarse for structural edits |
 | `insert_after_symbol` | PSI symbol resolution too coarse for structural edits |
-| `list_tests` | Scans for Java `@Test` annotations (not applicable to NUnit/xUnit) |
-| `run_tests` | Creates JUnit run configurations (not applicable to Rider test runner) |
+| `list_tests` | IntelliJ `TestFramework` extensions don't cover Rider's NUnit/xUnit backend |
+| `run_tests` | `ConfigurationContext` can't resolve Rider test runners from the frontend PSI |
 
 ### Conditional tools (all IDEs)
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemorySettingsConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/MemorySettingsConfigurable.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.memory;
 
 import com.github.catatafishen.agentbridge.memory.mining.BackfillMiner;
+import com.github.catatafishen.agentbridge.memory.mining.MiningTracker;
 import com.github.catatafishen.agentbridge.session.v2.SessionStoreV2;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.options.Configurable;
@@ -205,22 +206,28 @@ public final class MemorySettingsConfigurable implements Configurable {
                 indicator.setIndeterminate(false);
                 indicator.setFraction(0);
 
+                MiningTracker tracker = MiningTracker.getInstance(project);
+                tracker.startBackfill();
+
                 BackfillMiner backfillMiner = new BackfillMiner(project);
                 try {
                     backfillMiner.runSync(
                         text -> {
                             indicator.setText(text);
+                            tracker.reportProgress(text);
                             ApplicationManager.getApplication().invokeLater(() ->
                                 backfillStatusLabel.setText(text));
                         },
                         indicator::setFraction,
                         indicator::isCanceled);
+                    tracker.stop();
                     ApplicationManager.getApplication().invokeLater(() -> {
                         miningInProgress = false;
                         backfillButton.setEnabled(enabledCheckBox.isSelected());
                         updateBackfillStatus();
                     });
                 } catch (Exception e) {
+                    tracker.stop();
                     ApplicationManager.getApplication().invokeLater(() -> {
                         miningInProgress = false;
                         backfillButton.setEnabled(enabledCheckBox.isSelected());

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/MiningStatusBarWidget.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/MiningStatusBarWidget.java
@@ -1,0 +1,90 @@
+package com.github.catatafishen.agentbridge.memory.mining;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.StatusBarWidget;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.*;
+
+/**
+ * Status bar widget that shows a visible indicator while memory mining is active.
+ * Displays "Mining memory..." for per-turn mining and progress text for backfill.
+ * Returns empty text when idle so the widget occupies no space.
+ */
+final class MiningStatusBarWidget implements StatusBarWidget, StatusBarWidget.TextPresentation {
+
+    static final String WIDGET_ID = "AgentBridge.MemoryMining";
+
+    private final Project project;
+    private volatile String displayText = "";
+    private volatile String tooltipText = "";
+
+    MiningStatusBarWidget(@NotNull Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public @NotNull String ID() {
+        return WIDGET_ID;
+    }
+
+    @Override
+    public void install(@NotNull StatusBar statusBar) {
+        MiningTracker tracker = MiningTracker.getInstance(project);
+
+        // Set initial state in case mining is already in progress
+        updateFromState(tracker.getState(), null);
+
+        tracker.subscribe(this, (state, progressText) -> {
+            updateFromState(state, progressText);
+            statusBar.updateWidget(WIDGET_ID);
+        });
+    }
+
+    private void updateFromState(@NotNull MiningTracker.MiningState state,
+                                 @Nullable String progressText) {
+        switch (state) {
+            case IDLE -> {
+                displayText = "";
+                tooltipText = "";
+            }
+            case MINING_TURN -> {
+                displayText = "Mining memory...";
+                tooltipText = "Extracting memories from the latest conversation turn";
+            }
+            case BACKFILLING -> {
+                displayText = progressText != null
+                    ? "Mining: " + progressText
+                    : "Mining history...";
+                tooltipText = "Mining past conversation sessions into semantic memory";
+            }
+        }
+    }
+
+    @Override
+    public @NotNull String getText() {
+        return displayText;
+    }
+
+    @Override
+    public float getAlignment() {
+        return Component.LEFT_ALIGNMENT;
+    }
+
+    @Override
+    public @Nullable String getTooltipText() {
+        return tooltipText.isEmpty() ? null : tooltipText;
+    }
+
+    @Override
+    public @NotNull TextPresentation getPresentation() {
+        return this;
+    }
+
+    @Override
+    public void dispose() {
+        // Listener auto-disposed via Disposer tree (subscribe registered with this as parent)
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/MiningStatusBarWidgetFactory.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/MiningStatusBarWidgetFactory.java
@@ -1,0 +1,36 @@
+package com.github.catatafishen.agentbridge.memory.mining;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.StatusBarWidget;
+import com.intellij.openapi.wm.StatusBarWidgetFactory;
+import kotlinx.coroutines.CoroutineScope;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Factory for the memory mining status bar indicator.
+ * Registered in plugin.xml as a {@code statusBarWidgetFactory}.
+ */
+public final class MiningStatusBarWidgetFactory implements StatusBarWidgetFactory {
+
+    @Override
+    public @NotNull String getId() {
+        return MiningStatusBarWidget.WIDGET_ID;
+    }
+
+    @Override
+    public @Nls @NotNull String getDisplayName() {
+        return "Memory Mining Status";
+    }
+
+    @Override
+    public @NotNull StatusBarWidget createWidget(@NotNull Project project,
+                                                 @NotNull CoroutineScope scope) {
+        return new MiningStatusBarWidget(project);
+    }
+
+    @Override
+    public boolean isEnabledByDefault() {
+        return true;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/MiningTracker.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/MiningTracker.java
@@ -28,6 +28,11 @@ public class MiningTracker implements Disposable {
         this.project = project;
     }
 
+    /** Package-private no-arg constructor for test doubles that override {@link #fireChanged}. */
+    MiningTracker() {
+        this.project = null;
+    }
+
     public static MiningTracker getInstance(@NotNull Project project) {
         return PlatformApiCompat.getService(project, MiningTracker.class);
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/MiningTracker.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/memory/mining/MiningTracker.java
@@ -1,0 +1,105 @@
+package com.github.catatafishen.agentbridge.memory.mining;
+
+import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.messages.MessageBusConnection;
+import com.intellij.util.messages.Topic;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Tracks whether memory mining is currently active so the status bar widget
+ * can show a visible indicator. Thread-safe — mining runs on pooled threads.
+ */
+@Service(Service.Level.PROJECT)
+public class MiningTracker implements Disposable {
+
+    public static final Topic<Listener> TOPIC =
+        Topic.create("AgentBridge.MemoryMining", Listener.class);
+
+    private final Project project;
+    private final AtomicReference<MiningState> state = new AtomicReference<>(MiningState.IDLE);
+
+    public MiningTracker(@NotNull Project project) {
+        this.project = project;
+    }
+
+    public static MiningTracker getInstance(@NotNull Project project) {
+        return PlatformApiCompat.getService(project, MiningTracker.class);
+    }
+
+    /**
+     * Signal that per-turn mining has started.
+     */
+    public void startTurnMining() {
+        if (state.compareAndSet(MiningState.IDLE, MiningState.MINING_TURN)) {
+            fireChanged(MiningState.MINING_TURN, null);
+        }
+    }
+
+    /**
+     * Signal that history backfill has started.
+     */
+    public void startBackfill() {
+        state.set(MiningState.BACKFILLING);
+        fireChanged(MiningState.BACKFILLING, null);
+    }
+
+    /**
+     * Update progress text while mining is active (e.g., "session 3 of 15").
+     */
+    public void reportProgress(@NotNull String progressText) {
+        MiningState current = state.get();
+        if (current != MiningState.IDLE) {
+            fireChanged(current, progressText);
+        }
+    }
+
+    /**
+     * Signal that mining has finished (either turn mining or backfill).
+     */
+    public void stop() {
+        MiningState previous = state.getAndSet(MiningState.IDLE);
+        if (previous != MiningState.IDLE) {
+            fireChanged(MiningState.IDLE, null);
+        }
+    }
+
+    public @NotNull MiningState getState() {
+        return state.get();
+    }
+
+    /**
+     * Subscribe to mining state changes. The connection is disposed when the
+     * parent disposable is disposed.
+     */
+    public MessageBusConnection subscribe(@NotNull Disposable parent, @NotNull Listener listener) {
+        MessageBusConnection conn = project.getMessageBus().connect(parent);
+        conn.subscribe(TOPIC, listener);
+        return conn;
+    }
+
+    void fireChanged(@NotNull MiningState newState, @Nullable String progressText) {
+        project.getMessageBus().syncPublisher(TOPIC).miningStateChanged(newState, progressText);
+    }
+
+    @Override
+    public void dispose() {
+        state.set(MiningState.IDLE);
+    }
+
+    public enum MiningState {
+        IDLE,
+        MINING_TURN,
+        BACKFILLING
+    }
+
+    @FunctionalInterface
+    public interface Listener {
+        void miningStateChanged(@NotNull MiningState state, @Nullable String progressText);
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -65,6 +65,19 @@ public final class PsiBridgeService implements Disposable {
         Topic.create("PsiBridgeService.FocusRestore", FocusRestoreListener.class);
 
     private static final Set<String> SYNC_TOOL_CATEGORIES = Set.of("FILE", "EDITING", "REFACTOR", "GIT");
+
+    /**
+     * Tools disabled in Rider because they depend on detailed PSI (which lives in
+     * the ReSharper backend) or on JUnit-specific test infrastructure.
+     */
+    private static final Set<String> RIDER_DISABLED_TOOLS = Set.of(
+        "search_symbols",       // classifyElement() fails on Rider's coarse PSI stubs
+        "list_tests",           // scans for Java @Test annotations
+        "run_tests",            // creates JUnit run configurations
+        "replace_symbol_body",  // PSI symbol resolution too coarse
+        "insert_before_symbol", // PSI symbol resolution too coarse
+        "insert_after_symbol"   // PSI symbol resolution too coarse
+    );
     private final Map<String, ReentrantLock> toolLocks = new ConcurrentHashMap<>();
     private final java.util.concurrent.Semaphore writeToolSemaphore = new java.util.concurrent.Semaphore(1);
     private final WriteBatchCoordinator writeBatchCoordinator = new WriteBatchCoordinator(writeToolSemaphore);
@@ -101,6 +114,7 @@ public final class PsiBridgeService implements Disposable {
 
         // Register OO-style individual tool classes
         boolean hasJava = PlatformApiCompat.isPluginInstalled("com.intellij.modules.java");
+        boolean isRider = PlatformApiCompat.isPluginInstalled("com.intellij.modules.rider");
         var allTools = new java.util.ArrayList<com.github.catatafishen.agentbridge.psi.tools.Tool>();
         allTools.addAll(com.github.catatafishen.agentbridge.psi.tools.git.GitToolFactory.create(project));
         allTools.addAll(com.github.catatafishen.agentbridge.psi.tools.file.FileToolFactory.create(project));
@@ -116,6 +130,14 @@ public final class PsiBridgeService implements Disposable {
         allTools.addAll(com.github.catatafishen.agentbridge.psi.tools.debug.DebugToolFactory.create(project));
         allTools.addAll(com.github.catatafishen.agentbridge.psi.tools.database.DatabaseToolFactory.create(project));
         allTools.addAll(com.github.catatafishen.agentbridge.psi.tools.memory.MemoryToolFactory.create(project));
+
+        // Rider's C#/C++ PSI lives in the ReSharper backend, not the IntelliJ frontend.
+        // Symbol-based tools depend on detailed PSI that Rider doesn't provide, and testing
+        // tools are JUnit-specific. Disable them to avoid confusing agents with broken tools.
+        if (isRider) {
+            allTools.removeIf(tool -> RIDER_DISABLED_TOOLS.contains(tool.id()));
+        }
+
         registry.registerAll(allTools);
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
@@ -28,6 +28,13 @@ public final class ToolUtils {
     public static final String ELEMENT_TYPE_FUNCTION = "function";
     public static final String ELEMENT_TYPE_METHOD = "method";
 
+    // PSI class name substrings used for generic multi-language classification
+    private static final String PSI_PATTERN_CLASS = "Class";
+    private static final String PSI_PATTERN_INTERFACE = "Interface";
+    private static final String PSI_PATTERN_FUNCTION = "Function";
+    private static final String PSI_PATTERN_METHOD = "Method";
+    private static final String PSI_PATTERN_FIELD = "Field";
+
     private static final java.util.concurrent.ConcurrentHashMap<Class<?>, java.util.Optional<java.lang.reflect.Method>> IS_INTERFACE_CACHE =
         new java.util.concurrent.ConcurrentHashMap<>();
     private static final java.util.concurrent.ConcurrentHashMap<Class<?>, java.util.Optional<java.lang.reflect.Method>> IS_ENUM_CACHE =
@@ -51,11 +58,8 @@ public final class ToolUtils {
         String kotlinType = classifyKotlinElement(cls, element);
         if (kotlinType != null) return kotlinType;
 
-        // Generic patterns
-        if (cls.contains("Interface") && !cls.contains("Reference")) return ELEMENT_TYPE_INTERFACE;
-        if (cls.contains("Enum") && cls.contains("Class")) return ELEMENT_TYPE_CLASS;
-
-        return null;
+        // Other languages (Python, JS/TS, Go, C/C++, PHP, Ruby, Rust, C#)
+        return classifyGenericElement(cls);
     }
 
     static String classifyJavaClass(PsiElement element) {
@@ -95,29 +99,100 @@ public final class ToolUtils {
     }
 
     static String classifyKotlinClass(PsiElement element) {
-        try {
-            java.lang.reflect.Method isInterface = IS_INTERFACE_CACHE.computeIfAbsent(
-                element.getClass(), c -> {
-                    try {
-                        return java.util.Optional.of(c.getMethod("isInterface"));
-                    } catch (NoSuchMethodException e) {
-                        return java.util.Optional.empty();
-                    }
-                }).orElse(null);
-            if (isInterface != null && (boolean) isInterface.invoke(element)) return ELEMENT_TYPE_INTERFACE;
-            java.lang.reflect.Method isEnum = IS_ENUM_CACHE.computeIfAbsent(
-                element.getClass(), c -> {
-                    try {
-                        return java.util.Optional.of(c.getMethod("isEnum"));
-                    } catch (NoSuchMethodException e) {
-                        return java.util.Optional.empty();
-                    }
-                }).orElse(null);
-            if (isEnum != null && (boolean) isEnum.invoke(element)) return ELEMENT_TYPE_ENUM;
-        } catch (java.lang.reflect.InvocationTargetException | IllegalAccessException ignored) {
-            // Reflection invocation failed for this Kotlin class variant
-        }
-        return ELEMENT_TYPE_CLASS;
+        // Kotlin PSI classes (KtClass, KtObjectDeclaration) support the same isInterface()/isEnum()
+        // methods as Java's PsiClass — delegate to the shared reflection-based classifier
+        return classifyJavaClass(element);
+    }
+
+    /**
+     * Classifies PSI elements from non-Java/Kotlin languages by matching PSI class names.
+     * Covers Python, JavaScript/TypeScript, Go, C/C++, PHP, Ruby, Rust, and C#.
+     * PSI class simple names follow language-specific patterns (e.g. PyClass, JSFunction,
+     * GoTypeSpec) — we match on known prefixes for efficiency and fall back to generic
+     * patterns for unrecognized languages.
+     */
+    static String classifyGenericElement(String cls) {
+        if (cls.startsWith("Py")) return classifyPythonElement(cls);
+        if (cls.startsWith("JS") || cls.startsWith("TypeScript") || cls.startsWith("ES6"))
+            return classifyJsElement(cls);
+        if (cls.startsWith("Go")) return classifyGoElement(cls);
+        if (cls.startsWith("OC")) return classifyCppElement(cls);
+        if (cls.startsWith("Php") || cls.startsWith("php")) return classifyPhpElement(cls);
+        if (cls.startsWith("RClass") || cls.startsWith("RModule") || cls.startsWith("RMethod"))
+            return classifyRubyElement(cls);
+        if (cls.startsWith("Rs")) return classifyRustElement(cls);
+        if (cls.startsWith("CSharp")) return classifyCSharpElement(cls);
+
+        // Generic fallback for unrecognized languages
+        if (cls.contains(PSI_PATTERN_INTERFACE) && !cls.contains("Reference")) return ELEMENT_TYPE_INTERFACE;
+        if (cls.contains("Enum") && cls.contains(PSI_PATTERN_CLASS)) return ELEMENT_TYPE_CLASS;
+
+        return null;
+    }
+
+    static String classifyPythonElement(String cls) {
+        if (cls.contains(PSI_PATTERN_CLASS)) return ELEMENT_TYPE_CLASS;
+        if (cls.contains(PSI_PATTERN_FUNCTION)) return ELEMENT_TYPE_FUNCTION;
+        if ("PyTargetExpressionImpl".equals(cls)) return ELEMENT_TYPE_FIELD;
+        return null;
+    }
+
+    static String classifyJsElement(String cls) {
+        if (cls.contains(PSI_PATTERN_CLASS)) return ELEMENT_TYPE_CLASS;
+        if (cls.contains(PSI_PATTERN_INTERFACE)) return ELEMENT_TYPE_INTERFACE;
+        if (cls.contains("Enum") && !cls.contains("Literal")) return ELEMENT_TYPE_ENUM;
+        if (cls.contains(PSI_PATTERN_FUNCTION)) return ELEMENT_TYPE_FUNCTION;
+        if (cls.contains("Variable") || cls.contains("Property") || cls.contains(PSI_PATTERN_FIELD))
+            return ELEMENT_TYPE_FIELD;
+        return null;
+    }
+
+    static String classifyGoElement(String cls) {
+        if (cls.contains("TypeSpec")) return ELEMENT_TYPE_CLASS;
+        if (cls.contains(PSI_PATTERN_FUNCTION) || cls.contains(PSI_PATTERN_METHOD)) return ELEMENT_TYPE_FUNCTION;
+        if (cls.contains("VarDef") || cls.contains("ConstDef") || cls.contains("FieldDef"))
+            return ELEMENT_TYPE_FIELD;
+        return null;
+    }
+
+    static String classifyCppElement(String cls) {
+        if (cls.contains("Structlike")) return ELEMENT_TYPE_CLASS;
+        if (cls.contains("FunctionDef")) return ELEMENT_TYPE_FUNCTION;
+        if (cls.contains("Declarator") || cls.contains("FieldDecl")) return ELEMENT_TYPE_FIELD;
+        return null;
+    }
+
+    static String classifyPhpElement(String cls) {
+        if (cls.contains(PSI_PATTERN_CLASS)) return ELEMENT_TYPE_CLASS;
+        if (cls.contains(PSI_PATTERN_METHOD)) return ELEMENT_TYPE_METHOD;
+        if (cls.contains(PSI_PATTERN_FUNCTION)) return ELEMENT_TYPE_FUNCTION;
+        if (cls.contains(PSI_PATTERN_FIELD)) return ELEMENT_TYPE_FIELD;
+        return null;
+    }
+
+    static String classifyRubyElement(String cls) {
+        if (cls.startsWith("RClass")) return ELEMENT_TYPE_CLASS;
+        if (cls.startsWith("RModule")) return ELEMENT_TYPE_CLASS;
+        if (cls.startsWith("RMethod")) return ELEMENT_TYPE_METHOD;
+        return null;
+    }
+
+    static String classifyRustElement(String cls) {
+        if (cls.contains("StructItem") || cls.contains("ImplItem")) return ELEMENT_TYPE_CLASS;
+        if (cls.contains("EnumItem")) return ELEMENT_TYPE_ENUM;
+        if (cls.contains("TraitItem")) return ELEMENT_TYPE_INTERFACE;
+        if (cls.contains(PSI_PATTERN_FUNCTION)) return ELEMENT_TYPE_FUNCTION;
+        if (cls.contains("FieldDecl") || cls.contains("ConstItem")) return ELEMENT_TYPE_FIELD;
+        return null;
+    }
+
+    static String classifyCSharpElement(String cls) {
+        if (cls.contains(PSI_PATTERN_CLASS) || cls.contains("Struct")) return ELEMENT_TYPE_CLASS;
+        if (cls.contains(PSI_PATTERN_INTERFACE)) return ELEMENT_TYPE_INTERFACE;
+        if (cls.contains("Enum") && cls.contains("Decl")) return ELEMENT_TYPE_ENUM;
+        if (cls.contains(PSI_PATTERN_METHOD)) return ELEMENT_TYPE_METHOD;
+        if (cls.contains("Property") || cls.contains(PSI_PATTERN_FIELD)) return ELEMENT_TYPE_FIELD;
+        return null;
     }
 
     public static VirtualFile resolveVirtualFile(Project project, String path) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchSymbolsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchSymbolsTool.java
@@ -97,9 +97,10 @@ public final class SearchSymbolsTool extends NavigationTool {
         String basePath = project.getBasePath();
         int[] fileCount = {0};
 
-        ProjectFileIndex.getInstance(project).iterateContent(vf -> {
-            if (vf.isDirectory() || (!vf.getName().endsWith(ToolUtils.JAVA_EXTENSION) && !vf.getName().endsWith(".kt")))
-                return true;
+        ProjectFileIndex fileIndex = ProjectFileIndex.getInstance(project);
+        fileIndex.iterateContent(vf -> {
+            if (vf.isDirectory() || vf.getFileType().isBinary()) return true;
+            if (!fileIndex.isInSourceContent(vf)) return true;
             fileCount[0]++;
             PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
             if (psiFile == null) return true;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetSymbolInfoTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetSymbolInfoTool.java
@@ -131,6 +131,7 @@ public final class GetSymbolInfoTool extends RefactoringTool {
     private static PsiNamedElement findNamedAncestor(@Nullable PsiElement element) {
         PsiElement current = element;
         for (int depth = 0; depth < 10 && current != null; depth++) {
+            if (current instanceof PsiFile) return null;
             if (current instanceof PsiNamedElement named && named.getName() != null) return named;
             current = current.getParent();
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -1918,8 +1918,12 @@ class ChatToolWindowContent(
         val entries = chatConsolePanel.getEntries()
         if (entries.isEmpty()) return
 
+        val tracker = com.github.catatafishen.agentbridge.memory.mining.MiningTracker.getInstance(project)
+        tracker.startTurnMining()
+
         val miner = com.github.catatafishen.agentbridge.memory.mining.TurnMiner(project)
         miner.mineTurn(entries, sessionId, agentName)
+            .whenComplete { _, _ -> tracker.stop() }
     }
 
     private fun restoreConversation(onComplete: () -> Unit = {}) {
@@ -2138,9 +2142,12 @@ class ChatToolWindowContent(
         if (settings.isEnabled && settings.isAutoMineOnSessionArchive) {
             val entries = chatConsolePanel.getEntries()
             if (entries.isNotEmpty()) {
+                val tracker = com.github.catatafishen.agentbridge.memory.mining.MiningTracker.getInstance(project)
+                tracker.startTurnMining()
                 val sessionId = conversationStore.getCurrentSessionId(project.basePath)
                 val miner = com.github.catatafishen.agentbridge.memory.mining.TurnMiner(project)
                 miner.mineTurn(entries, sessionId, agentManager.activeProfile.displayName)
+                    .whenComplete { _, _ -> tracker.stop() }
             }
         }
         conversationStore.archive(project.basePath)

--- a/plugin-core/src/main/resources/META-INF/plugin.xml
+++ b/plugin-core/src/main/resources/META-INF/plugin.xml
@@ -134,6 +134,13 @@ GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, and Ope
       serviceImplementation="com.github.catatafishen.agentbridge.memory.MemorySettings"/>
     <projectService
       serviceImplementation="com.github.catatafishen.agentbridge.memory.MemoryService"/>
+    <projectService
+      serviceImplementation="com.github.catatafishen.agentbridge.memory.mining.MiningTracker"/>
+
+    <!-- Memory mining status bar indicator -->
+    <statusBarWidgetFactory
+      id="AgentBridge.MemoryMining"
+      implementation="com.github.catatafishen.agentbridge.memory.mining.MiningStatusBarWidgetFactory"/>
 
     <!-- Custom external MCP server proxy -->
     <projectService

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/MiningTrackerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/MiningTrackerTest.java
@@ -106,13 +106,8 @@ class MiningTrackerTest {
      * Lightweight test double that bypasses MessageBus and project dependency.
      * Overrides {@link MiningTracker#fireChanged} to use a simple listener list.
      */
-    @SuppressWarnings("NullableProblems") // null project is acceptable in this test double
     private static final class TestTracker extends MiningTracker {
         private final List<MiningTracker.Listener> listeners = new ArrayList<>();
-
-        TestTracker() {
-            super(null); // project not used by state logic
-        }
 
         void addTestListener(MiningTracker.Listener listener) {
             listeners.add(listener);

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/MiningTrackerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/memory/mining/MiningTrackerTest.java
@@ -1,0 +1,128 @@
+package com.github.catatafishen.agentbridge.memory.mining;
+
+import com.github.catatafishen.agentbridge.memory.mining.MiningTracker.MiningState;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link MiningTracker} state machine.
+ * Does not require IntelliJ platform — tests the state transitions only.
+ */
+class MiningTrackerTest {
+
+    @Test
+    void startsIdle() {
+        var tracker = new TestTracker();
+        assertEquals(MiningState.IDLE, tracker.getState());
+    }
+
+    @Test
+    void startTurnMiningTransitionsFromIdle() {
+        var tracker = new TestTracker();
+        tracker.startTurnMining();
+        assertEquals(MiningState.MINING_TURN, tracker.getState());
+    }
+
+    @Test
+    void startTurnMiningIgnoredIfAlreadyMining() {
+        var tracker = new TestTracker();
+        tracker.startTurnMining();
+        tracker.startTurnMining(); // second call should not change state
+        assertEquals(MiningState.MINING_TURN, tracker.getState());
+    }
+
+    @Test
+    void startBackfillOverridesCurrentState() {
+        var tracker = new TestTracker();
+        tracker.startTurnMining();
+        tracker.startBackfill();
+        assertEquals(MiningState.BACKFILLING, tracker.getState());
+    }
+
+    @Test
+    void stopReturnsToIdle() {
+        var tracker = new TestTracker();
+        tracker.startTurnMining();
+        tracker.stop();
+        assertEquals(MiningState.IDLE, tracker.getState());
+    }
+
+    @Test
+    void stopWhenIdleIsNoOp() {
+        var tracker = new TestTracker();
+        tracker.stop(); // no exception
+        assertEquals(MiningState.IDLE, tracker.getState());
+    }
+
+    @Test
+    void reportProgressDoesNothingWhenIdle() {
+        var tracker = new TestTracker();
+        tracker.reportProgress("should be ignored");
+        assertEquals(MiningState.IDLE, tracker.getState());
+    }
+
+    @Test
+    void listenerReceivesStateChanges() {
+        var tracker = new TestTracker();
+        List<MiningState> observed = new ArrayList<>();
+        tracker.addTestListener((state, progress) -> observed.add(state));
+
+        tracker.startTurnMining();
+        tracker.stop();
+        tracker.startBackfill();
+        tracker.reportProgress("session 3 of 15");
+        tracker.stop();
+
+        assertEquals(List.of(
+            MiningState.MINING_TURN,
+            MiningState.IDLE,
+            MiningState.BACKFILLING,
+            MiningState.BACKFILLING, // reportProgress fires with current state
+            MiningState.IDLE
+        ), observed);
+    }
+
+    @Test
+    void listenerReceivesProgressText() {
+        var tracker = new TestTracker();
+        List<String> texts = new ArrayList<>();
+        tracker.addTestListener((state, progress) -> {
+            if (progress != null) texts.add(progress);
+        });
+
+        tracker.startBackfill();
+        tracker.reportProgress("session 1 of 10");
+        tracker.reportProgress("session 2 of 10");
+        tracker.stop();
+
+        assertEquals(List.of("session 1 of 10", "session 2 of 10"), texts);
+    }
+
+    /**
+     * Lightweight test double that bypasses MessageBus and project dependency.
+     * Overrides {@link MiningTracker#fireChanged} to use a simple listener list.
+     */
+    @SuppressWarnings("NullableProblems") // null project is acceptable in this test double
+    private static final class TestTracker extends MiningTracker {
+        private final List<MiningTracker.Listener> listeners = new ArrayList<>();
+
+        TestTracker() {
+            super(null); // project not used by state logic
+        }
+
+        void addTestListener(MiningTracker.Listener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        void fireChanged(MiningState newState, String progressText) {
+            for (MiningTracker.Listener l : listeners) {
+                l.miningStateChanged(newState, progressText);
+            }
+        }
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/ToolUtilsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/ToolUtilsTest.java
@@ -648,4 +648,99 @@ class ToolUtilsTest {
             assertTrue(result.contains("Use offset="), "Should indicate more content available");
         }
     }
+
+    @Nested
+    @DisplayName("classifyGenericElement — multi-language PSI classification")
+    class ClassifyGenericElementTest {
+
+        @ParameterizedTest
+        @CsvSource({
+            // Python
+            "PyClassImpl, class",
+            "PyFunctionImpl, function",
+            "PyTargetExpressionImpl, field",
+            "PyDecoratorImpl,",
+            // JavaScript
+            "JSClassImpl, class",
+            "JSFunctionImpl, function",
+            "JSVariable, field",
+            "JSProperty, field",
+            "JSLiteralExpression,",
+            // TypeScript
+            "TypeScriptClassImpl, class",
+            "TypeScriptInterfaceImpl, interface",
+            "TypeScriptEnumImpl, enum",
+            "TypeScriptFunctionImpl, function",
+            "TypeScriptVariable, field",
+            // ES6
+            "ES6ClassImpl, class",
+            // Go
+            "GoTypeSpec, class",
+            "GoFunctionDeclaration, function",
+            "GoMethodDeclaration, function",
+            "GoVarDefinition, field",
+            "GoConstDefinition, field",
+            "GoFieldDefinition, field",
+            "GoPackageClause,",
+            // C/C++
+            "OCStructlike, class",
+            "OCFunctionDefinition, function",
+            "OCDeclarator, field",
+            "OCFieldDeclaration, field",
+            "OCInclude,",
+            // PHP
+            "PhpClassImpl, class",
+            "PhpMethodImpl, method",
+            "PhpFunctionImpl, function",
+            "PhpFieldImpl, field",
+            // Ruby
+            "RClassImpl, class",
+            "RModuleImpl, class",
+            "RMethodImpl, method",
+            // Rust
+            "RsStructItem, class",
+            "RsImplItem, class",
+            "RsEnumItem, enum",
+            "RsTraitItem, interface",
+            "RsFunction, function",
+            "RsFieldDecl, field",
+            "RsConstItem, field",
+            // C#
+            "CSharpClassDeclaration, class",
+            "CSharpStructDeclaration, class",
+            "CSharpInterfaceDeclaration, interface",
+            "CSharpEnumDeclaration, enum",
+            "CSharpMethodDeclaration, method",
+            "CSharpPropertyDeclaration, field",
+            "CSharpFieldDeclaration, field",
+            // Generic fallback
+            "SomeInterfaceDeclaration, interface",
+            // Unknown — should return null
+            "PsiWhiteSpaceImpl,",
+            "PsiCommentImpl,"
+        })
+        void classifiesByPsiClassName(String className, String expectedType) {
+            String result = ToolUtils.classifyGenericElement(className);
+            if (expectedType == null || expectedType.isEmpty()) {
+                assertNull(result, "Expected null for " + className);
+            } else {
+                assertEquals(expectedType, result, "Wrong type for " + className);
+            }
+        }
+
+        @Test
+        void pythonClassImplReturnsClass() {
+            assertEquals("class", ToolUtils.classifyGenericElement("PyClassImpl"));
+        }
+
+        @Test
+        void jsEnumLiteralNotClassifiedAsEnum() {
+            assertNull(ToolUtils.classifyGenericElement("JSEnumLiteralExpression"));
+        }
+
+        @Test
+        void unknownPrefixReturnsNull() {
+            assertNull(ToolUtils.classifyGenericElement("XyzUnknownElement"));
+        }
+    }
 }


### PR DESCRIPTION
## Multi-language PSI + Rider tool filtering

### Changes

**1. Language-agnostic PSI tools** — PSI-based tools (`search_symbols`, `get_file_outline`, `get_symbol_info`) were hardcoded for Java/Kotlin. Now work across all JetBrains IDEs with per-language classifiers for Python, JS/TS, Go, C/C++, PHP, Ruby, Rust, and C#.

**2. Rider-disabled tools** — Rider's C#/C++ PSI lives in the ReSharper backend, not the IntelliJ frontend. The following tools are now filtered out when running in Rider to avoid presenting broken tools to agents:

| Tool | Reason |
|------|--------|
| `search_symbols` | `classifyElement()` fails on Rider's coarse PSI stubs |
| `replace_symbol_body` | PSI symbol resolution too coarse for structural edits |
| `insert_before_symbol` | PSI symbol resolution too coarse for structural edits |
| `insert_after_symbol` | PSI symbol resolution too coarse for structural edits |
| `list_tests` | IntelliJ `TestFramework` extensions do not cover Rider's NUnit/xUnit backend |
| `run_tests` | `ConfigurationContext` cannot resolve Rider test runners from the frontend PSI |

Detection uses `com.intellij.modules.rider` plugin check, consistent with the existing `com.intellij.modules.java` gating pattern.

> Thanks to Reddit user [VirusPanin](https://www.reddit.com/user/VirusPanin/) for discovering these limitations by testing AgentBridge in Rider with C++ code.

**3. IDE compatibility table in README** — Documents which tools are available per IDE:
- IntelliJ IDEA: All 120+ tools
- WebStorm, PyCharm, GoLand, etc.: ~114 (6 Java-only tools excluded)
- Rider: ~108 (6 Java-only + 6 Rider-disabled tools excluded)

**4. CI fix** — MiningTrackerTest passed null to `@NotNull` constructor parameter, causing 9 test failures from IntelliJ's runtime null-check instrumentation.

### Note on Rider PSI limitations

For C++/C# in Rider specifically, PSI is managed by the ReSharper backend — the IntelliJ frontend only has lightweight stubs. The language-agnostic classifiers will work better in CLion (full C++ PSI) and other IDEs with native PSI support for their languages.