### PR TITLE
fix: replace inverted WriteAction/CommandProcessor with WriteCommandAction

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editing/EditingTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editing/EditingTool.java
@@ -6,8 +6,7 @@ import com.github.catatafishen.agentbridge.services.ToolRegistry;
 import com.google.gson.JsonObject;
 import com.intellij.codeInsight.actions.ReformatCodeProcessor;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.WriteAction;
-import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
@@ -64,13 +63,11 @@ public abstract class EditingTool extends Tool {
     protected void formatInline(VirtualFile vf) {
         PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
         if (psiFile == null) return;
-        WriteAction.run(() ->
-            CommandProcessor.getInstance().executeCommand(project, () -> {
-                PsiDocumentManager.getInstance(project).commitAllDocuments();
-                new ReformatCodeProcessor(psiFile, false).run();
-                PsiDocumentManager.getInstance(project).commitAllDocuments();
-            }, "Auto-Format (Symbol Edit)", null)
-        );
+        WriteCommandAction.runWriteCommandAction(project, "Auto-Format (Symbol Edit)", null, () -> {
+            PsiDocumentManager.getInstance(project).commitAllDocuments();
+            new ReformatCodeProcessor(psiFile, false).run();
+            PsiDocumentManager.getInstance(project).commitAllDocuments();
+        });
         // Defer import optimization to end of turn so imports added by earlier
         // edits in the same response are not stripped before later edits use them.
         com.github.catatafishen.agentbridge.psi.tools.file.FileTool.queueAutoFormat(project, vf.getPath());

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editing/InsertAfterSymbolTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editing/InsertAfterSymbolTool.java
@@ -7,8 +7,7 @@ import com.github.catatafishen.agentbridge.psi.ToolUtils;
 import com.github.catatafishen.agentbridge.psi.tools.file.FileTool;
 import com.github.catatafishen.agentbridge.ui.renderers.ReplaceSymbolRenderer;
 import com.google.gson.JsonObject;
-import com.intellij.openapi.application.WriteAction;
-import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
@@ -131,11 +130,9 @@ public final class InsertAfterSymbolTool extends EditingTool {
             final String fContent = normalized;
             final int fOffset = offset;
 
-            WriteAction.run(() ->
-                CommandProcessor.getInstance().executeCommand(
-                    project, () -> doc.insertString(fOffset, fContent),
-                    "Insert After Symbol", null)
-            );
+            WriteCommandAction.runWriteCommandAction(
+                project, "Insert After Symbol", null,
+                () -> doc.insertString(fOffset, fContent));
 
             PsiDocumentManager.getInstance(project).commitDocument(doc);
             formatInline(vf);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editing/InsertBeforeSymbolTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editing/InsertBeforeSymbolTool.java
@@ -7,8 +7,7 @@ import com.github.catatafishen.agentbridge.psi.ToolUtils;
 import com.github.catatafishen.agentbridge.psi.tools.file.FileTool;
 import com.github.catatafishen.agentbridge.ui.renderers.ReplaceSymbolRenderer;
 import com.google.gson.JsonObject;
-import com.intellij.openapi.application.WriteAction;
-import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
@@ -113,11 +112,9 @@ public final class InsertBeforeSymbolTool extends EditingTool {
                 final String fContent = normalized;
                 final int fOffset = offset;
 
-                WriteAction.run(() ->
-                    CommandProcessor.getInstance().executeCommand(
-                        project, () -> doc.insertString(fOffset, fContent),
-                        "Insert Before Symbol", null)
-                );
+                WriteCommandAction.runWriteCommandAction(
+                    project, "Insert Before Symbol", null,
+                    () -> doc.insertString(fOffset, fContent));
 
                 PsiDocumentManager.getInstance(project).commitDocument(doc);
                 formatInline(vf);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editing/ReplaceSymbolBodyTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editing/ReplaceSymbolBodyTool.java
@@ -7,8 +7,7 @@ import com.github.catatafishen.agentbridge.psi.ToolUtils;
 import com.github.catatafishen.agentbridge.psi.tools.file.FileTool;
 import com.github.catatafishen.agentbridge.ui.renderers.ReplaceSymbolRenderer;
 import com.google.gson.JsonObject;
-import com.intellij.openapi.application.WriteAction;
-import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
@@ -116,11 +115,9 @@ public final class ReplaceSymbolBodyTool extends EditingTool {
                 final int fEnd = endOffset;
                 final String fNew = normalized;
 
-                WriteAction.run(() ->
-                    CommandProcessor.getInstance().executeCommand(
-                        project, () -> doc.replaceString(fStart, fEnd, fNew),
-                        "Replace Symbol Body", null)
-                );
+                WriteCommandAction.runWriteCommandAction(
+                    project, "Replace Symbol Body", null,
+                    () -> doc.replaceString(fStart, fEnd, fNew));
 
                 PsiDocumentManager.getInstance(project).commitDocument(doc);
                 formatInline(vf);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
@@ -9,7 +9,7 @@ import com.github.catatafishen.agentbridge.services.ToolRegistry;
 import com.intellij.codeInsight.actions.OptimizeImportsProcessor;
 import com.intellij.codeInsight.actions.ReformatCodeProcessor;
 import com.intellij.openapi.application.WriteAction;
-import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.EditorCustomElementRenderer;
@@ -110,16 +110,14 @@ public abstract class FileTool extends Tool {
             PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
             if (psiFile == null) return;
             Document doc = psiFile.getViewProvider().getDocument();
-            WriteAction.run(() ->
-                CommandProcessor.getInstance().executeCommand(project, () -> {
-                    if (doc != null)
-                        PsiDocumentManager.getInstance(project).commitDocument(doc);
-                    new OptimizeImportsProcessor(project, psiFile).run();
-                    new ReformatCodeProcessor(psiFile, false).run();
-                    if (doc != null)
-                        PsiDocumentManager.getInstance(project).commitDocument(doc);
-                }, "Auto-Format (Deferred)", null)
-            );
+            WriteCommandAction.runWriteCommandAction(project, "Auto-Format (Deferred)", null, () -> {
+                if (doc != null)
+                    PsiDocumentManager.getInstance(project).commitDocument(doc);
+                new OptimizeImportsProcessor(project, psiFile).run();
+                new ReformatCodeProcessor(psiFile, false).run();
+                if (doc != null)
+                    PsiDocumentManager.getInstance(project).commitDocument(doc);
+            });
             LOG.info("Deferred auto-format: " + pathStr);
         } catch (Exception e) {
             LOG.warn("Deferred auto-format failed for " + pathStr + ": " + e.getMessage());

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/WriteFileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/WriteFileTool.java
@@ -7,7 +7,7 @@ import com.github.catatafishen.agentbridge.psi.ToolUtils;
 import com.github.catatafishen.agentbridge.ui.renderers.WriteFileRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.application.WriteAction;
-import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
@@ -172,10 +172,8 @@ public class WriteFileTool extends FileTool {
         Document doc = FileDocumentManager.getInstance().getDocument(vf);
         if (doc != null) {
             String oldContent = doc.getText();
-            WriteAction.run(() ->
-                CommandProcessor.getInstance().executeCommand(
-                    project, () -> doc.setText(newContent), "Write File", null)
-            );
+            WriteCommandAction.runWriteCommandAction(
+                project, "Write File", null, () -> doc.setText(newContent));
             FileDocumentManager.getInstance().saveDocument(doc);
             int[] diff = CodeChangeTracker.diffLines(oldContent, newContent);
             CodeChangeTracker.recordChange(diff[0], diff[1]);
@@ -281,11 +279,9 @@ public class WriteFileTool extends FileTool {
         }
         final int finalIdx = idx;
         final int finalLen = matchLen;
-        WriteAction.run(() ->
-            CommandProcessor.getInstance().executeCommand(
-                project, () -> doc.replaceString(finalIdx, finalIdx + finalLen, normalizedNew),
-                "Edit File", null)
-        );
+        WriteCommandAction.runWriteCommandAction(
+            project, "Edit File", null,
+            () -> doc.replaceString(finalIdx, finalIdx + finalLen, normalizedNew));
         FileDocumentManager.getInstance().saveDocument(doc);
         CodeChangeTracker.recordChange(CodeChangeTracker.countLines(normalizedNew), CodeChangeTracker.countLines(normalizedOld));
         String syntaxWarning = checkSyntaxErrors(doc, pathStr);
@@ -343,11 +339,9 @@ public class WriteFileTool extends FileTool {
         final int fEnd = endOffset;
         final String fNew = newStr;
         int replacedLines = endLine - startLine + 1;
-        WriteAction.run(() ->
-            CommandProcessor.getInstance().executeCommand(
-                project, () -> doc.replaceString(fStart, fEnd, fNew),
-                "Edit File (Line Range)", null)
-        );
+        WriteCommandAction.runWriteCommandAction(
+            project, "Edit File (Line Range)", null,
+            () -> doc.replaceString(fStart, fEnd, fNew));
         FileDocumentManager.getInstance().saveDocument(doc);
         CodeChangeTracker.recordChange(CodeChangeTracker.countLines(fNew), replacedLines);
         String syntaxWarning = checkSyntaxErrors(doc, pathStr);
@@ -432,14 +426,12 @@ public class WriteFileTool extends FileTool {
                 closestMatchHint(text, normalizedOld));
             return;
         }
-        WriteAction.run(() ->
-            CommandProcessor.getInstance().executeCommand(project, () -> {
-                for (int i = positions.size() - 1; i >= 0; i--) {
-                    int start = positions.get(i);
-                    doc.replaceString(start, start + normalizedOld.length(), normalizedNew);
-                }
-            }, "Edit File", null)
-        );
+        WriteCommandAction.runWriteCommandAction(project, "Edit File", null, () -> {
+            for (int i = positions.size() - 1; i >= 0; i--) {
+                int start = positions.get(i);
+                doc.replaceString(start, start + normalizedOld.length(), normalizedNew);
+            }
+        });
         FileDocumentManager.getInstance().saveDocument(doc);
         CodeChangeTracker.recordChange(
             positions.size() * CodeChangeTracker.countLines(normalizedNew),
@@ -493,13 +485,11 @@ public class WriteFileTool extends FileTool {
     private void formatFileSync(VirtualFile vf) {
         PsiFile psiFile = PsiManager.getInstance(project).findFile(vf);
         if (psiFile == null) return;
-        WriteAction.run(() ->
-            CommandProcessor.getInstance().executeCommand(project, () -> {
-                PsiDocumentManager.getInstance(project).commitAllDocuments();
-                new com.intellij.codeInsight.actions.ReformatCodeProcessor(psiFile, false).run();
-                PsiDocumentManager.getInstance(project).commitAllDocuments();
-            }, "Pre-Format for Edit", null)
-        );
+        WriteCommandAction.runWriteCommandAction(project, "Pre-Format for Edit", null, () -> {
+            PsiDocumentManager.getInstance(project).commitAllDocuments();
+            new com.intellij.codeInsight.actions.ReformatCodeProcessor(psiFile, false).run();
+            PsiDocumentManager.getInstance(project).commitAllDocuments();
+        });
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/FormatCodeTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/FormatCodeTool.java
@@ -4,8 +4,7 @@ import com.github.catatafishen.agentbridge.psi.EdtUtil;
 import com.github.catatafishen.agentbridge.psi.tools.file.FileTool;
 import com.github.catatafishen.agentbridge.ui.renderers.SimpleStatusRenderer;
 import com.google.gson.JsonObject;
-import com.intellij.openapi.application.WriteAction;
-import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDocumentManager;
 import org.jetbrains.annotations.NotNull;
@@ -63,12 +62,10 @@ public final class FormatCodeTool extends QualityTool {
             try {
                 FilePair pair = resolveFilePair(pathStr, resultFuture);
                 if (pair == null) return;
-                WriteAction.run(() ->
-                    CommandProcessor.getInstance().executeCommand(project, () -> {
-                        PsiDocumentManager.getInstance(project).commitAllDocuments();
-                        new com.intellij.codeInsight.actions.ReformatCodeProcessor(pair.psiFile(), false).run();
-                    }, "Reformat Code", null)
-                );
+                WriteCommandAction.runWriteCommandAction(project, "Reformat Code", null, () -> {
+                    PsiDocumentManager.getInstance(project).commitAllDocuments();
+                    new com.intellij.codeInsight.actions.ReformatCodeProcessor(pair.psiFile(), false).run();
+                });
                 String relPath = project.getBasePath() != null
                     ? relativize(project.getBasePath(), pair.vf().getPath()) : pathStr;
                 resultFuture.complete("Code formatted: " + relPath);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/OptimizeImportsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/OptimizeImportsTool.java
@@ -3,8 +3,7 @@ package com.github.catatafishen.agentbridge.psi.tools.quality;
 import com.github.catatafishen.agentbridge.psi.EdtUtil;
 import com.github.catatafishen.agentbridge.ui.renderers.SimpleStatusRenderer;
 import com.google.gson.JsonObject;
-import com.intellij.openapi.application.WriteAction;
-import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDocumentManager;
 import org.jetbrains.annotations.NotNull;
@@ -61,12 +60,10 @@ public final class OptimizeImportsTool extends QualityTool {
             try {
                 FilePair pair = resolveFilePair(pathStr, resultFuture);
                 if (pair == null) return;
-                WriteAction.run(() ->
-                    CommandProcessor.getInstance().executeCommand(project, () -> {
-                        PsiDocumentManager.getInstance(project).commitAllDocuments();
-                        new com.intellij.codeInsight.actions.OptimizeImportsProcessor(project, pair.psiFile()).run();
-                    }, "Optimize Imports", null)
-                );
+                WriteCommandAction.runWriteCommandAction(project, "Optimize Imports", null, () -> {
+                    PsiDocumentManager.getInstance(project).commitAllDocuments();
+                    new com.intellij.codeInsight.actions.OptimizeImportsProcessor(project, pair.psiFile()).run();
+                });
                 String relPath = project.getBasePath() != null
                     ? relativize(project.getBasePath(), pair.vf().getPath()) : pathStr;
                 resultFuture.complete("Imports optimized: " + relPath);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/SuppressInspectionTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/SuppressInspectionTool.java
@@ -5,8 +5,7 @@ import com.github.catatafishen.agentbridge.psi.ToolUtils;
 import com.github.catatafishen.agentbridge.psi.tools.file.FileTool;
 import com.github.catatafishen.agentbridge.ui.renderers.SimpleStatusRenderer;
 import com.google.gson.JsonObject;
-import com.intellij.openapi.application.WriteAction;
-import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.project.Project;
@@ -159,12 +158,10 @@ public final class SuppressInspectionTool extends QualityTool {
         }
 
         String annotation = buildKotlinSuppressAnnotation(info.indent(), inspectionId);
-        WriteAction.run(() ->
-            CommandProcessor.getInstance().executeCommand(project, () -> {
-                document.insertString(info.lineStart(), annotation);
-                PsiDocumentManager.getInstance(project).commitDocument(document);
-            }, LABEL_SUPPRESS_INSPECTION, null)
-        );
+        WriteCommandAction.runWriteCommandAction(project, LABEL_SUPPRESS_INSPECTION, null, () -> {
+            document.insertString(info.lineStart(), annotation);
+            PsiDocumentManager.getInstance(project).commitDocument(document);
+        });
 
         return formatAnnotationResult(inspectionId, info.targetLine() + 1);
     }
@@ -172,12 +169,10 @@ public final class SuppressInspectionTool extends QualityTool {
     private String suppressWithComment(PsiElement target, String inspectionId, Document document) {
         LineInfo info = getLineInfo(target, document);
         String comment = buildSuppressComment(info.indent(), inspectionId);
-        WriteAction.run(() ->
-            CommandProcessor.getInstance().executeCommand(project, () -> {
-                document.insertString(info.lineStart(), comment);
-                PsiDocumentManager.getInstance(project).commitDocument(document);
-            }, LABEL_SUPPRESS_INSPECTION, null)
-        );
+        WriteCommandAction.runWriteCommandAction(project, LABEL_SUPPRESS_INSPECTION, null, () -> {
+            document.insertString(info.lineStart(), comment);
+            PsiDocumentManager.getInstance(project).commitDocument(document);
+        });
         return formatCommentResult(inspectionId, info.targetLine() + 1);
     }
 


### PR DESCRIPTION
Replace all instances of the anti-pattern:
```java
WriteAction.run(() -> CommandProcessor.executeCommand(...))
```
with the canonical IntelliJ pattern:
```java
WriteCommandAction.runWriteCommandAction(project, name, null, runnable)
```

The inverted nesting (WriteAction outside CommandProcessor) is not the recommended usage. `WriteCommandAction` handles both the write lock and command registration in the correct order.

**Fixed:** WriteFileTool (5 instances) + FileTool.formatSingleFile (1 instance)

**Root cause:** 3 EDT threading violations logged in tool-stats.db for `write_file` — "Access is allowed from Event Dispatch Thread (EDT) only" on mcp-http thread. The inverted pattern is more fragile under edge-case threading.