### PR TITLE
fix: resolve JCEF scroll tearing during streaming

### DIFF
--- a/plugin-core/chat-ui/src/components/ChatContainer.ts
+++ b/plugin-core/chat-ui/src/components/ChatContainer.ts
@@ -92,10 +92,14 @@ export default class ChatContainer extends HTMLElement {
         };
         this.addEventListener('scroll', this._onScroll);
 
-        // When the container or its content resizes, re-anchor to bottom if auto-scrolling
+        // When the container or its content resizes, re-anchor to bottom if auto-scrolling.
+        // Debounced via rAF to avoid synchronous forced-reflow tearing in JCEF OSR.
         this._resizeObs = new ResizeObserver(() => {
-            if (this._autoScroll && !this._restoring) {
-                this.scrollTop = this.scrollHeight;
+            if (this._autoScroll && !this._restoring && !this._scrollRAF) {
+                this._scrollRAF = requestAnimationFrame(() => {
+                    this._scrollRAF = null;
+                    this.scrollIfNeeded();
+                });
             }
         });
         this._resizeObs.observe(this);
@@ -234,6 +238,14 @@ export default class ChatContainer extends HTMLElement {
 
     compensateScroll(targetY: number): void {
         this.scrollTop = targetY;
+    }
+
+    /**
+     * Disable smooth scroll during streaming to prevent CSS animation conflicts
+     * with rapid programmatic scrollTop changes in JCEF OSR.
+     */
+    setStreaming(active: boolean, smoothScrollEnabled: boolean): void {
+        this.style.scrollBehavior = active ? 'auto' : (smoothScrollEnabled ? 'smooth' : 'auto');
     }
 
     disconnectedCallback(): void {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -104,10 +104,17 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
     @Volatile
     private var activeAskUserRequestId: String? = null
 
-    // CEF windowless frame rate — high during streaming, low when idle
+    // CEF windowless frame rate — high during streaming, moderate when idle.
+    // 10fps was too aggressive — caused stale-frame tearing during manual scroll.
     private fun setFrameRate(fps: Int) {
         browser?.cefBrowser?.setWindowlessFrameRate(fps)
     }
+
+    // Periodic CEF invalidation during streaming — forces OSR buffer refresh
+    // as a safety net against compositor desync during rapid content changes.
+    private val repaintTimer = javax.swing.Timer(200) {
+        browser?.cefBrowser?.invalidate()
+    }.apply { isRepeats = true }
 
     // ── Swing fallback ─────────────────────────────────────────────
     private val fallbackArea: JBTextArea?
@@ -122,7 +129,7 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
 
         private const val FAILED_SPAN = "<span style='color:var(--error)'>✖ Failed</span>"
         private const val STREAMING_FRAME_RATE = 60
-        private const val IDLE_FRAME_RATE = 10
+        private const val IDLE_FRAME_RATE = 30
 
         private val GIT_HISTORY_TOOLS = setOf("git_log", "git_show")
     }
@@ -303,6 +310,10 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
 
     override fun startStreaming() {
         setFrameRate(STREAMING_FRAME_RATE)
+        repaintTimer.start()
+        // Disable smooth scroll during streaming — CSS scroll animations conflict
+        // with rapid programmatic scrollTop changes, causing JCEF OSR tearing.
+        executeJs("document.querySelector('chat-container')?.setStreaming(true, false)")
     }
 
     override fun setCodeChangeStats(linesAdded: Int, linesRemoved: Int) {
@@ -679,6 +690,9 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
 
     override fun finishResponse(toolCallCount: Int, modelId: String, multiplier: String) {
         setFrameRate(IDLE_FRAME_RATE)
+        repaintTimer.stop()
+        val smooth = McpServerSettings.getInstance(project).isSmoothScrollEnabled
+        executeJs("document.querySelector('chat-container')?.setStreaming(false, $smooth)")
         toolJustCompleted = false
         finalizeCurrentText()
         collapseThinking()
@@ -762,6 +776,9 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
 
     override fun cancelAllRunning() {
         setFrameRate(IDLE_FRAME_RATE)
+        repaintTimer.stop()
+        val smooth = McpServerSettings.getInstance(project).isSmoothScrollEnabled
+        executeJs("document.querySelector('chat-container')?.setStreaming(false, $smooth)")
         clearPendingAskUserRequest(null)
         executeJs("ChatController.cancelAllRunning()")
     }
@@ -1060,6 +1077,7 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
 
     override fun dispose() {
         registry.removeKindStateListener(kindStateListener)
+        repaintTimer.stop()
         instances.remove(project)
     }
 


### PR DESCRIPTION
Fixes screen tearing in the chat pane during scroll, which regressed after commit 609dbfb7 (reduce JCEF repaint overhead).

## Root Cause

Four compounding issues:

1. **ResizeObserver synchronous scroll** — forced-reflow layout thrashing during streaming
2. **Smooth scroll + streaming conflict** — CSS scroll animations overlapped with rapid programmatic scrollTop changes
3. **IDLE_FRAME_RATE=10 too aggressive** — stale OSR frames between 100ms refreshes
4. **Removed repaint safety net** — no forced repaints during scroll animations

## Fix

- Debounce ResizeObserver via shared `_scrollRAF` gate (1 scroll update per animation frame)
- Disable smooth scroll during streaming via new `ChatContainer.setStreaming()`, restore on finish
- Increase IDLE_FRAME_RATE from 10 → 30 (33ms frame time)
- Re-add periodic `cef.invalidate()` timer (200ms) during streaming lifecycle only

## Files Changed

- `ChatContainer.ts` — rAF-debounced ResizeObserver, new `setStreaming()` method
- `ChatConsolePanel.kt` — repaintTimer lifecycle, IDLE_FRAME_RATE bump, streaming smooth-scroll management