### PR TITLE
fix: relax run_in_terminal command restrictions

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
@@ -562,26 +562,11 @@ public final class ToolUtils {
         // Block direct Gradle compile tasks — should use build_project (IntelliJ incremental compiler)
         if (isGradleCompileCommand(cmd)) return "compile";
 
+        // Block build/check tasks that implicitly run tests — should use build_project or run_tests
+        if (isBuildCommand(cmd)) return "test";
+
         // Block test commands — should use run_tests
-        // Explicit test tasks
-        if (cmd.matches(".*(gradlew|gradle|mvn|npm|yarn|pnpm|pytest|jest|mocha|go) test.*") ||
-            cmd.matches(".*\\./gradlew.*test.*") ||
-            cmd.matches(".*python.*-m.*pytest.*") ||
-            cmd.matches(".*cargo test.*") ||
-            cmd.matches(".*dotnet test.*") ||
-            // Bare pytest with args (pytest alone is caught by the first pattern via "pytest test")
-            cmd.matches("pytest\\s+.*") ||
-            // npx/bunx/pnpx wrappers for test runners
-            cmd.matches(".*(npx|bunx|pnpx)\\s+(jest|vitest|mocha|ava|tap|jasmine).*") ||
-            // Gradle build/check tasks (implicitly run tests)
-            cmd.matches(".*(gradlew|gradle)\\s+(build|check)(\\s.*|$)") ||
-            cmd.matches(".*\\./gradlew\\s+(build|check)(\\s.*|$)") ||
-            // Maven lifecycle phases that include tests
-            cmd.matches(".*mvn\\s+(verify|package|install|deploy)(\\s.*|$)") ||
-            // npm/yarn/pnpm run test
-            cmd.matches(".*(npm|yarn|pnpm)\\s+run\\s+test.*")) {
-            return "test";
-        }
+        if (isTestCommand(cmd)) return "test";
 
         return null;
     }
@@ -592,28 +577,126 @@ public final class ToolUtils {
         return isGradleCmd && hasCompileTask;
     }
 
+    private static boolean isTestCommand(String cmd) {
+        return cmd.matches(".*(gradlew|gradle|mvn|npm|yarn|pnpm|pytest|jest|mocha|go) test.*") ||
+            cmd.matches(".*\\./gradlew.*test.*") ||
+            cmd.matches(".*python.*-m.*pytest.*") ||
+            cmd.matches(".*cargo test.*") ||
+            cmd.matches(".*dotnet test.*") ||
+            cmd.matches("pytest\\s+.*") ||
+            cmd.matches(".*(npx|bunx|pnpx)\\s+(jest|vitest|mocha|ava|tap|jasmine).*") ||
+            cmd.matches(".*(npm|yarn|pnpm)\\s+run\\s+test.*") ||
+            // Bare test runner invocations (jest, vitest, mocha, etc.)
+            cmd.matches("(jest|vitest|mocha|ava|tap|jasmine)(\\s.*|$)");
+    }
+
+    private static boolean isBuildCommand(String cmd) {
+        return cmd.matches(".*(gradlew|gradle)\\s+(build|check)(\\s.*|$)") ||
+            cmd.matches(".*\\./gradlew\\s+(build|check)(\\s.*|$)") ||
+            cmd.matches(".*mvn\\s+(verify|package|install|deploy)(\\s.*|$)");
+    }
+
+    /**
+     * Detects hard-block abuse patterns for {@code run_in_terminal}.
+     * Only blocks commands that cause IDE state desync (git, sed).
+     * For commands with better MCP alternatives (grep, cat, find), use
+     * {@link #getTerminalReprimand(String)} to append a warning instead.
+     */
+    public static @Nullable String detectTerminalAbuseType(@NotNull String command) {
+        String cmd = command.toLowerCase().trim();
+        if (cmd.startsWith("git ") || cmd.equals("git")) return "git";
+        if (cmd.startsWith("sed ")) return "sed";
+        return null;
+    }
+
+    /**
+     * Returns a warning message for terminal commands that have better MCP tool alternatives.
+     * Unlike {@link #detectTerminalAbuseType(String)}, this does NOT block execution — the
+     * command runs normally but the warning is prepended to the output to nudge the agent
+     * toward the purpose-built tool.
+     *
+     * @return a warning string to prepend to output, or null if no reprimand needed
+     */
+    public static @Nullable String getTerminalReprimand(@NotNull String command) {
+        String cmd = command.toLowerCase().trim();
+
+        // grep/rg/ag — prefer search_text or search_symbols
+        if (cmd.startsWith("grep ") || cmd.startsWith("rg ") || cmd.startsWith("ag ") ||
+            cmd.contains("| grep ") || cmd.contains("| rg ") || cmd.contains("| ag ")) {
+            return "⚠️ Prefer search_text or search_symbols over shell grep — "
+                + "they search live editor buffers and support semantic lookup.";
+        }
+
+        // cat/head/tail/less/more — prefer read_file
+        if (cmd.matches("(cat|head|tail|less|more) .*")) {
+            return "⚠️ Prefer read_file over shell cat/head/tail — "
+                + "it reads live editor buffers, not stale disk content.";
+        }
+
+        // find — prefer list_project_files / list_directory_tree
+        if (cmd.matches("find \\S+.*-name.*") || cmd.matches("find \\S+.*-type.*") ||
+            cmd.startsWith("find .") || cmd.startsWith("find /")) {
+            return "⚠️ Prefer list_project_files or list_directory_tree over shell find — "
+                + "they respect project structure and exclusions.";
+        }
+
+        // ls/dir/tree — prefer list_project_files / list_directory_tree
+        if (cmd.startsWith("ls ") || cmd.equals("ls") ||
+            cmd.startsWith("dir ") || cmd.equals("dir") ||
+            cmd.startsWith("tree ") || cmd.equals("tree")) {
+            return "⚠️ Prefer list_project_files or list_directory_tree over shell ls/tree — "
+                + "they respect project structure and exclusions.";
+        }
+
+        // test commands — prefer run_tests
+        if (isTestCommand(cmd)) {
+            return "⚠️ Prefer run_tests over shell test commands — "
+                + "it provides structured pass/fail results with IntelliJ test runner integration.";
+        }
+
+        // compile/build commands — prefer build_project
+        if (isGradleCompileCommand(cmd) || isBuildCommand(cmd)) {
+            return "⚠️ Prefer build_project over shell compile/build commands — "
+                + "it uses IntelliJ's incremental compiler with structured error reporting.";
+        }
+
+        return null;
+    }
+
     /**
      * Map abuse type to a human-readable error message for MCP tool responses.
+     *
+     * @param abuseType the detected abuse category
+     * @param toolName  the tool that detected the abuse (e.g. "run_command", "run_in_terminal")
      */
-    public static String getCommandAbuseMessage(String abuseType) {
+    public static String getCommandAbuseMessage(String abuseType, String toolName) {
         return switch (abuseType) {
-            case "git" -> "Error: git commands are not allowed via run_command (causes IntelliJ buffer desync). "
+            case "git" -> "Error: git commands are not allowed via " + toolName + " (causes IntelliJ buffer desync). "
                 + "Use the dedicated git tools instead: git_status, git_diff, git_log, git_commit, "
                 + "git_stage, git_unstage, git_branch, git_stash, git_show, git_blame, git_push, git_remote, "
                 + "git_fetch, git_pull, git_merge, git_rebase, git_cherry_pick, git_tag, git_reset.";
-            case "cat" -> "Error: cat/head/tail/less/more are not allowed via run_command (reads stale disk files). "
-                + "Use intellij_read_file to read live editor buffers instead.";
-            case "sed" -> "Error: sed is not allowed via run_command (bypasses IntelliJ editor buffers). "
+            case "cat" ->
+                "Error: cat/head/tail/less/more are not allowed via " + toolName + " (reads stale disk files). "
+                    + "Use intellij_read_file to read live editor buffers instead.";
+            case "sed" -> "Error: sed is not allowed via " + toolName + " (bypasses IntelliJ editor buffers). "
                 + "Use edit_text with old_str/new_str for file editing instead.";
-            case "grep" -> "Error: grep/rg commands are not allowed via run_command (searches stale disk files). "
+            case "grep" -> "Error: grep/rg commands are not allowed via " + toolName + " (searches stale disk files). "
                 + "Use search_text or search_symbols to search live editor buffers instead.";
-            case "find" -> "Error: find commands are not allowed via run_command. "
+            case "find" -> "Error: find commands are not allowed via " + toolName + ". "
                 + "Use list_project_files to find files instead.";
-            case "compile" -> "Error: Gradle compile tasks are not allowed via run_command. "
+            case "compile" -> "Error: Gradle compile tasks are not allowed via " + toolName + ". "
                 + "Use build_project to compile via IntelliJ's incremental compiler instead.";
-            case "test" -> "Error: test commands are not allowed via run_command (including build/check/verify " +
+            case "test" -> "Error: test commands are not allowed via " + toolName + " (including build/check/verify " +
                 "which implicitly run tests). Use run_tests to run tests with proper IntelliJ integration instead.";
-            default -> "Error: this command is not allowed via run_command. Use dedicated IntelliJ tools instead.";
+            default -> "Error: this command is not allowed via " + toolName + ". Use dedicated IntelliJ tools instead.";
         };
+    }
+
+    /**
+     * Map abuse type to a human-readable error message for MCP tool responses.
+     * Uses "run_command" as the default tool name for backward compatibility.
+     */
+    public static String getCommandAbuseMessage(String abuseType) {
+        return getCommandAbuseMessage(abuseType, "run_command");
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/RunInTerminalTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/RunInTerminalTool.java
@@ -70,7 +70,7 @@ public final class RunInTerminalTool extends TerminalTool {
         if (!(toolCall instanceof JsonObject jsonToolCall)) return null;
         String command = extractCommand(jsonToolCall);
         if (command == null) return null;
-        return ToolUtils.detectCommandAbuseType(command);
+        return ToolUtils.detectTerminalAbuseType(command);
     }
 
     private static @Nullable String extractCommand(@NotNull JsonObject toolCall) {
@@ -90,8 +90,11 @@ public final class RunInTerminalTool extends TerminalTool {
         String command = args.get(JSON_COMMAND).getAsString();
 
         // Runtime guard: reject abuse patterns even if the pre-check was skipped
-        String abuseType = ToolUtils.detectCommandAbuseType(command);
-        if (abuseType != null) return ToolUtils.getCommandAbuseMessage(abuseType);
+        String abuseType = ToolUtils.detectTerminalAbuseType(command);
+        if (abuseType != null) return ToolUtils.getCommandAbuseMessage(abuseType, "run_in_terminal");
+
+        // Soft reprimand: command runs but output is prefixed with a nudge toward the better tool
+        String reprimand = ToolUtils.getTerminalReprimand(command);
 
         String tabName = args.has(JSON_TAB_NAME) ? args.get(JSON_TAB_NAME).getAsString() : null;
         boolean newTab = args.has(JSON_NEW_TAB) && args.get(JSON_NEW_TAB).getAsBoolean();
@@ -123,7 +126,8 @@ public final class RunInTerminalTool extends TerminalTool {
         });
 
         try {
-            return resultFuture.get(10, TimeUnit.SECONDS);
+            String result = resultFuture.get(10, TimeUnit.SECONDS);
+            return reprimand != null ? reprimand + "\n\n" + result : result;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             return "Terminal opened (response timed out, but command was likely sent).";

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/TerminalAbuseDetectionTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/TerminalAbuseDetectionTest.java
@@ -1,0 +1,145 @@
+package com.github.catatafishen.agentbridge.psi;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link ToolUtils#detectTerminalAbuseType(String)} (hard blocks)
+ * and {@link ToolUtils#getTerminalReprimand(String)} (soft warnings).
+ */
+class TerminalAbuseDetectionTest {
+
+    @Nested
+    @DisplayName("hard blocks — commands that cause IDE desync")
+    class HardBlocks {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"git status", "git diff HEAD", "git push origin main", "git"})
+        void blocksGitCommands(String command) {
+            assertEquals("git", ToolUtils.detectTerminalAbuseType(command));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"sed -i 's/foo/bar/' file.txt", "sed 's/old/new/g' input.txt"})
+        void blocksSedCommands(String command) {
+            assertEquals("sed", ToolUtils.detectTerminalAbuseType(command));
+        }
+    }
+
+    @Nested
+    @DisplayName("soft reprimands — commands with better MCP alternatives")
+    class SoftReprimands {
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "grep -r 'pattern' src/",
+            "rg 'pattern' .",
+            "ag 'pattern'",
+            "echo foo | grep bar",
+            "cat file | rg pattern",
+        })
+        void reprimandsGrepCommands(String command) {
+            assertNull(ToolUtils.detectTerminalAbuseType(command));
+            String reprimand = ToolUtils.getTerminalReprimand(command);
+            assertNotNull(reprimand, "Expected reprimand for: " + command);
+            assertTrue(reprimand.contains("search_text"), "Should suggest search_text for: " + command);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "cat README.md",
+            "head -n 10 file.txt",
+            "tail log.txt",
+            "less config.yaml",
+            "more data.csv",
+        })
+        void reprimandsCatCommands(String command) {
+            assertNull(ToolUtils.detectTerminalAbuseType(command));
+            String reprimand = ToolUtils.getTerminalReprimand(command);
+            assertNotNull(reprimand, "Expected reprimand for: " + command);
+            assertTrue(reprimand.contains("read_file"), "Should suggest read_file for: " + command);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "find . -name '*.java'",
+            "find /tmp -type f",
+            "find ./src -name 'Test*'",
+        })
+        void reprimandsFindCommands(String command) {
+            assertNull(ToolUtils.detectTerminalAbuseType(command));
+            String reprimand = ToolUtils.getTerminalReprimand(command);
+            assertNotNull(reprimand, "Expected reprimand for: " + command);
+            assertTrue(reprimand.contains("list_project_files"), "Should suggest list_project_files for: " + command);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"ls", "ls -la", "dir", "tree", "tree src/"})
+        void reprimandsLsCommands(String command) {
+            assertNull(ToolUtils.detectTerminalAbuseType(command));
+            String reprimand = ToolUtils.getTerminalReprimand(command);
+            assertNotNull(reprimand, "Expected reprimand for: " + command);
+            assertTrue(reprimand.contains("list_project_files") || reprimand.contains("list_directory_tree"),
+                "Should suggest list tool for: " + command);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "npm test",
+            "pytest -v tests/",
+            "cargo test",
+            "./gradlew test",
+            "jest --watch",
+            "npm run test",
+        })
+        void reprimandsTestCommands(String command) {
+            assertNull(ToolUtils.detectTerminalAbuseType(command));
+            String reprimand = ToolUtils.getTerminalReprimand(command);
+            assertNotNull(reprimand, "Expected reprimand for: " + command);
+            assertTrue(reprimand.contains("run_tests"), "Should suggest run_tests for: " + command);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "./gradlew build",
+            "./gradlew compileJava",
+            "gradle check",
+            "mvn package",
+            "mvn install",
+        })
+        void reprimandsBuildCommands(String command) {
+            assertNull(ToolUtils.detectTerminalAbuseType(command));
+            String reprimand = ToolUtils.getTerminalReprimand(command);
+            assertNotNull(reprimand, "Expected reprimand for: " + command);
+            assertTrue(reprimand.contains("build_project"), "Should suggest build_project for: " + command);
+        }
+    }
+
+    @Nested
+    @DisplayName("allowed commands — no block, no reprimand")
+    class AllowedCommands {
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "npm start",
+            "npm run dev",
+            "python manage.py runserver",
+            "echo hello",
+            "mkdir new_dir",
+            "docker compose up",
+            "ssh user@host",
+            "curl https://example.com",
+        })
+        void allowsWithoutReprimand(String command) {
+            assertNull(ToolUtils.detectTerminalAbuseType(command), "Should not hard-block: " + command);
+            assertNull(ToolUtils.getTerminalReprimand(command), "Should not reprimand: " + command);
+        }
+    }
+}


### PR DESCRIPTION
Fixes run_in_terminal incorrectly blocking test/compile/grep/cat/find commands.

**Root cause:** `run_in_terminal` shared `ToolUtils.detectCommandAbuseType()` with `run_command`, blocking all the same commands. But the terminal is designed for interactive use — `pytest --pdb`, `gradle test --debug`, `grep -r` etc. are all valid terminal use cases. The error message also hard-coded "run_command" even when triggered from `run_in_terminal`.

**Fix:**
- New `detectTerminalAbuseType()` — only blocks `git` and `sed` (true IDE-desync risks)
- New `getCommandAbuseMessage(type, toolName)` overload for correct tool name in errors
- Old single-arg overload delegates to new one with "run_command" default

Found via tool call statistics DB analysis (2 occurrences).