### PR TITLE
fix: use full text range for findNamedElement line matching

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolUtils.java
@@ -281,8 +281,13 @@ public final class ToolUtils {
     }
 
     /**
-     * Finds the first {@link com.intellij.psi.PsiNameIdentifierOwner} with the given name whose
-     * text offset falls within the line bounds described by {@code ctx}.
+     * Walks the PSI tree looking for a {@link com.intellij.psi.PsiNameIdentifierOwner} whose
+     * {@link com.intellij.psi.PsiNameIdentifierOwner#getName() name} equals {@code name} and whose
+     * text range overlaps the line bounds described by {@code ctx}.
+     * <p>
+     * Uses the element's full text range (not just the name identifier offset) so that
+     * methods with annotations or multi-line signatures are found regardless of which line
+     * the caller specifies — the annotation line, the signature line, or any line in the body.
      * <p>
      * Shared between {@link CallHierarchySupport} and {@code TypeHierarchySupport} to avoid
      * duplicating the PSI visitor pattern.
@@ -301,8 +306,8 @@ public final class ToolUtils {
             public void visitElement(@NotNull com.intellij.psi.PsiElement element) {
                 if (element instanceof com.intellij.psi.PsiNameIdentifierOwner owner
                     && name.equals(owner.getName())) {
-                    int offset = owner.getTextOffset();
-                    if (offset >= ctx.lineStart() && offset <= ctx.lineEnd()) {
+                    com.intellij.openapi.util.TextRange range = owner.getTextRange();
+                    if (range.getStartOffset() <= ctx.lineEnd() && range.getEndOffset() >= ctx.lineStart()) {
                         found[0] = owner;
                         stopWalking();
                         return;


### PR DESCRIPTION
Fixes get_call_hierarchy "Could not find method X at file:line" errors.

**Root cause:** `ToolUtils.findNamedElement()` checked only the name identifier offset against the specified line bounds. For methods with annotations or multi-line signatures, the identifier is on a different line than the one the caller specifies:

```java
@Override              // line 10 ← caller specifies this
@Transactional         // line 11
public void myMethod() // line 12 ← getTextOffset() points here
```

**Fix:** Use the element's full `getTextRange()` and check for overlap with the specified line, so methods are found regardless of which line is specified — annotation, signature, or body.

Found via tool call statistics DB analysis (3 occurrences).