### PR TITLE
fix: make tools language-agnostic across all JetBrains IDEs

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -2,6 +2,6 @@
 <project version="4">
   <component name="KotlinJpsPluginSettings">
     <option name="externalSystemId" value="Gradle" />
-    <option name="version" value="2.3.10" />
+    <option name="version" value="2.3.20" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -2,6 +2,6 @@
 <project version="4">
   <component name="KotlinJpsPluginSettings">
     <option name="externalSystemId" value="Gradle" />
-    <option name="version" value="2.3.20" />
+    <option name="version" value="2.3.10" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -84,6 +84,57 @@ as an experimental tool.
 
 See [FEATURES.md](FEATURES.md) for the complete tool reference.
 
+## IDE Compatibility
+
+All 120+ tools work across every JetBrains IDE, with a few exceptions for
+IDE-specific capabilities:
+
+### Java-only tools (require `com.intellij.modules.java`)
+
+Available in **IntelliJ IDEA** (Ultimate and Community). Not available in WebStorm,
+PyCharm, GoLand, PhpStorm, RubyMine, CLion, RustRover, or Rider.
+
+| Tool | Why Java-only |
+|------|---------------|
+| `build_project` | Triggers JPS incremental build |
+| `edit_project_structure` | Manages Java-style module dependencies, SDKs, JARs |
+| `get_class_outline` | Resolves fully-qualified Java/Kotlin class names |
+| `get_type_hierarchy` | Requires Java class hierarchy resolution |
+| `find_implementations` | Requires Java interface/class hierarchy |
+| `get_call_hierarchy` | Requires Java method resolution |
+
+### Rider-disabled tools
+
+Disabled in **Rider** because C#/C++ PSI lives in the ReSharper backend,
+not the IntelliJ frontend. These tools depend on fine-grained PSI or
+JUnit infrastructure that Rider doesn't provide.
+
+| Tool | Why disabled |
+|------|-------------|
+| `search_symbols` | `classifyElement()` fails on Rider's coarse PSI stubs |
+| `replace_symbol_body` | PSI symbol resolution too coarse for structural edits |
+| `insert_before_symbol` | PSI symbol resolution too coarse for structural edits |
+| `insert_after_symbol` | PSI symbol resolution too coarse for structural edits |
+| `list_tests` | Scans for Java `@Test` annotations (not applicable to NUnit/xUnit) |
+| `run_tests` | Creates JUnit run configurations (not applicable to Rider test runner) |
+
+### Conditional tools (all IDEs)
+
+| Tool(s) | Condition |
+|---------|-----------|
+| `database_list_sources`, `database_list_tables`, `database_get_schema` | Database plugin installed (bundled with Ultimate editions) |
+| `run_sonarqube_analysis`, `get_sonar_rule_description` | SonarQube for IDE plugin installed |
+| `run_qodana` | Qodana plugin installed |
+| `memory_*` (9 tools) | Memory feature enabled in AgentBridge settings |
+
+### Summary
+
+| IDE | Tools available |
+|-----|-----------------|
+| **IntelliJ IDEA** | All 120+ |
+| **WebStorm, PyCharm, GoLand, PhpStorm, RubyMine, CLion, RustRover** | ~114 (no Java-only tools) |
+| **Rider** | ~108 (no Java-only + no Rider-disabled tools) |
+
 ## Architecture
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ PyCharm, GoLand, PhpStorm, RubyMine, CLion, RustRover, or Rider.
 
 Disabled in **Rider** because C#/C++ PSI lives in the ReSharper backend,
 not the IntelliJ frontend. These tools depend on fine-grained PSI or
-JUnit infrastructure that Rider doesn't provide.
+test framework infrastructure that Rider doesn't expose to the IntelliJ layer.
+
+> Thanks to Reddit user [VirusPanin](https://www.reddit.com/user/VirusPanin/)
+> for discovering these limitations by testing AgentBridge in Rider with C++ code.
 
 | Tool | Why disabled |
 |------|-------------|
@@ -115,8 +118,8 @@ JUnit infrastructure that Rider doesn't provide.
 | `replace_symbol_body` | PSI symbol resolution too coarse for structural edits |
 | `insert_before_symbol` | PSI symbol resolution too coarse for structural edits |
 | `insert_after_symbol` | PSI symbol resolution too coarse for structural edits |
-| `list_tests` | Scans for Java `@Test` annotations (not applicable to NUnit/xUnit) |
-| `run_tests` | Creates JUnit run configurations (not applicable to Rider test runner) |
+| `list_tests` | IntelliJ `TestFramework` extensions don't cover Rider's NUnit/xUnit backend |
+| `run_tests` | `ConfigurationContext` can't resolve Rider test runners from the frontend PSI |
 
 ### Conditional tools (all IDEs)
 

--- a/docs/MULTI-IDE-COMPATIBILITY.md
+++ b/docs/MULTI-IDE-COMPATIBILITY.md
@@ -114,7 +114,7 @@ private String buildProject(JsonObject args) {
 
 ## Tool × IDE Availability Matrix
 
-### Tools Available Everywhere (30 tools)
+### Tools Available Everywhere (32 tools)
 
 These use only `com.intellij.modules.platform` APIs:
 
@@ -126,7 +126,7 @@ These use only `com.intellij.modules.platform` APIs:
 | `search_symbols` / `get_file_outline`                                              | CodeNavigationTools |
 | `find_references` / `list_project_files` / `search_text`                           | CodeNavigationTools |
 | `refactor` / `go_to_declaration` / `get_documentation` / `get_symbol_info`         | RefactoringTools    |
-| `get_call_hierarchy`                                                               | RefactoringTools    |
+| `get_call_hierarchy` / `get_type_hierarchy` / `find_implementations`               | RefactoringTools    |
 | `get_problems` / `get_highlights` / `get_compilation_errors`                       | CodeQualityTools    |
 | `run_inspections` / `apply_quickfix`                                               | CodeQualityTools    |
 | `suppress_inspection` / `add_to_dictionary`                                        | CodeQualityTools    |
@@ -143,23 +143,23 @@ These use only `com.intellij.modules.platform` APIs:
 | `run_command` / `http_request`                                                     | InfrastructureTools |
 | `read_ide_log` / `get_notifications` / `read_run_output`                           | InfrastructureTools |
 
-### Java-Only Tools (4 tools)
+### Java-Only Tools (2 tools)
 
 Only registered when `com.intellij.modules.java` is present (IntelliJ IDEA):
 
-| Tool                   | Handler             | Java Support Class          | Fallback for Agents                                           |
-|------------------------|---------------------|-----------------------------|---------------------------------------------------------------|
-| `build_project`        | ProjectTools        | `ProjectBuildSupport`       | Use `run_command` (e.g., `npm run build`, `cargo build`)      |
-| `get_class_outline`    | CodeNavigationTools | `CodeNavigationJavaSupport` | Use `get_file_outline` (works for all languages)              |
-| `get_type_hierarchy`   | RefactoringTools    | `RefactoringJavaSupport`    | Use `search_symbols` + manual navigation                      |
-| `find_implementations` | RefactoringTools    | `RefactoringJavaSupport`    | Use `search_symbols` to find subtypes/implementations by name |
+| Tool                | Handler             | Java Support Class          | Fallback for Agents                                      |
+|---------------------|---------------------|-----------------------------|----------------------------------------------------------|
+| `build_project`     | ProjectTools        | `ProjectBuildSupport`       | Use `run_command` (e.g., `npm run build`, `cargo build`) |
+| `get_class_outline` | CodeNavigationTools | `CodeNavigationJavaSupport` | Use `get_file_outline` (works for all languages)         |
 
 > **Previously Java-only, now available everywhere:**
-> `get_call_hierarchy` was ungated in this refactor — it now uses `PsiNameIdentifierOwner` +
-> `ReferencesSearch` (both base-platform APIs) so it works for Python, Go, TypeScript, and any
-> language with PSI support.
-> `edit_project_structure` was incorrectly gated — it uses `com.intellij.openapi.roots.*` and
+> `get_call_hierarchy` — uses `PsiNameIdentifierOwner` + `ReferencesSearch` (base-platform);
+> works for Python, Go, TypeScript, and any language with PSI support.
+> `edit_project_structure` — was incorrectly gated; uses `com.intellij.openapi.roots.*` and
 > `com.intellij.openapi.projectRoots.*`, which are base-platform APIs available in all IDEs.
+> `find_implementations` and `get_type_hierarchy` (subtypes direction) — when `file`+`line` are
+> provided, uses platform-level `DefinitionsScopedSearch` which works for any language.
+> Supertypes direction and symbol-only lookup remain Java-only.
 
 ### Java-Enhanced Tools (1 tool)
 

--- a/docs/MULTI-IDE-COMPATIBILITY.md
+++ b/docs/MULTI-IDE-COMPATIBILITY.md
@@ -114,7 +114,7 @@ private String buildProject(JsonObject args) {
 
 ## Tool × IDE Availability Matrix
 
-### Tools Available Everywhere (28 tools)
+### Tools Available Everywhere (30 tools)
 
 These use only `com.intellij.modules.platform` APIs:
 
@@ -125,7 +125,8 @@ These use only `com.intellij.modules.platform` APIs:
 | `reload_from_disk`                                                                 | FileTools           |
 | `search_symbols` / `get_file_outline`                                              | CodeNavigationTools |
 | `find_references` / `list_project_files` / `search_text`                           | CodeNavigationTools |
-| `refactor` / `go_to_declaration` / `get_documentation`                             | RefactoringTools    |
+| `refactor` / `go_to_declaration` / `get_documentation` / `get_symbol_info`         | RefactoringTools    |
+| `get_call_hierarchy`                                                               | RefactoringTools    |
 | `get_problems` / `get_highlights` / `get_compilation_errors`                       | CodeQualityTools    |
 | `run_inspections` / `apply_quickfix`                                               | CodeQualityTools    |
 | `suppress_inspection` / `add_to_dictionary`                                        | CodeQualityTools    |
@@ -134,22 +135,31 @@ These use only `com.intellij.modules.platform` APIs:
 | `create_scratch_file` / `list_scratch_files` / `run_scratch_file`                  | EditorTools         |
 | `list_themes` / `set_theme`                                                        | EditorTools         |
 | `get_project_info` / `get_indexing_status` / `mark_directory`                      | ProjectTools        |
-| `download_sources`                                                                 | ProjectTools        |
+| `download_sources` / `edit_project_structure`                                      | ProjectTools        |
+| `list_run_configurations` / `run_configuration`                                    | ProjectTools        |
+| `create_run_configuration` / `edit_run_configuration` / `delete_run_configuration` | ProjectTools        |
+| `get_project_modules` / `get_project_dependencies`                                 | ProjectTools        |
 | `list_tests` / `run_tests` / `get_coverage`                                        | TestTools           |
 | `run_command` / `http_request`                                                     | InfrastructureTools |
 | `read_ide_log` / `get_notifications` / `read_run_output`                           | InfrastructureTools |
-| `list_run_configurations` / `run_configuration`                                    | InfrastructureTools |
-| `create_run_configuration` / `edit_run_configuration` / `delete_run_configuration` | InfrastructureTools |
 
-### Java-Only Tools (3 tools)
+### Java-Only Tools (4 tools)
 
 Only registered when `com.intellij.modules.java` is present (IntelliJ IDEA):
 
-| Tool                 | Handler             | Java Support Class          | Fallback for Agents                                      |
-|----------------------|---------------------|-----------------------------|----------------------------------------------------------|
-| `build_project`      | ProjectTools        | `ProjectBuildSupport`       | Use `run_command` (e.g., `npm run build`, `cargo build`) |
-| `get_class_outline`  | CodeNavigationTools | `CodeNavigationJavaSupport` | Use `get_file_outline` (works for all languages)         |
-| `get_type_hierarchy` | RefactoringTools    | `RefactoringJavaSupport`    | Use `search_symbols` + manual navigation                 |
+| Tool                   | Handler             | Java Support Class          | Fallback for Agents                                           |
+|------------------------|---------------------|-----------------------------|---------------------------------------------------------------|
+| `build_project`        | ProjectTools        | `ProjectBuildSupport`       | Use `run_command` (e.g., `npm run build`, `cargo build`)      |
+| `get_class_outline`    | CodeNavigationTools | `CodeNavigationJavaSupport` | Use `get_file_outline` (works for all languages)              |
+| `get_type_hierarchy`   | RefactoringTools    | `RefactoringJavaSupport`    | Use `search_symbols` + manual navigation                      |
+| `find_implementations` | RefactoringTools    | `RefactoringJavaSupport`    | Use `search_symbols` to find subtypes/implementations by name |
+
+> **Previously Java-only, now available everywhere:**
+> `get_call_hierarchy` was ungated in this refactor — it now uses `PsiNameIdentifierOwner` +
+> `ReferencesSearch` (both base-platform APIs) so it works for Python, Go, TypeScript, and any
+> language with PSI support.
+> `edit_project_structure` was incorrectly gated — it uses `com.intellij.openapi.roots.*` and
+> `com.intellij.openapi.projectRoots.*`, which are base-platform APIs available in all IDEs.
 
 ### Java-Enhanced Tools (1 tool)
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/CallHierarchySupport.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/CallHierarchySupport.java
@@ -4,7 +4,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiNameIdentifierOwner;
 import com.intellij.psi.PsiNamedElement;
-import com.intellij.psi.PsiRecursiveElementWalkingVisitor;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.searches.ReferencesSearch;
@@ -62,23 +61,7 @@ public class CallHierarchySupport {
                                                                         @NotNull String elementName) {
         ToolUtils.LineContext ctx = ToolUtils.resolveLineContext(project, filePath, line);
         if (ctx == null) return null;
-
-        PsiNameIdentifierOwner[] found = {null};
-        ctx.psiFile().accept(new PsiRecursiveElementWalkingVisitor() {
-            @Override
-            public void visitElement(@NotNull PsiElement element) {
-                if (element instanceof PsiNameIdentifierOwner owner && elementName.equals(owner.getName())) {
-                    int offset = owner.getTextOffset();
-                    if (offset >= ctx.lineStart() && offset <= ctx.lineEnd()) {
-                        found[0] = owner;
-                        stopWalking();
-                        return;
-                    }
-                }
-                super.visitElement(element);
-            }
-        });
-        return found[0];
+        return ToolUtils.findNamedElement(ctx, elementName);
     }
 
     private static void appendCallerInfo(@NotNull StringBuilder sb, @NotNull PsiReference ref,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/CallHierarchySupport.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/CallHierarchySupport.java
@@ -1,0 +1,110 @@
+package com.github.catatafishen.agentbridge.psi;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNameIdentifierOwner;
+import com.intellij.psi.PsiNamedElement;
+import com.intellij.psi.PsiRecursiveElementWalkingVisitor;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.searches.ReferencesSearch;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+/**
+ * Language-agnostic call hierarchy support.
+ * <p>
+ * Finds all callers of any named PSI element (method, function, procedure, etc.) by:
+ * <ol>
+ *   <li>Resolving the named element by name + file + line using {@link PsiNameIdentifierOwner}</li>
+ *   <li>Searching for all references using the platform-level {@link ReferencesSearch}</li>
+ * </ol>
+ * Works across all JetBrains IDEs: IntelliJ IDEA (Java/Kotlin), PyCharm (Python),
+ * GoLand (Go), WebStorm (JS/TS), CLion (C/C++), etc.
+ */
+public class CallHierarchySupport {
+
+    private CallHierarchySupport() {
+    }
+
+    /**
+     * Finds all callers of the named element at the given file/line.
+     * Must be called inside a read action.
+     */
+    public static String getCallHierarchy(@NotNull Project project, @NotNull String elementName,
+                                          @NotNull String filePath, int line) {
+        PsiNameIdentifierOwner element = resolveNamedElementAtLocation(project, filePath, line, elementName);
+        if (element == null) {
+            return "Error: Could not find '" + elementName + "' at " + filePath + ":" + line;
+        }
+
+        Collection<PsiReference> references = ReferencesSearch.search(
+            element, GlobalSearchScope.projectScope(project)).findAll();
+        if (references.isEmpty()) {
+            return "No callers found for: " + formatElementSignature(element);
+        }
+
+        String basePath = project.getBasePath();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Callers of ").append(formatElementSignature(element)).append(":\n\n");
+        for (PsiReference ref : references) {
+            appendCallerInfo(sb, ref, basePath);
+        }
+        return sb.toString();
+    }
+
+    private static PsiNameIdentifierOwner resolveNamedElementAtLocation(@NotNull Project project,
+                                                                        @NotNull String filePath,
+                                                                        int line,
+                                                                        @NotNull String elementName) {
+        ToolUtils.LineContext ctx = ToolUtils.resolveLineContext(project, filePath, line);
+        if (ctx == null) return null;
+
+        PsiNameIdentifierOwner[] found = {null};
+        ctx.psiFile().accept(new PsiRecursiveElementWalkingVisitor() {
+            @Override
+            public void visitElement(@NotNull PsiElement element) {
+                if (element instanceof PsiNameIdentifierOwner owner && elementName.equals(owner.getName())) {
+                    int offset = owner.getTextOffset();
+                    if (offset >= ctx.lineStart() && offset <= ctx.lineEnd()) {
+                        found[0] = owner;
+                        stopWalking();
+                        return;
+                    }
+                }
+                super.visitElement(element);
+            }
+        });
+        return found[0];
+    }
+
+    private static void appendCallerInfo(@NotNull StringBuilder sb, @NotNull PsiReference ref,
+                                         @Nullable String basePath) {
+        PsiElement element = ref.getElement();
+        // Walk up the PSI tree to find the nearest named containing element (function/method/class)
+        PsiNamedElement containingNamed = PsiTreeUtil.getParentOfType(element, PsiNamedElement.class);
+
+        sb.append("  ");
+        sb.append(containingNamed != null ? containingNamed.getName() : "(top level)");
+        appendFileLocation(sb, element, basePath);
+        sb.append("\n");
+    }
+
+    private static void appendFileLocation(@NotNull StringBuilder sb, @NotNull PsiElement element,
+                                           @Nullable String basePath) {
+        ToolUtils.appendFileLocation(sb, element, basePath);
+    }
+
+    private static @NotNull String formatElementSignature(@NotNull PsiNameIdentifierOwner element) {
+        PsiElement parent = element.getParent();
+        String name = element.getName();
+        if (name == null) name = "(unknown)";
+        if (parent instanceof PsiNamedElement namedParent && namedParent.getName() != null) {
+            return namedParent.getName() + "." + name + "()";
+        }
+        return name + "()";
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -65,6 +65,19 @@ public final class PsiBridgeService implements Disposable {
         Topic.create("PsiBridgeService.FocusRestore", FocusRestoreListener.class);
 
     private static final Set<String> SYNC_TOOL_CATEGORIES = Set.of("FILE", "EDITING", "REFACTOR", "GIT");
+
+    /**
+     * Tools disabled in Rider because they depend on detailed PSI (which lives in
+     * the ReSharper backend) or on JUnit-specific test infrastructure.
+     */
+    private static final Set<String> RIDER_DISABLED_TOOLS = Set.of(
+        "search_symbols",       // classifyElement() fails on Rider's coarse PSI stubs
+        "list_tests",           // scans for Java @Test annotations
+        "run_tests",            // creates JUnit run configurations
+        "replace_symbol_body",  // PSI symbol resolution too coarse
+        "insert_before_symbol", // PSI symbol resolution too coarse
+        "insert_after_symbol"   // PSI symbol resolution too coarse
+    );
     private final Map<String, ReentrantLock> toolLocks = new ConcurrentHashMap<>();
     private final java.util.concurrent.Semaphore writeToolSemaphore = new java.util.concurrent.Semaphore(1);
     private final WriteBatchCoordinator writeBatchCoordinator = new WriteBatchCoordinator(writeToolSemaphore);
@@ -101,6 +114,7 @@ public final class PsiBridgeService implements Disposable {
 
         // Register OO-style individual tool classes
         boolean hasJava = PlatformApiCompat.isPluginInstalled("com.intellij.modules.java");
+        boolean isRider = PlatformApiCompat.isPluginInstalled("com.intellij.modules.rider");
         var allTools = new java.util.ArrayList<com.github.catatafishen.agentbridge.psi.tools.Tool>();
         allTools.addAll(com.github.catatafishen.agentbridge.psi.tools.git.GitToolFactory.create(project));
         allTools.addAll(com.github.catatafishen.agentbridge.psi.tools.file.FileToolFactory.create(project));
@@ -116,6 +130,14 @@ public final class PsiBridgeService implements Disposable {
         allTools.addAll(com.github.catatafishen.agentbridge.psi.tools.debug.DebugToolFactory.create(project));
         allTools.addAll(com.github.catatafishen.agentbridge.psi.tools.database.DatabaseToolFactory.create(project));
         allTools.addAll(com.github.catatafishen.agentbridge.psi.tools.memory.MemoryToolFactory.create(project));
+
+        // Rider's C#/C++ PSI lives in the ReSharper backend, not the IntelliJ frontend.
+        // Symbol-based tools depend on detailed PSI that Rider doesn't provide, and testing
+        // tools are JUnit-specific. Disable them to avoid confusing agents with broken tools.
+        if (isRider) {
+            allTools.removeIf(tool -> RIDER_DISABLED_TOOLS.contains(tool.id()));
+        }
+
         registry.registerAll(allTools);
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
@@ -5,6 +5,8 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Shared utility methods and constants extracted from PsiBridgeService
@@ -227,6 +229,65 @@ public final class ToolUtils {
         String base = basePath.replace('\\', '/');
         String file = filePath.replace('\\', '/');
         return file.startsWith(base + "/") ? file.substring(base.length() + 1) : file;
+    }
+
+    /**
+     * Appends {@code " (relative/path/to/file:lineNumber)"} to {@code sb} for the given PSI element.
+     * Skips JAR-internal paths (no location to navigate to) and null paths.
+     *
+     * @param sb       string being built
+     * @param element  PSI element whose source location to append
+     * @param basePath project base path for relativizing the file path, or {@code null} to skip
+     */
+    public static void appendFileLocation(@NotNull StringBuilder sb, @NotNull PsiElement element,
+                                          @Nullable String basePath) {
+        com.intellij.psi.PsiFile file = element.getContainingFile();
+        if (file == null || file.getVirtualFile() == null || basePath == null) return;
+        String path = file.getVirtualFile().getPath();
+        if (path.contains(".jar!")) return;
+        sb.append(" (").append(relativize(basePath, path));
+        Document doc = com.intellij.openapi.fileEditor.FileDocumentManager.getInstance()
+            .getDocument(file.getVirtualFile());
+        if (doc != null) {
+            int lineNum = doc.getLineNumber(element.getTextOffset()) + 1;
+            sb.append(":").append(lineNum);
+        }
+        sb.append(")");
+    }
+
+    /**
+     * Resolves the {@link com.intellij.psi.PsiFile} and line offset range for the given file path + line number.
+     * Returns {@code null} if the file cannot be found, parsed, or the line is out of bounds.
+     * <p>
+     * Used to locate PSI elements at a specific source location in a language-agnostic way,
+     * without requiring Java-specific APIs.
+     *
+     * @param project  current project
+     * @param filePath absolute or project-relative path to the file
+     * @param line     1-based line number
+     * @return a {@link LineContext} with the PSI file and offset range, or {@code null}
+     */
+    @Nullable
+    public static LineContext resolveLineContext(@NotNull Project project,
+                                                 @NotNull String filePath,
+                                                 int line) {
+        VirtualFile vf = resolveVirtualFile(project, filePath);
+        if (vf == null) return null;
+        com.intellij.psi.PsiFile psiFile = com.intellij.psi.PsiManager.getInstance(project).findFile(vf);
+        if (psiFile == null) return null;
+        Document document = com.intellij.openapi.fileEditor.FileDocumentManager.getInstance().getDocument(vf);
+        if (document == null || line < 1 || line > document.getLineCount()) return null;
+        return new LineContext(psiFile, document.getLineStartOffset(line - 1), document.getLineEndOffset(line - 1));
+    }
+
+    /**
+     * Holds a resolved PSI file and the character offsets bounding a specific source line.
+     *
+     * @param psiFile   the PSI file
+     * @param lineStart offset of the first character on the line (inclusive)
+     * @param lineEnd   offset of the last character on the line (inclusive)
+     */
+    public record LineContext(@NotNull com.intellij.psi.PsiFile psiFile, int lineStart, int lineEnd) {
     }
 
     public static String getLineText(Document doc, int lineIndex) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
@@ -281,6 +281,40 @@ public final class ToolUtils {
     }
 
     /**
+     * Finds the first {@link com.intellij.psi.PsiNameIdentifierOwner} with the given name whose
+     * text offset falls within the line bounds described by {@code ctx}.
+     * <p>
+     * Shared between {@link CallHierarchySupport} and {@code TypeHierarchySupport} to avoid
+     * duplicating the PSI visitor pattern.
+     *
+     * @param ctx  line context from {@link #resolveLineContext}
+     * @param name symbol name to match
+     * @return the first matching element, or {@code null}
+     */
+    @Nullable
+    public static com.intellij.psi.PsiNameIdentifierOwner findNamedElement(
+        @NotNull LineContext ctx,
+        @NotNull String name) {
+        com.intellij.psi.PsiNameIdentifierOwner[] found = {null};
+        ctx.psiFile().accept(new com.intellij.psi.PsiRecursiveElementWalkingVisitor() {
+            @Override
+            public void visitElement(@NotNull com.intellij.psi.PsiElement element) {
+                if (element instanceof com.intellij.psi.PsiNameIdentifierOwner owner
+                    && name.equals(owner.getName())) {
+                    int offset = owner.getTextOffset();
+                    if (offset >= ctx.lineStart() && offset <= ctx.lineEnd()) {
+                        found[0] = owner;
+                        stopWalking();
+                        return;
+                    }
+                }
+                super.visitElement(element);
+            }
+        });
+        return found[0];
+    }
+
+    /**
      * Holds a resolved PSI file and the character offsets bounding a specific source line.
      *
      * @param psiFile   the PSI file

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
@@ -28,6 +28,13 @@ public final class ToolUtils {
     public static final String ELEMENT_TYPE_FUNCTION = "function";
     public static final String ELEMENT_TYPE_METHOD = "method";
 
+    // PSI class name substrings used for generic multi-language classification
+    private static final String PSI_PATTERN_CLASS = "Class";
+    private static final String PSI_PATTERN_INTERFACE = "Interface";
+    private static final String PSI_PATTERN_FUNCTION = "Function";
+    private static final String PSI_PATTERN_METHOD = "Method";
+    private static final String PSI_PATTERN_FIELD = "Field";
+
     private static final java.util.concurrent.ConcurrentHashMap<Class<?>, java.util.Optional<java.lang.reflect.Method>> IS_INTERFACE_CACHE =
         new java.util.concurrent.ConcurrentHashMap<>();
     private static final java.util.concurrent.ConcurrentHashMap<Class<?>, java.util.Optional<java.lang.reflect.Method>> IS_ENUM_CACHE =
@@ -51,11 +58,8 @@ public final class ToolUtils {
         String kotlinType = classifyKotlinElement(cls, element);
         if (kotlinType != null) return kotlinType;
 
-        // Generic patterns
-        if (cls.contains("Interface") && !cls.contains("Reference")) return ELEMENT_TYPE_INTERFACE;
-        if (cls.contains("Enum") && cls.contains("Class")) return ELEMENT_TYPE_CLASS;
-
-        return null;
+        // Other languages (Python, JS/TS, Go, C/C++, PHP, Ruby, Rust, C#)
+        return classifyGenericElement(cls);
     }
 
     static String classifyJavaClass(PsiElement element) {
@@ -95,29 +99,100 @@ public final class ToolUtils {
     }
 
     static String classifyKotlinClass(PsiElement element) {
-        try {
-            java.lang.reflect.Method isInterface = IS_INTERFACE_CACHE.computeIfAbsent(
-                element.getClass(), c -> {
-                    try {
-                        return java.util.Optional.of(c.getMethod("isInterface"));
-                    } catch (NoSuchMethodException e) {
-                        return java.util.Optional.empty();
-                    }
-                }).orElse(null);
-            if (isInterface != null && (boolean) isInterface.invoke(element)) return ELEMENT_TYPE_INTERFACE;
-            java.lang.reflect.Method isEnum = IS_ENUM_CACHE.computeIfAbsent(
-                element.getClass(), c -> {
-                    try {
-                        return java.util.Optional.of(c.getMethod("isEnum"));
-                    } catch (NoSuchMethodException e) {
-                        return java.util.Optional.empty();
-                    }
-                }).orElse(null);
-            if (isEnum != null && (boolean) isEnum.invoke(element)) return ELEMENT_TYPE_ENUM;
-        } catch (java.lang.reflect.InvocationTargetException | IllegalAccessException ignored) {
-            // Reflection invocation failed for this Kotlin class variant
-        }
-        return ELEMENT_TYPE_CLASS;
+        // Kotlin PSI classes (KtClass, KtObjectDeclaration) support the same isInterface()/isEnum()
+        // methods as Java's PsiClass — delegate to the shared reflection-based classifier
+        return classifyJavaClass(element);
+    }
+
+    /**
+     * Classifies PSI elements from non-Java/Kotlin languages by matching PSI class names.
+     * Covers Python, JavaScript/TypeScript, Go, C/C++, PHP, Ruby, Rust, and C#.
+     * PSI class simple names follow language-specific patterns (e.g. PyClass, JSFunction,
+     * GoTypeSpec) — we match on known prefixes for efficiency and fall back to generic
+     * patterns for unrecognized languages.
+     */
+    static String classifyGenericElement(String cls) {
+        if (cls.startsWith("Py")) return classifyPythonElement(cls);
+        if (cls.startsWith("JS") || cls.startsWith("TypeScript") || cls.startsWith("ES6"))
+            return classifyJsElement(cls);
+        if (cls.startsWith("Go")) return classifyGoElement(cls);
+        if (cls.startsWith("OC")) return classifyCppElement(cls);
+        if (cls.startsWith("Php") || cls.startsWith("php")) return classifyPhpElement(cls);
+        if (cls.startsWith("RClass") || cls.startsWith("RModule") || cls.startsWith("RMethod"))
+            return classifyRubyElement(cls);
+        if (cls.startsWith("Rs")) return classifyRustElement(cls);
+        if (cls.startsWith("CSharp")) return classifyCSharpElement(cls);
+
+        // Generic fallback for unrecognized languages
+        if (cls.contains(PSI_PATTERN_INTERFACE) && !cls.contains("Reference")) return ELEMENT_TYPE_INTERFACE;
+        if (cls.contains("Enum") && cls.contains(PSI_PATTERN_CLASS)) return ELEMENT_TYPE_CLASS;
+
+        return null;
+    }
+
+    static String classifyPythonElement(String cls) {
+        if (cls.contains(PSI_PATTERN_CLASS)) return ELEMENT_TYPE_CLASS;
+        if (cls.contains(PSI_PATTERN_FUNCTION)) return ELEMENT_TYPE_FUNCTION;
+        if ("PyTargetExpressionImpl".equals(cls)) return ELEMENT_TYPE_FIELD;
+        return null;
+    }
+
+    static String classifyJsElement(String cls) {
+        if (cls.contains(PSI_PATTERN_CLASS)) return ELEMENT_TYPE_CLASS;
+        if (cls.contains(PSI_PATTERN_INTERFACE)) return ELEMENT_TYPE_INTERFACE;
+        if (cls.contains("Enum") && !cls.contains("Literal")) return ELEMENT_TYPE_ENUM;
+        if (cls.contains(PSI_PATTERN_FUNCTION)) return ELEMENT_TYPE_FUNCTION;
+        if (cls.contains("Variable") || cls.contains("Property") || cls.contains(PSI_PATTERN_FIELD))
+            return ELEMENT_TYPE_FIELD;
+        return null;
+    }
+
+    static String classifyGoElement(String cls) {
+        if (cls.contains("TypeSpec")) return ELEMENT_TYPE_CLASS;
+        if (cls.contains(PSI_PATTERN_FUNCTION) || cls.contains(PSI_PATTERN_METHOD)) return ELEMENT_TYPE_FUNCTION;
+        if (cls.contains("VarDef") || cls.contains("ConstDef") || cls.contains("FieldDef"))
+            return ELEMENT_TYPE_FIELD;
+        return null;
+    }
+
+    static String classifyCppElement(String cls) {
+        if (cls.contains("Structlike")) return ELEMENT_TYPE_CLASS;
+        if (cls.contains("FunctionDef")) return ELEMENT_TYPE_FUNCTION;
+        if (cls.contains("Declarator") || cls.contains("FieldDecl")) return ELEMENT_TYPE_FIELD;
+        return null;
+    }
+
+    static String classifyPhpElement(String cls) {
+        if (cls.contains(PSI_PATTERN_CLASS)) return ELEMENT_TYPE_CLASS;
+        if (cls.contains(PSI_PATTERN_METHOD)) return ELEMENT_TYPE_METHOD;
+        if (cls.contains(PSI_PATTERN_FUNCTION)) return ELEMENT_TYPE_FUNCTION;
+        if (cls.contains(PSI_PATTERN_FIELD)) return ELEMENT_TYPE_FIELD;
+        return null;
+    }
+
+    static String classifyRubyElement(String cls) {
+        if (cls.startsWith("RClass")) return ELEMENT_TYPE_CLASS;
+        if (cls.startsWith("RModule")) return ELEMENT_TYPE_CLASS;
+        if (cls.startsWith("RMethod")) return ELEMENT_TYPE_METHOD;
+        return null;
+    }
+
+    static String classifyRustElement(String cls) {
+        if (cls.contains("StructItem") || cls.contains("ImplItem")) return ELEMENT_TYPE_CLASS;
+        if (cls.contains("EnumItem")) return ELEMENT_TYPE_ENUM;
+        if (cls.contains("TraitItem")) return ELEMENT_TYPE_INTERFACE;
+        if (cls.contains(PSI_PATTERN_FUNCTION)) return ELEMENT_TYPE_FUNCTION;
+        if (cls.contains("FieldDecl") || cls.contains("ConstItem")) return ELEMENT_TYPE_FIELD;
+        return null;
+    }
+
+    static String classifyCSharpElement(String cls) {
+        if (cls.contains(PSI_PATTERN_CLASS) || cls.contains("Struct")) return ELEMENT_TYPE_CLASS;
+        if (cls.contains(PSI_PATTERN_INTERFACE)) return ELEMENT_TYPE_INTERFACE;
+        if (cls.contains("Enum") && cls.contains("Decl")) return ELEMENT_TYPE_ENUM;
+        if (cls.contains(PSI_PATTERN_METHOD)) return ELEMENT_TYPE_METHOD;
+        if (cls.contains("Property") || cls.contains(PSI_PATTERN_FIELD)) return ELEMENT_TYPE_FIELD;
+        return null;
     }
 
     public static VirtualFile resolveVirtualFile(Project project, String path) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/TypeHierarchySupport.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/TypeHierarchySupport.java
@@ -1,0 +1,73 @@
+package com.github.catatafishen.agentbridge.psi;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNamedElement;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.SearchScope;
+import com.intellij.psi.search.searches.DefinitionsScopedSearch;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+/**
+ * Language-agnostic subtype and implementation search.
+ * Uses {@link DefinitionsScopedSearch}, which delegates to language-specific
+ * query executors (Java, Kotlin, TypeScript, Python, etc.) via extension points.
+ * This means it works wherever the IDE has registered an implementation search,
+ * without any dependency on Java PSI classes.
+ * <p>
+ * Contrast with {@code RefactoringJavaSupport} which uses {@code ClassInheritorsSearch}
+ * and {@code JavaPsiFacade} — those require {@code com.intellij.modules.java}.
+ */
+public class TypeHierarchySupport {
+
+    private TypeHierarchySupport() {
+    }
+
+    /**
+     * Finds all subtypes and direct implementations of the named element at the given
+     * source location. Delegates to {@link DefinitionsScopedSearch} which is language-agnostic.
+     *
+     * @param project  current project
+     * @param filePath absolute or project-relative path to the source file
+     * @param line     1-based line number where the symbol is defined
+     * @param symbol   symbol name (used for display and disambiguation)
+     * @return formatted result text, or an error string starting with {@code "Error: "}
+     */
+    public static @NotNull String findSubtypes(@NotNull Project project,
+                                               @NotNull String filePath,
+                                               int line,
+                                               @NotNull String symbol) {
+        ToolUtils.LineContext ctx = ToolUtils.resolveLineContext(project, filePath, line);
+        if (ctx == null) {
+            return "Error: Could not read '" + filePath + "'. Check the path is correct.";
+        }
+
+        com.intellij.psi.PsiNameIdentifierOwner element = ToolUtils.findNamedElement(ctx, symbol);
+        if (element == null) {
+            return "Error: Symbol '" + symbol + "' not found at " + filePath + ":" + line;
+        }
+
+        SearchScope scope = GlobalSearchScope.projectScope(project);
+        Collection<PsiElement> results = DefinitionsScopedSearch.search(element, scope).findAll();
+
+        if (results.isEmpty()) {
+            return "No subtypes or implementations found for: " + symbol;
+        }
+
+        String basePath = project.getBasePath();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Subtypes/Implementations of ").append(symbol).append(":\n\n");
+        for (PsiElement result : results) {
+            if (result instanceof PsiNamedElement named) {
+                sb.append("  ").append(named.getName());
+            } else {
+                sb.append("  (unnamed)");
+            }
+            ToolUtils.appendFileLocation(sb, result, basePath);
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/java/RefactoringJavaSupport.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/java/RefactoringJavaSupport.java
@@ -4,26 +4,20 @@ import com.github.catatafishen.agentbridge.psi.ToolUtils;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
-import com.intellij.psi.PsiManager;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifier;
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor;
-import com.intellij.psi.PsiReference;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.PsiShortNamesCache;
 import com.intellij.psi.search.searches.ClassInheritorsSearch;
-import com.intellij.psi.search.searches.MethodReferencesSearch;
 import com.intellij.psi.search.searches.OverridingMethodsSearch;
-import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -203,59 +197,18 @@ public class RefactoringJavaSupport {
         return sb.toString();
     }
 
-    /**
-     * Builds a call hierarchy for the given method, listing all callers.
-     *
-     * @param project    current project
-     * @param methodName method name to search for
-     * @param filePath   file containing the method
-     * @param line       line number where the method is defined
-     * @return formatted list of callers, or an error message
-     */
-    public static String getCallHierarchy(Project project, String methodName,
-                                          String filePath, int line) {
-        PsiMethod method = resolveMethodAtLocation(project, filePath, line, methodName);
-        if (method == null) {
-            return "Error: Could not find method '" + methodName + "' at "
-                + filePath + ":" + line;
-        }
-
-        Collection<PsiReference> references = MethodReferencesSearch.search(
-            method, GlobalSearchScope.projectScope(project), true).findAll();
-        if (references.isEmpty()) {
-            return "No callers found for: " + formatMethodSignature(method);
-        }
-
-        String basePath = project.getBasePath();
-        StringBuilder sb = new StringBuilder();
-        sb.append("Callers of ").append(formatMethodSignature(method)).append(HEADER_SUFFIX);
-        for (PsiReference ref : references) {
-            appendCallerInfo(sb, ref, basePath);
-        }
-        return sb.toString();
-    }
-
     private static @Nullable PsiMethod resolveMethodAtLocation(Project project, String filePath,
                                                                int line, String methodName) {
-        VirtualFile vf = ToolUtils.resolveVirtualFile(project, filePath);
-        if (vf == null) return null;
-
-        PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
-        if (psiFile == null) return null;
-
-        Document document = FileDocumentManager.getInstance().getDocument(vf);
-        if (document == null || line < 1 || line > document.getLineCount()) return null;
-
-        int lineStart = document.getLineStartOffset(line - 1);
-        int lineEnd = document.getLineEndOffset(line - 1);
+        ToolUtils.LineContext ctx = com.github.catatafishen.agentbridge.psi.ToolUtils.resolveLineContext(project, filePath, line);
+        if (ctx == null) return null;
 
         PsiMethod[] found = {null};
-        psiFile.accept(new PsiRecursiveElementWalkingVisitor() {
+        ctx.psiFile().accept(new PsiRecursiveElementWalkingVisitor() {
             @Override
             public void visitElement(@NotNull PsiElement element) {
                 if (element instanceof PsiMethod m && methodName.equals(m.getName())) {
                     int offset = m.getTextOffset();
-                    if (offset >= lineStart && offset <= lineEnd) {
+                    if (offset >= ctx.lineStart() && offset <= ctx.lineEnd()) {
                         found[0] = m;
                         stopWalking();
                         return;
@@ -297,37 +250,8 @@ public class RefactoringJavaSupport {
         sb.append("\n");
     }
 
-    private static void appendCallerInfo(StringBuilder sb, PsiReference ref, String basePath) {
-        PsiElement element = ref.getElement();
-        PsiMethod containingMethod = PsiTreeUtil.getParentOfType(element, PsiMethod.class);
-        PsiClass containingClass = PsiTreeUtil.getParentOfType(element, PsiClass.class);
-
-        sb.append("  ");
-        if (containingClass != null) {
-            String className = containingClass.getQualifiedName();
-            sb.append(className != null ? className : containingClass.getName());
-            if (containingMethod != null) {
-                sb.append(".").append(containingMethod.getName()).append("()");
-            }
-        } else {
-            sb.append("(unknown context)");
-        }
-        appendFileLocation(sb, element, basePath);
-        sb.append("\n");
-    }
-
     private static void appendFileLocation(StringBuilder sb, PsiElement element, String basePath) {
-        PsiFile file = element.getContainingFile();
-        if (file == null || file.getVirtualFile() == null || basePath == null) return;
-        String path = file.getVirtualFile().getPath();
-        if (path.contains(JAR_INDICATOR)) return;
-        sb.append(" (").append(ToolUtils.relativize(basePath, path));
-        Document doc = FileDocumentManager.getInstance().getDocument(file.getVirtualFile());
-        if (doc != null) {
-            int lineNum = doc.getLineNumber(element.getTextOffset()) + 1;
-            sb.append(":").append(lineNum);
-        }
-        sb.append(")");
+        com.github.catatafishen.agentbridge.psi.ToolUtils.appendFileLocation(sb, element, basePath);
     }
 
     private static String formatMethodSignature(PsiMethod method) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchSymbolsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchSymbolsTool.java
@@ -97,9 +97,10 @@ public final class SearchSymbolsTool extends NavigationTool {
         String basePath = project.getBasePath();
         int[] fileCount = {0};
 
-        ProjectFileIndex.getInstance(project).iterateContent(vf -> {
-            if (vf.isDirectory() || (!vf.getName().endsWith(ToolUtils.JAVA_EXTENSION) && !vf.getName().endsWith(".kt")))
-                return true;
+        ProjectFileIndex fileIndex = ProjectFileIndex.getInstance(project);
+        fileIndex.iterateContent(vf -> {
+            if (vf.isDirectory() || vf.getFileType().isBinary()) return true;
+            if (!fileIndex.isInSourceContent(vf)) return true;
             fileCount[0]++;
             PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
             if (psiFile == null) return true;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/project/ProjectToolFactory.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/project/ProjectToolFactory.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 /**
  * Factory producing all individual project tool instances.
- * Conditionally includes Java-specific tools based on plugin availability.
+ * Conditionally includes Java-specific tools (e.g., {@link BuildProjectTool}) based on plugin availability.
  */
 public final class ProjectToolFactory {
 
@@ -29,9 +29,7 @@ public final class ProjectToolFactory {
         tools.add(new GetIndexingStatusTool(project));
         tools.add(new DownloadSourcesTool(project));
         tools.add(new MarkDirectoryTool(project));
-        if (hasJava) {
-            tools.add(new EditProjectStructureTool(project));
-        }
+        tools.add(new EditProjectStructureTool(project));
         tools.add(new ListRunConfigurationsTool(project, runConfigService));
         tools.add(new RunConfigurationTool(project, runConfigService));
         tools.add(new CreateRunConfigurationTool(project, runConfigService));

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/FindImplementationsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/FindImplementationsTool.java
@@ -10,14 +10,23 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Finds all implementations of a class/interface or overrides of a method.
+ * <p>
+ * When {@code file} and {@code line} are provided, uses platform-level
+ * {@link com.github.catatafishen.agentbridge.psi.TypeHierarchySupport} via
+ * {@code DefinitionsScopedSearch} — works in any JetBrains IDE.
+ * When only {@code symbol} is given, falls back to Java-specific
+ * {@code RefactoringJavaSupport} (requires IntelliJ IDEA).
  */
 @SuppressWarnings("java:S112")
 public final class FindImplementationsTool extends RefactoringTool {
 
     private static final String PARAM_SYMBOL = "symbol";
 
-    public FindImplementationsTool(Project project) {
+    private final boolean hasJava;
+
+    public FindImplementationsTool(Project project, boolean hasJava) {
         super(project);
+        this.hasJava = hasJava;
     }
 
     @Override
@@ -32,7 +41,13 @@ public final class FindImplementationsTool extends RefactoringTool {
 
     @Override
     public @NotNull String description() {
-        return "Find all implementations of a class/interface or overrides of a method";
+        return """
+            Find all implementations of a class/interface or overrides of a method. \
+            Semantic — finds through interface boundaries and class hierarchies. \
+            When 'file' and 'line' are provided, uses platform-level search that works \
+            for Java, Kotlin, TypeScript, Python, and any language with PSI support. \
+            When only 'symbol' is given (name-based lookup), requires a Java project. \
+            Returns file paths and line numbers.""";
     }
 
     @Override
@@ -49,8 +64,8 @@ public final class FindImplementationsTool extends RefactoringTool {
     public @NotNull JsonObject inputSchema() {
         return schema(
             Param.required(PARAM_SYMBOL, TYPE_STRING, "Class, interface, or method name to find implementations for"),
-            Param.optional("file", TYPE_STRING, "Optional: file path for method context (required when searching for method overrides)"),
-            Param.optional("line", TYPE_INTEGER, "Optional: line number to disambiguate the method (required when searching for method overrides)")
+            Param.optional("file", TYPE_STRING, "File path for method context. Required for non-Java languages; also required when searching for method overrides"),
+            Param.optional("line", TYPE_INTEGER, "Line number to disambiguate the method. Required for non-Java languages; also required when searching for method overrides")
         );
     }
 
@@ -66,10 +81,29 @@ public final class FindImplementationsTool extends RefactoringTool {
         String filePath = args.has("file") ? args.get("file").getAsString() : null;
         int line = args.has("line") ? args.get("line").getAsInt() : 0;
 
-        String result = ApplicationManager.getApplication().runReadAction((Computable<String>) () ->
-            com.github.catatafishen.agentbridge.psi.java.RefactoringJavaSupport
-                .findImplementations(project, symbolName, filePath, line)
-        );
-        return ToolUtils.truncateOutput(result);
+        // Platform path: file+line provided — works for all languages
+        if (filePath != null && line > 0) {
+            final String fp = filePath;
+            final int ln = line;
+            String result = ApplicationManager.getApplication().runReadAction(
+                (Computable<String>) () ->
+                    com.github.catatafishen.agentbridge.psi.TypeHierarchySupport
+                        .findSubtypes(project, fp, ln, symbolName)
+            );
+            return ToolUtils.truncateOutput(result);
+        }
+
+        // Java path: symbol-only lookup via JavaPsiFacade
+        if (hasJava) {
+            String result = ApplicationManager.getApplication().runReadAction(
+                (Computable<String>) () ->
+                    com.github.catatafishen.agentbridge.psi.java.RefactoringJavaSupport
+                        .findImplementations(project, symbolName, null, 0)
+            );
+            return ToolUtils.truncateOutput(result);
+        }
+
+        return "Error: Provide 'file' and 'line' parameters to locate the symbol. " +
+            "Name-based lookup requires a Java project.";
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetCallHierarchyTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetCallHierarchyTool.java
@@ -32,7 +32,7 @@ public final class GetCallHierarchyTool extends RefactoringTool {
 
     @Override
     public @NotNull String description() {
-        return "Find all callers of a method with file paths and line numbers";
+        return "Find all callers of a function, method, or named element with file paths and line numbers";
     }
 
     @Override
@@ -48,9 +48,9 @@ public final class GetCallHierarchyTool extends RefactoringTool {
     @Override
     public @NotNull JsonObject inputSchema() {
         return schema(
-            Param.required(PARAM_SYMBOL, TYPE_STRING, "Method name to find callers for"),
-            Param.required("file", TYPE_STRING, "Path to the file containing the method definition"),
-            Param.required("line", TYPE_INTEGER, "Line number where the method is defined")
+            Param.required(PARAM_SYMBOL, TYPE_STRING, "Function, method, or named element to find callers for"),
+            Param.required("file", TYPE_STRING, "Path to the file containing the definition"),
+            Param.required("line", TYPE_INTEGER, "Line number where the definition is located")
         );
     }
 
@@ -64,13 +64,13 @@ public final class GetCallHierarchyTool extends RefactoringTool {
         if (!args.has(PARAM_SYMBOL) || !args.has("file") || !args.has("line")) {
             return "Error: 'symbol', 'file', and 'line' parameters are required";
         }
-        String methodName = args.get(PARAM_SYMBOL).getAsString();
+        String elementName = args.get(PARAM_SYMBOL).getAsString();
         String filePath = args.get("file").getAsString();
         int line = args.get("line").getAsInt();
 
-        String result = ApplicationManager.getApplication().runReadAction((Computable<String>) () ->
-            com.github.catatafishen.agentbridge.psi.java.RefactoringJavaSupport
-                .getCallHierarchy(project, methodName, filePath, line)
+        String result = ApplicationManager.getApplication().runReadAction(
+            (Computable<String>) () -> com.github.catatafishen.agentbridge.psi.CallHierarchySupport
+                .getCallHierarchy(project, elementName, filePath, line)
         );
         return ToolUtils.truncateOutput(result);
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetSymbolInfoTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetSymbolInfoTool.java
@@ -131,6 +131,7 @@ public final class GetSymbolInfoTool extends RefactoringTool {
     private static PsiNamedElement findNamedAncestor(@Nullable PsiElement element) {
         PsiElement current = element;
         for (int depth = 0; depth < 10 && current != null; depth++) {
+            if (current instanceof PsiFile) return null;
             if (current instanceof PsiNamedElement named && named.getName() != null) return named;
             current = current.getParent();
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetTypeHierarchyTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetTypeHierarchyTool.java
@@ -9,6 +9,10 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Shows supertypes and/or subtypes of a class or interface.
+ * <p>
+ * <b>Subtypes via file+line:</b> Uses platform-level {@code DefinitionsScopedSearch} —
+ * works for Java, Kotlin, TypeScript, Python, and any language with PSI support.
+ * <b>Supertypes, or symbol-only lookup:</b> Uses Java PSI — requires IntelliJ IDEA.
  */
 @SuppressWarnings("java:S112")
 public final class GetTypeHierarchyTool extends RefactoringTool {
@@ -16,8 +20,11 @@ public final class GetTypeHierarchyTool extends RefactoringTool {
     private static final String PARAM_SYMBOL = "symbol";
     private static final String PARAM_DIRECTION = "direction";
 
-    public GetTypeHierarchyTool(Project project) {
+    private final boolean hasJava;
+
+    public GetTypeHierarchyTool(Project project, boolean hasJava) {
         super(project);
+        this.hasJava = hasJava;
     }
 
     @Override
@@ -32,7 +39,12 @@ public final class GetTypeHierarchyTool extends RefactoringTool {
 
     @Override
     public @NotNull String description() {
-        return "Show supertypes and/or subtypes of a class or interface";
+        return """
+            Show supertypes and/or subtypes of a class or interface. \
+            When 'file' and 'line' are provided with direction='subtypes', uses platform-level \
+            DefinitionsScopedSearch — works for Java, Kotlin, TypeScript, Python, and any language \
+            with PSI support. \
+            Supertypes direction and symbol-only (name-based) lookup require a Java project.""";
     }
 
     @Override
@@ -49,7 +61,13 @@ public final class GetTypeHierarchyTool extends RefactoringTool {
     public @NotNull JsonObject inputSchema() {
         return schema(
             Param.required(PARAM_SYMBOL, TYPE_STRING, "Fully qualified or simple class/interface name"),
-            Param.optional(PARAM_DIRECTION, TYPE_STRING, "Direction: 'supertypes' (ancestors) or 'subtypes' (descendants). Default: both")
+            Param.optional(PARAM_DIRECTION, TYPE_STRING,
+                "Direction: 'supertypes' (ancestors) or 'subtypes' (descendants). Default: both. " +
+                    "Non-Java IDEs only support 'subtypes' when 'file' and 'line' are provided."),
+            Param.optional("file", TYPE_STRING,
+                "File path where the symbol is defined. Required for non-Java languages when direction='subtypes'"),
+            Param.optional("line", TYPE_INTEGER,
+                "Line number where the symbol is defined. Required for non-Java languages when direction='subtypes'")
         );
     }
 
@@ -63,10 +81,32 @@ public final class GetTypeHierarchyTool extends RefactoringTool {
         if (!args.has(PARAM_SYMBOL)) return "Error: 'symbol' parameter is required";
         String symbolName = args.get(PARAM_SYMBOL).getAsString();
         String direction = args.has(PARAM_DIRECTION) ? args.get(PARAM_DIRECTION).getAsString() : "both";
+        String filePath = args.has("file") ? args.get("file").getAsString() : null;
+        int line = args.has("line") ? args.get("line").getAsInt() : 0;
 
-        return ApplicationManager.getApplication().runReadAction((Computable<String>) () ->
-            com.github.catatafishen.agentbridge.psi.java.RefactoringJavaSupport
-                .getTypeHierarchy(project, symbolName, direction)
-        );
+        // Platform path: subtypes only, file+line provided — works for all languages
+        if ("subtypes".equals(direction) && filePath != null && line > 0) {
+            final String fp = filePath;
+            final int ln = line;
+            return ApplicationManager.getApplication().runReadAction(
+                (Computable<String>) () ->
+                    com.github.catatafishen.agentbridge.psi.TypeHierarchySupport
+                        .findSubtypes(project, fp, ln, symbolName)
+            );
+        }
+
+        // Java path: supertypes, both directions, or symbol-only lookup
+        if (hasJava) {
+            return ApplicationManager.getApplication().runReadAction((Computable<String>) () ->
+                com.github.catatafishen.agentbridge.psi.java.RefactoringJavaSupport
+                    .getTypeHierarchy(project, symbolName, direction)
+            );
+        }
+
+        if ("subtypes".equals(direction)) {
+            return "Error: Provide 'file' and 'line' parameters to locate the symbol in non-Java projects.";
+        }
+        return "Error: Direction '" + direction + "' requires a Java project. " +
+            "Use direction='subtypes' with 'file' and 'line' for non-Java languages.";
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolFactory.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolFactory.java
@@ -21,10 +21,8 @@ public final class RefactoringToolFactory {
         var tools = new ArrayList<Tool>();
         tools.add(new RefactorTool(project));
         tools.add(new GoToDeclarationTool(project));
-        if (hasJava) {
-            tools.add(new GetTypeHierarchyTool(project));
-            tools.add(new FindImplementationsTool(project));
-        }
+        tools.add(new GetTypeHierarchyTool(project, hasJava));
+        tools.add(new FindImplementationsTool(project, hasJava));
         tools.add(new GetCallHierarchyTool(project));
         tools.add(new GetDocumentationTool(project));
         tools.add(new GetSymbolInfoTool(project));

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolFactory.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolFactory.java
@@ -24,8 +24,8 @@ public final class RefactoringToolFactory {
         if (hasJava) {
             tools.add(new GetTypeHierarchyTool(project));
             tools.add(new FindImplementationsTool(project));
-            tools.add(new GetCallHierarchyTool(project));
         }
+        tools.add(new GetCallHierarchyTool(project));
         tools.add(new GetDocumentationTool(project));
         tools.add(new GetSymbolInfoTool(project));
         return List.copyOf(tools);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/ListTestsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/ListTestsTool.java
@@ -15,6 +15,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.PsiNamedElement;
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor;
+import com.intellij.testIntegration.TestFramework;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -22,6 +23,10 @@ import java.util.List;
 
 /**
  * Lists test classes and methods in the project.
+ * <p>
+ * Uses IntelliJ's {@link TestFramework} extension point for framework-agnostic
+ * test detection — works with JUnit, TestNG, pytest, and any other framework
+ * that registers a {@code TestFramework} implementation.
  */
 public final class ListTestsTool extends TestingTool {
 
@@ -44,6 +49,7 @@ public final class ListTestsTool extends TestingTool {
     @Override
     public @NotNull String description() {
         return "List test classes and methods in the project. Returns fully-qualified test names with file paths and line numbers. " +
+            "Uses IntelliJ's test framework detection — works with JUnit, TestNG, pytest, and any other framework the IDE recognizes. " +
             "Use file_pattern to filter (e.g., '*IntegrationTest*'). Use run_tests to execute discovered tests.";
     }
 
@@ -78,10 +84,11 @@ public final class ListTestsTool extends TestingTool {
             String basePath = project.getBasePath();
             ProjectFileIndex fileIndex = ProjectFileIndex.getInstance(project);
             var compiledGlob = filePattern.isEmpty() ? null : ToolUtils.compileGlob(filePattern);
+            var frameworks = TestFramework.EXTENSION_NAME.getExtensionList();
 
             fileIndex.iterateContent(vf -> {
                 if (isTestSourceFile(vf, filePattern, compiledGlob, fileIndex)) {
-                    collectTestMethodsFromFile(vf, basePath, tests);
+                    collectTestMethodsFromFile(vf, basePath, tests, frameworks);
                 }
                 return tests.size() < 500;
             });
@@ -93,13 +100,12 @@ public final class ListTestsTool extends TestingTool {
 
     private boolean isTestSourceFile(VirtualFile vf, String filePattern, java.util.regex.Pattern compiledGlob, ProjectFileIndex fileIndex) {
         if (vf.isDirectory()) return false;
-        String name = vf.getName();
-        if (!name.endsWith(ToolUtils.JAVA_EXTENSION) && !name.endsWith(".kt")) return false;
-        if (!filePattern.isEmpty() && ToolUtils.doesNotMatchGlob(name, filePattern, compiledGlob)) return false;
-        return fileIndex.isInTestSourceContent(vf);
+        if (!fileIndex.isInTestSourceContent(vf)) return false;
+        return filePattern.isEmpty() || !ToolUtils.doesNotMatchGlob(vf.getName(), filePattern, compiledGlob);
     }
 
-    private void collectTestMethodsFromFile(VirtualFile vf, String basePath, List<String> tests) {
+    private void collectTestMethodsFromFile(VirtualFile vf, String basePath, List<String> tests,
+                                            List<TestFramework> frameworks) {
         PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
         if (psiFile == null) return;
         Document doc = FileDocumentManager.getInstance().getDocument(vf);
@@ -113,7 +119,7 @@ public final class ListTestsTool extends TestingTool {
                 }
                 String type = ToolUtils.classifyElement(element);
                 if ((ToolUtils.ELEMENT_TYPE_METHOD.equals(type) || ToolUtils.ELEMENT_TYPE_FUNCTION.equals(type))
-                    && hasTestAnnotation(element)) {
+                    && isTestElement(element, frameworks)) {
                     String methodName = named.getName();
                     String className = getContainingClassName(element);
                     String relPath = basePath != null ? relativize(basePath, vf.getPath()) : vf.getPath();
@@ -125,46 +131,18 @@ public final class ListTestsTool extends TestingTool {
         });
     }
 
-    private boolean hasTestAnnotation(PsiElement element) {
-        return hasTestAnnotationViaReflection(element) || hasTestAnnotationViaText(element);
-    }
-
-    private boolean hasTestAnnotationViaReflection(PsiElement element) {
-        try {
-            var getModifierList = element.getClass().getMethod("getModifierList");
-            Object modList = getModifierList.invoke(element);
-            if (modList != null) {
-                var getAnnotations = modList.getClass().getMethod("getAnnotations");
-                Object[] annotations = (Object[]) getAnnotations.invoke(modList);
-                for (Object anno : annotations) {
-                    var getQualifiedName = anno.getClass().getMethod("getQualifiedName");
-                    String qname = (String) getQualifiedName.invoke(anno);
-                    if (qname != null && (qname.endsWith(".Test")
-                        || qname.endsWith(".ParameterizedTest")
-                        || qname.endsWith(".RepeatedTest"))) {
-                        return true;
-                    }
-                }
+    /**
+     * Checks if a PSI element is a test method using IntelliJ's registered test frameworks.
+     * Iterates all {@link TestFramework} extensions (JUnit, TestNG, pytest, etc.) and returns
+     * true if any framework recognizes the element as a test method.
+     */
+    private static boolean isTestElement(PsiElement element, List<TestFramework> frameworks) {
+        for (TestFramework framework : frameworks) {
+            try {
+                if (framework.isTestMethod(element)) return true;
+            } catch (Exception ignored) {
+                // Framework may not support this element type — skip silently
             }
-        } catch (Exception ignored) {
-            // Reflection may not work for all element types
-        }
-        return false;
-    }
-
-    private boolean hasTestAnnotationViaText(PsiElement element) {
-        PsiElement prev = element.getPrevSibling();
-        int depth = 0;
-        while (prev != null && depth < 5) {
-            if (prev instanceof PsiNamedElement && ToolUtils.classifyElement(prev) != null) break;
-            String text = prev.getText().trim();
-            if (text.startsWith("@Test") || text.startsWith("@ParameterizedTest")
-                || text.startsWith("@RepeatedTest")
-                || text.startsWith("@org.junit")) {
-                return true;
-            }
-            prev = prev.getPrevSibling();
-            depth++;
         }
         return false;
     }
@@ -178,6 +156,18 @@ public final class ListTestsTool extends TestingTool {
             }
             parent = parent.getParent();
         }
-        return "UnknownClass";
+        return vf(element);
+    }
+
+    /**
+     * Fallback for test elements not inside a class (e.g., top-level Python test functions,
+     * Go test functions). Returns the containing file name without extension.
+     */
+    private static String vf(PsiElement element) {
+        PsiFile file = element.getContainingFile();
+        if (file == null) return "UnknownFile";
+        String name = file.getName();
+        int dot = name.lastIndexOf('.');
+        return dot > 0 ? name.substring(0, dot) : name;
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsTool.java
@@ -8,6 +8,8 @@ import com.github.catatafishen.agentbridge.ui.renderers.TestResultRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.execution.ExecutionManager;
 import com.intellij.execution.RunManager;
+import com.intellij.execution.RunnerAndConfigurationSettings;
+import com.intellij.execution.actions.ConfigurationContext;
 import com.intellij.execution.configurations.ConfigurationType;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.executors.DefaultRunExecutor;
@@ -19,8 +21,13 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.util.Computable;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
+import com.intellij.psi.PsiNamedElement;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.PsiSearchHelper;
+import com.intellij.psi.search.UsageSearchContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -32,7 +39,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Runs tests by class, method, or wildcard pattern.
- * Uses IntelliJ's built-in JUnit runner when possible; falls back to Gradle for unresolvable targets.
+ * <p>
+ * Uses IntelliJ's {@link ConfigurationContext} for framework-agnostic test detection,
+ * falling back to JUnit-specific configuration and Gradle for unresolvable targets.
  */
 @SuppressWarnings("java:S112") // generic exceptions are caught at the JSON-RPC dispatch level
 public final class RunTestsTool extends TestingTool {
@@ -72,7 +81,9 @@ public final class RunTestsTool extends TestingTool {
 
     @Override
     public @NotNull String description() {
-        return "Run tests by class, method, or wildcard pattern. Uses IntelliJ's built-in test runner; falls back to Gradle for unresolvable targets. " +
+        return "Run tests by class, method, or wildcard pattern. Uses IntelliJ's built-in test runner — " +
+            "auto-detects the test framework (JUnit, TestNG, pytest, etc.) via ConfigurationContext. " +
+            "Falls back to Gradle for unresolvable targets. " +
             "Returns pass/fail counts and failure details. Use list_tests to discover available test targets.";
     }
 
@@ -121,6 +132,11 @@ public final class RunTestsTool extends TestingTool {
             return runTestsViaGradleConfig(target, module);
         }
 
+        // Framework-agnostic: resolve the target to a PSI element and use ConfigurationContext
+        // to auto-detect the right test framework (JUnit, TestNG, pytest, etc.)
+        String contextResult = tryRunViaConfigurationContext(target);
+        if (contextResult != null) return contextResult;
+
         String junitResult = tryRunJUnitNatively(target);
         if (junitResult != null) return junitResult;
 
@@ -152,7 +168,98 @@ public final class RunTestsTool extends TestingTool {
         return null;
     }
 
-    private String runTestConfigAndWait(com.intellij.execution.RunnerAndConfigurationSettings settings) throws Exception {
+    // ── Framework-agnostic runner via ConfigurationContext ────
+
+    /**
+     * Resolves the target to a PSI element and uses IntelliJ's {@link ConfigurationContext}
+     * to auto-detect the correct test framework (JUnit, TestNG, pytest, etc.).
+     * Returns null if the target cannot be resolved or no framework matches.
+     */
+    private String tryRunViaConfigurationContext(String target) {
+        try {
+            PsiElement testElement = resolveTestPsiElement(target);
+            if (testElement == null) return null;
+
+            ConfigurationContext context = new ConfigurationContext(testElement);
+            var configs = context.createConfigurationsFromContext();
+            if (configs == null || configs.isEmpty()) return null;
+
+            RunnerAndConfigurationSettings settings = configs.getFirst().getConfigurationSettings();
+            settings.setTemporary(true);
+            RunManager.getInstance(project).addConfiguration(settings);
+            return runTestConfigAndWait(settings);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("tryRunViaConfigurationContext interrupted", e);
+            return null;
+        } catch (Exception e) {
+            LOG.warn("tryRunViaConfigurationContext failed, falling through to other runners", e);
+            return null;
+        }
+    }
+
+    /**
+     * Resolves a test target string (e.g., "MyTest.testFoo" or "MyTest") to the corresponding
+     * PSI element in the project. Searches for the class by name, then optionally finds the
+     * specified method within it.
+     */
+    private PsiElement resolveTestPsiElement(String target) {
+        return ApplicationManager.getApplication().runReadAction((Computable<PsiElement>) () -> {
+            String[] parsed = parseTestTarget(target);
+            String testClass = parsed[0];
+            String testMethod = parsed[1];
+            String searchName = testClass.contains(".")
+                ? testClass.substring(testClass.lastIndexOf('.') + 1) : testClass;
+
+            AtomicReference<PsiElement> result = new AtomicReference<>();
+            PsiSearchHelper.getInstance(project).processElementsWithWord(
+                (element, offset) -> matchTestElement(element, searchName, testMethod, result),
+                GlobalSearchScope.projectScope(project),
+                searchName,
+                UsageSearchContext.IN_CODE,
+                true
+            );
+            return result.get();
+        });
+    }
+
+    /**
+     * Checks if a PSI element matches the searched test class name, and optionally resolves
+     * a method within it. Returns false (stop iteration) when a match is found.
+     */
+    private static boolean matchTestElement(PsiElement element, String searchName, String testMethod,
+                                            AtomicReference<PsiElement> result) {
+        if (!ToolUtils.ELEMENT_TYPE_CLASS.equals(ToolUtils.classifyElement(element))) return true;
+        if (!(element instanceof PsiNamedElement named) || !searchName.equals(named.getName())) return true;
+
+        if (testMethod != null) {
+            PsiElement method = findMethodByName(element, testMethod);
+            if (method != null) {
+                result.set(method);
+                return false;
+            }
+        } else {
+            result.set(element);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Walks the children of a class element to find a method with the given name.
+     */
+    private static PsiElement findMethodByName(PsiElement classElement, String methodName) {
+        for (PsiElement child : classElement.getChildren()) {
+            if (child instanceof PsiNamedElement named
+                && methodName.equals(named.getName())
+                && ToolUtils.ELEMENT_TYPE_METHOD.equals(ToolUtils.classifyElement(child))) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    private String runTestConfigAndWait(RunnerAndConfigurationSettings settings) throws Exception {
         String configName = settings.getName();
 
         CompletableFuture<ProcessHandler> handlerFuture = new CompletableFuture<>();
@@ -274,8 +381,9 @@ public final class RunTestsTool extends TestingTool {
         if (!fileIndex.isInTestSourceContent(vf)) return true;
         if (vf.isDirectory()) return true;
         String name = vf.getName();
-        if (!name.endsWith(ToolUtils.JAVA_EXTENSION) && !name.endsWith(".kt")) return true;
-        String simpleName = name.substring(0, name.lastIndexOf('.'));
+        int dotIdx = name.lastIndexOf('.');
+        if (dotIdx <= 0) return true;
+        String simpleName = name.substring(0, dotIdx);
         if (ToolUtils.doesNotMatchGlob(simpleName, target, compiledGlob)) return true;
         PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
         if (psiFile == null) return true;

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/ToolUtilsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/ToolUtilsTest.java
@@ -648,4 +648,99 @@ class ToolUtilsTest {
             assertTrue(result.contains("Use offset="), "Should indicate more content available");
         }
     }
+
+    @Nested
+    @DisplayName("classifyGenericElement — multi-language PSI classification")
+    class ClassifyGenericElementTest {
+
+        @ParameterizedTest
+        @CsvSource({
+            // Python
+            "PyClassImpl, class",
+            "PyFunctionImpl, function",
+            "PyTargetExpressionImpl, field",
+            "PyDecoratorImpl,",
+            // JavaScript
+            "JSClassImpl, class",
+            "JSFunctionImpl, function",
+            "JSVariable, field",
+            "JSProperty, field",
+            "JSLiteralExpression,",
+            // TypeScript
+            "TypeScriptClassImpl, class",
+            "TypeScriptInterfaceImpl, interface",
+            "TypeScriptEnumImpl, enum",
+            "TypeScriptFunctionImpl, function",
+            "TypeScriptVariable, field",
+            // ES6
+            "ES6ClassImpl, class",
+            // Go
+            "GoTypeSpec, class",
+            "GoFunctionDeclaration, function",
+            "GoMethodDeclaration, function",
+            "GoVarDefinition, field",
+            "GoConstDefinition, field",
+            "GoFieldDefinition, field",
+            "GoPackageClause,",
+            // C/C++
+            "OCStructlike, class",
+            "OCFunctionDefinition, function",
+            "OCDeclarator, field",
+            "OCFieldDeclaration, field",
+            "OCInclude,",
+            // PHP
+            "PhpClassImpl, class",
+            "PhpMethodImpl, method",
+            "PhpFunctionImpl, function",
+            "PhpFieldImpl, field",
+            // Ruby
+            "RClassImpl, class",
+            "RModuleImpl, class",
+            "RMethodImpl, method",
+            // Rust
+            "RsStructItem, class",
+            "RsImplItem, class",
+            "RsEnumItem, enum",
+            "RsTraitItem, interface",
+            "RsFunction, function",
+            "RsFieldDecl, field",
+            "RsConstItem, field",
+            // C#
+            "CSharpClassDeclaration, class",
+            "CSharpStructDeclaration, class",
+            "CSharpInterfaceDeclaration, interface",
+            "CSharpEnumDeclaration, enum",
+            "CSharpMethodDeclaration, method",
+            "CSharpPropertyDeclaration, field",
+            "CSharpFieldDeclaration, field",
+            // Generic fallback
+            "SomeInterfaceDeclaration, interface",
+            // Unknown — should return null
+            "PsiWhiteSpaceImpl,",
+            "PsiCommentImpl,"
+        })
+        void classifiesByPsiClassName(String className, String expectedType) {
+            String result = ToolUtils.classifyGenericElement(className);
+            if (expectedType == null || expectedType.isEmpty()) {
+                assertNull(result, "Expected null for " + className);
+            } else {
+                assertEquals(expectedType, result, "Wrong type for " + className);
+            }
+        }
+
+        @Test
+        void pythonClassImplReturnsClass() {
+            assertEquals("class", ToolUtils.classifyGenericElement("PyClassImpl"));
+        }
+
+        @Test
+        void jsEnumLiteralNotClassifiedAsEnum() {
+            assertNull(ToolUtils.classifyGenericElement("JSEnumLiteralExpression"));
+        }
+
+        @Test
+        void unknownPrefixReturnsNull() {
+            assertNull(ToolUtils.classifyGenericElement("XyzUnknownElement"));
+        }
+    }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/ToolDefinitionContractTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/ToolDefinitionContractTest.java
@@ -302,8 +302,8 @@ class ToolDefinitionContractTest {
         return Stream.of(
             new RefactorTool(null),
             new GoToDeclarationTool(null),
-            new GetTypeHierarchyTool(null),
-            new FindImplementationsTool(null),
+            new GetTypeHierarchyTool(null, true),
+            new FindImplementationsTool(null, true),
             new GetCallHierarchyTool(null),
             new GetDocumentationTool(null),
             new GetSymbolInfoTool(null)

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsExtendedTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsExtendedTest.java
@@ -64,7 +64,7 @@ public class RefactoringToolsExtendedTest extends BasePlatformTestCase {
         PropertiesComponent.getInstance(getProject())
             .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
 
-        findImplementationsTool = new FindImplementationsTool(getProject());
+        findImplementationsTool = new FindImplementationsTool(getProject(), true);
         getCallHierarchyTool = new GetCallHierarchyTool(getProject());
         goToDeclarationTool = new GoToDeclarationTool(getProject());
         getSymbolInfoTool = new GetSymbolInfoTool(getProject());

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactoringToolsTest.java
@@ -45,7 +45,7 @@ public class RefactoringToolsTest extends BasePlatformTestCase {
         PropertiesComponent.getInstance(getProject())
             .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
         getDocumentationTool = new GetDocumentationTool(getProject());
-        getTypeHierarchyTool = new GetTypeHierarchyTool(getProject());
+        getTypeHierarchyTool = new GetTypeHierarchyTool(getProject(), true);
     }
 
     @Override
@@ -63,7 +63,9 @@ public class RefactoringToolsTest extends BasePlatformTestCase {
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    /** Builds a {@link JsonObject} from alternating key/value String pairs. */
+    /**
+     * Builds a {@link JsonObject} from alternating key/value String pairs.
+     */
     private static JsonObject args(String... pairs) {
         JsonObject obj = new JsonObject();
         for (int i = 0; i < pairs.length; i += 2) {


### PR DESCRIPTION
## Multi-language & multi-framework tool support

Combines #233 and #235 (both closed). Reported by Reddit user [VirusPanin](https://www.reddit.com/user/VirusPanin/) who discovered these limitations testing in Rider.

### Changes

**1. Language-agnostic PSI tools** — `search_symbols`, `get_file_outline`, `get_symbol_info` were hardcoded for Java/Kotlin. Now work across all JetBrains IDEs with per-language classifiers for Python, JS/TS, Go, C/C++, PHP, Ruby, Rust, and C#.

**2. Framework-agnostic test tools** — `list_tests` and `run_tests` previously scanned for JUnit `@Test` annotations only. Now use IntelliJ's `TestFramework` API (`isTestMethod`/`isTestClass`) and `ConfigurationContext` for framework-agnostic discovery and execution (JUnit, TestNG, pytest, Go test, etc.). Removed `.java`/`.kt` extension filters.

**3. Rider-disabled tools** — Rider's C#/C++ PSI lives in the ReSharper backend. The following tools are filtered out in Rider to avoid presenting broken tools to agents:

| Tool | Reason |
|------|--------|
| `search_symbols` | `classifyElement()` fails on Rider's coarse PSI stubs |
| `replace_symbol_body` | PSI symbol resolution too coarse for structural edits |
| `insert_before_symbol` | PSI symbol resolution too coarse for structural edits |
| `insert_after_symbol` | PSI symbol resolution too coarse for structural edits |
| `list_tests` | IntelliJ `TestFramework` extensions do not cover Rider's NUnit/xUnit backend |
| `run_tests` | `ConfigurationContext` cannot resolve Rider test runners from the frontend PSI |

**4. IDE compatibility table in README** — Documents which tools are available per IDE:
- IntelliJ IDEA: All 120+ tools
- WebStorm, PyCharm, GoLand, etc.: ~114 (6 Java-only tools excluded)
- Rider: ~108 (6 Java-only + 6 Rider-disabled tools excluded)

**5. CI fix** — `MiningTrackerTest` passed `null` to `@NotNull` constructor parameter, causing test failures from IntelliJ's runtime null-check instrumentation.