### PR TITLE
feat: migrate usage statistics charts from JSONL to SQLite

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsService.java
@@ -19,10 +19,13 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Project-level service that records every MCP tool call in a SQLite database
@@ -122,6 +125,27 @@ public final class ToolCallStatisticsService implements Disposable {
                 "CREATE INDEX IF NOT EXISTS idx_tool_calls_tool_name ON tool_calls(tool_name)");
             // Migration: add error_message column to existing databases
             migrateAddErrorMessageColumn(stmt);
+
+            stmt.execute("""
+                CREATE TABLE IF NOT EXISTS turn_stats (
+                    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id       TEXT    NOT NULL,
+                    agent_id         TEXT    NOT NULL,
+                    date             TEXT    NOT NULL,
+                    input_tokens     INTEGER NOT NULL DEFAULT 0,
+                    output_tokens    INTEGER NOT NULL DEFAULT 0,
+                    tool_calls       INTEGER NOT NULL DEFAULT 0,
+                    duration_ms      INTEGER NOT NULL DEFAULT 0,
+                    lines_added      INTEGER NOT NULL DEFAULT 0,
+                    lines_removed    INTEGER NOT NULL DEFAULT 0,
+                    premium_requests REAL    NOT NULL DEFAULT 1.0,
+                    timestamp        TEXT    NOT NULL
+                )
+                """);
+            stmt.execute(
+                "CREATE INDEX IF NOT EXISTS idx_turn_stats_date ON turn_stats(date)");
+            stmt.execute(
+                "CREATE INDEX IF NOT EXISTS idx_turn_stats_session ON turn_stats(session_id)");
         }
     }
 
@@ -431,6 +455,212 @@ public final class ToolCallStatisticsService implements Disposable {
     }
 
     /**
+     * Records per-turn statistics for the usage charts.
+     *
+     * @param record the turn statistics to store
+     */
+    public synchronized void recordTurnStats(@NotNull TurnStatsRecord record) {
+        if (connection == null) return;
+        String sql = """
+            INSERT INTO turn_stats (session_id, agent_id, date, input_tokens, output_tokens,
+                                    tool_calls, duration_ms, lines_added, lines_removed,
+                                    premium_requests, timestamp)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """;
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, record.sessionId());
+            stmt.setString(2, record.agentId());
+            stmt.setString(3, record.date());
+            stmt.setLong(4, record.inputTokens());
+            stmt.setLong(5, record.outputTokens());
+            stmt.setInt(6, record.toolCalls());
+            stmt.setLong(7, record.durationMs());
+            stmt.setInt(8, record.linesAdded());
+            stmt.setInt(9, record.linesRemoved());
+            stmt.setDouble(10, record.premiumRequests());
+            stmt.setString(11, record.timestamp());
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            if (isDbMoved(e) && tryReconnect()) {
+                try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+                    stmt.setString(1, record.sessionId());
+                    stmt.setString(2, record.agentId());
+                    stmt.setString(3, record.date());
+                    stmt.setLong(4, record.inputTokens());
+                    stmt.setLong(5, record.outputTokens());
+                    stmt.setInt(6, record.toolCalls());
+                    stmt.setLong(7, record.durationMs());
+                    stmt.setInt(8, record.linesAdded());
+                    stmt.setInt(9, record.linesRemoved());
+                    stmt.setDouble(10, record.premiumRequests());
+                    stmt.setString(11, record.timestamp());
+                    stmt.executeUpdate();
+                } catch (SQLException retryEx) {
+                    LOG.warn("Failed to record turn stats after reconnect", retryEx);
+                }
+            } else {
+                LOG.warn("Failed to record turn stats", e);
+            }
+        }
+    }
+
+    /**
+     * Checks whether a turn stats record already exists at the given timestamp.
+     * Used by {@link TurnStatisticsBackfill} for deduplication.
+     */
+    public synchronized boolean hasTurnStatsAt(@NotNull String timestamp) {
+        if (connection == null) return false;
+        try (PreparedStatement stmt = connection.prepareStatement(
+            "SELECT 1 FROM turn_stats WHERE timestamp = ? LIMIT 1")) {
+            stmt.setString(1, timestamp);
+            try (ResultSet rs = stmt.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            LOG.warn("Failed to check for existing turn stats", e);
+            return false;
+        }
+    }
+
+    /**
+     * Returns the total number of turn stats records in the database.
+     * Used to determine whether a backfill is needed.
+     */
+    public synchronized int getTurnStatsCount() {
+        if (connection == null) return 0;
+        try (PreparedStatement stmt = connection.prepareStatement("SELECT COUNT(*) FROM turn_stats");
+             ResultSet rs = stmt.executeQuery()) {
+            return rs.next() ? rs.getInt(1) : 0;
+        } catch (SQLException e) {
+            LOG.warn("Failed to count turn stats", e);
+            return 0;
+        }
+    }
+
+    /**
+     * Queries daily per-agent turn statistics aggregated by date and agent_id.
+     * Returns one row per (date, agentId) bucket within the specified date range.
+     *
+     * @param startDate inclusive start date (YYYY-MM-DD)
+     * @param endDate   inclusive end date (YYYY-MM-DD)
+     * @return aggregated daily stats sorted by date then agent_id
+     */
+    public synchronized List<DailyTurnAggregate> queryDailyTurnStats(
+        @NotNull String startDate, @NotNull String endDate) {
+        if (connection == null) return List.of();
+        String sql = """
+            SELECT date, agent_id,
+                   COUNT(*)          AS turns,
+                   SUM(input_tokens)     AS input_tokens,
+                   SUM(output_tokens)    AS output_tokens,
+                   SUM(tool_calls)       AS tool_calls,
+                   SUM(duration_ms)      AS duration_ms,
+                   SUM(lines_added)      AS lines_added,
+                   SUM(lines_removed)    AS lines_removed,
+                   SUM(premium_requests) AS premium_requests
+            FROM turn_stats
+            WHERE date BETWEEN ? AND ?
+            GROUP BY date, agent_id
+            ORDER BY date, agent_id
+            """;
+        List<DailyTurnAggregate> results = new ArrayList<>();
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, startDate);
+            stmt.setString(2, endDate);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    results.add(new DailyTurnAggregate(
+                        LocalDate.parse(rs.getString("date")),
+                        rs.getString("agent_id"),
+                        rs.getInt("turns"),
+                        rs.getLong("input_tokens"),
+                        rs.getLong("output_tokens"),
+                        rs.getInt("tool_calls"),
+                        rs.getLong("duration_ms"),
+                        rs.getInt("lines_added"),
+                        rs.getInt("lines_removed"),
+                        rs.getDouble("premium_requests")
+                    ));
+                }
+            }
+        } catch (SQLException e) {
+            LOG.warn("Failed to query daily turn stats", e);
+        }
+        return results;
+    }
+
+    /**
+     * Returns all distinct agent IDs that have turn statistics, along with
+     * their display names from the sessions index.
+     */
+    public synchronized Set<String> getDistinctTurnAgents() {
+        if (connection == null) return Set.of();
+        Set<String> agents = new LinkedHashSet<>();
+        try (ResultSet rs = connection.createStatement()
+            .executeQuery("SELECT DISTINCT agent_id FROM turn_stats ORDER BY agent_id")) {
+            while (rs.next()) {
+                agents.add(rs.getString("agent_id"));
+            }
+        } catch (SQLException e) {
+            LOG.warn("Failed to query distinct turn agents", e);
+        }
+        return agents;
+    }
+
+    /**
+     * Returns the earliest date in the turn_stats table, or null if empty.
+     */
+    @Nullable
+    public synchronized LocalDate getEarliestTurnDate() {
+        if (connection == null) return null;
+        try (ResultSet rs = connection.createStatement()
+            .executeQuery("SELECT MIN(date) AS min_date FROM turn_stats")) {
+            if (rs.next()) {
+                String minDate = rs.getString("min_date");
+                if (minDate != null) return LocalDate.parse(minDate);
+            }
+        } catch (SQLException e) {
+            LOG.warn("Failed to query earliest turn date", e);
+        }
+        return null;
+    }
+
+    /**
+     * Aggregated daily turn statistics for a single (date, agent) bucket.
+     */
+    public record DailyTurnAggregate(
+        @NotNull LocalDate date,
+        @NotNull String agentId,
+        int turns,
+        long inputTokens,
+        long outputTokens,
+        int toolCalls,
+        long durationMs,
+        int linesAdded,
+        int linesRemoved,
+        double premiumRequests
+    ) {
+    }
+
+    /**
+     * A single turn stats record for insertion.
+     */
+    public record TurnStatsRecord(
+        @NotNull String sessionId,
+        @NotNull String agentId,
+        @NotNull String date,
+        long inputTokens,
+        long outputTokens,
+        int toolCalls,
+        long durationMs,
+        int linesAdded,
+        int linesRemoved,
+        double premiumRequests,
+        @NotNull String timestamp
+    ) {
+    }
+
+    /**
      * Threshold below which the database is considered empty enough to warrant backfill.
      * If the DB has fewer records than this, session JSONL files are scanned.
      */
@@ -441,17 +671,31 @@ public final class ToolCallStatisticsService implements Disposable {
         String basePath = project.getBasePath();
         if (basePath == null) return;
 
-        if (service.getRecordCount() >= BACKFILL_THRESHOLD) return;
-
         ApplicationManager.getApplication().executeOnPooledThread(() -> {
-            try {
-                ToolCallStatisticsBackfill.BackfillResult result =
-                    ToolCallStatisticsBackfill.backfill(service, basePath);
-                if (result.inserted() > 0) {
-                    LOG.info("Tool statistics backfill: " + result);
+            // Tool calls backfill
+            if (service.getRecordCount() < BACKFILL_THRESHOLD) {
+                try {
+                    ToolCallStatisticsBackfill.BackfillResult result =
+                        ToolCallStatisticsBackfill.backfill(service, basePath);
+                    if (result.inserted() > 0) {
+                        LOG.info("Tool statistics backfill: " + result);
+                    }
+                } catch (Exception e) {
+                    LOG.warn("Tool statistics backfill failed", e);
                 }
-            } catch (Exception e) {
-                LOG.warn("Tool statistics backfill failed", e);
+            }
+
+            // Turn stats backfill
+            if (service.getTurnStatsCount() < BACKFILL_THRESHOLD) {
+                try {
+                    TurnStatisticsBackfill.BackfillResult result =
+                        TurnStatisticsBackfill.backfill(service, basePath);
+                    if (result.inserted() > 0) {
+                        LOG.info("Turn statistics backfill: " + result);
+                    }
+                } catch (Exception e) {
+                    LOG.warn("Turn statistics backfill failed", e);
+                }
             }
         });
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/TurnStatisticsBackfill.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/TurnStatisticsBackfill.java
@@ -1,0 +1,239 @@
+package com.github.catatafishen.agentbridge.services;
+
+import com.github.catatafishen.agentbridge.session.exporters.ExportUtils;
+import com.github.catatafishen.agentbridge.session.v2.SessionStoreV2;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.intellij.openapi.diagnostic.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Backfills turn statistics from session JSONL files into the SQLite database.
+ *
+ * <p>Session files contain {@code "type":"turnStats"} entries with per-turn token counts,
+ * tool call counts, duration, and code change metrics. This class scans those entries
+ * and inserts them as {@link ToolCallStatisticsService.TurnStatsRecord}s.</p>
+ *
+ * <p>Backfill is idempotent: it skips entries whose timestamp already exists in the
+ * database (uses the ISO 8601 timestamp for deduplication).</p>
+ */
+public final class TurnStatisticsBackfill {
+
+    private static final Logger LOG = Logger.getInstance(TurnStatisticsBackfill.class);
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    private TurnStatisticsBackfill() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public record BackfillResult(int inserted, int skipped, int errors) {
+        @NotNull
+        @Override
+        public String toString() {
+            return "BackfillResult{inserted=" + inserted + ", skipped=" + skipped
+                + ", errors=" + errors + "}";
+        }
+    }
+
+    /**
+     * Scans all session JSONL files and backfills turn stats records into the
+     * given service. Skips entries that already exist (by timestamp).
+     *
+     * @param service  the statistics service to insert records into
+     * @param basePath the project base path (for locating session files)
+     * @return the backfill result with counts
+     */
+    public static BackfillResult backfill(@NotNull ToolCallStatisticsService service,
+                                          @NotNull String basePath) {
+        SessionStoreV2 store = new SessionStoreV2();
+        List<SessionStoreV2.SessionRecord> sessions = store.listSessions(basePath);
+        if (sessions.isEmpty()) {
+            LOG.info("Turn stats backfill: no sessions found");
+            return new BackfillResult(0, 0, 0);
+        }
+
+        Map<String, String> sessionToAgent = buildSessionAgentMap(sessions);
+        File sessionsDir = ExportUtils.sessionsDir(basePath);
+        int inserted = 0;
+        int skipped = 0;
+        int errors = 0;
+
+        for (SessionStoreV2.SessionRecord session : sessions) {
+            Path jsonlPath = sessionsDir.toPath().resolve(session.id() + ".jsonl");
+            if (!Files.exists(jsonlPath)) continue;
+
+            String agentId = sessionToAgent.get(session.id());
+            BackfillResult sessionResult = backfillSession(
+                service, jsonlPath, session.id(), agentId);
+            inserted += sessionResult.inserted();
+            skipped += sessionResult.skipped();
+            errors += sessionResult.errors();
+        }
+
+        LOG.info("Turn stats backfill complete: " + inserted + " inserted, "
+            + skipped + " skipped, " + errors + " errors");
+        return new BackfillResult(inserted, skipped, errors);
+    }
+
+    private static Map<String, String> buildSessionAgentMap(
+        @NotNull List<SessionStoreV2.SessionRecord> sessions) {
+        Map<String, String> map = new HashMap<>();
+        for (SessionStoreV2.SessionRecord session : sessions) {
+            map.put(session.id(), AgentIdMapper.toAgentId(session.agent()));
+        }
+        return map;
+    }
+
+    private static BackfillResult backfillSession(@NotNull ToolCallStatisticsService service,
+                                                  @NotNull Path jsonlPath,
+                                                  @NotNull String sessionId,
+                                                  @NotNull String agentId) {
+        int inserted = 0;
+        int skipped = 0;
+        int errors = 0;
+        String[] lastSeenTimestamp = {null};
+
+        try (BufferedReader reader = Files.newBufferedReader(jsonlPath, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                trackTimestamp(line, lastSeenTimestamp);
+                if (!line.contains("\"turnStats\"")) continue;
+
+                EntryResult entryResult = processEntry(
+                    service, line, sessionId, agentId, lastSeenTimestamp[0]);
+                switch (entryResult) {
+                    case INSERTED -> inserted++;
+                    case SKIPPED -> skipped++;
+                    case ERROR -> errors++;
+                }
+            }
+        } catch (IOException e) {
+            LOG.warn("Turn stats backfill: failed to read " + jsonlPath.getFileName(), e);
+        }
+
+        return new BackfillResult(inserted, skipped, errors);
+    }
+
+    private static void trackTimestamp(@NotNull String line, @NotNull String[] holder) {
+        int tsIdx = line.indexOf("\"timestamp\":\"");
+        if (tsIdx < 0) return;
+        int start = tsIdx + "\"timestamp\":\"".length();
+        int end = line.indexOf('"', start);
+        if (end > start) {
+            String candidate = line.substring(start, end);
+            if (!candidate.isEmpty()) {
+                holder[0] = candidate;
+            }
+        }
+    }
+
+    private enum EntryResult {INSERTED, SKIPPED, ERROR}
+
+    private static EntryResult processEntry(@NotNull ToolCallStatisticsService service,
+                                            @NotNull String line,
+                                            @NotNull String sessionId,
+                                            @NotNull String agentId,
+                                            @Nullable String fallbackTimestamp) {
+        ToolCallStatisticsService.TurnStatsRecord turnRecord =
+            parseTurnStatsEntry(line, sessionId, agentId, fallbackTimestamp);
+        if (turnRecord == null) return EntryResult.ERROR;
+
+        if (service.hasTurnStatsAt(turnRecord.timestamp())) {
+            return EntryResult.SKIPPED;
+        }
+        service.recordTurnStats(turnRecord);
+        return EntryResult.INSERTED;
+    }
+
+    @Nullable
+    private static ToolCallStatisticsService.TurnStatsRecord parseTurnStatsEntry(
+        @NotNull String line,
+        @NotNull String sessionId,
+        @NotNull String agentId,
+        @Nullable String fallbackTimestamp) {
+
+        JsonObject obj = JsonParser.parseString(line).getAsJsonObject();
+
+        String type = getStr(obj, "type");
+        if (!"turnStats".equals(type)) return null;
+
+        // Resolve timestamp — prefer entry's own, fall back to last seen
+        String timestamp = getStr(obj, "timestamp");
+        if (timestamp.isEmpty()) {
+            timestamp = fallbackTimestamp;
+        }
+        if (timestamp == null || timestamp.isEmpty()) return null;
+
+        // Derive date from timestamp
+        String date;
+        try {
+            date = Instant.parse(timestamp)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate()
+                .format(DATE_FORMAT);
+        } catch (Exception e) {
+            return null;
+        }
+
+        long inputTokens = getLong(obj, "inputTokens");
+        long outputTokens = getLong(obj, "outputTokens");
+        int toolCalls = getInt(obj, "toolCallCount");
+        long durationMs = getLong(obj, "durationMs");
+        int linesAdded = getInt(obj, "linesAdded");
+        int linesRemoved = getInt(obj, "linesRemoved");
+        double premiumRequests = parsePremiumMultiplier(getStr(obj, "multiplier"));
+
+        return new ToolCallStatisticsService.TurnStatsRecord(
+            sessionId, agentId, date,
+            inputTokens, outputTokens, toolCalls, durationMs,
+            linesAdded, linesRemoved, premiumRequests, timestamp);
+    }
+
+    private static double parsePremiumMultiplier(String multiplier) {
+        if (multiplier == null || multiplier.isEmpty()) return 1.0;
+        String cleaned = multiplier.endsWith("x")
+            ? multiplier.substring(0, multiplier.length() - 1)
+            : multiplier;
+        try {
+            return Double.parseDouble(cleaned);
+        } catch (NumberFormatException e) {
+            return 1.0;
+        }
+    }
+
+    @NotNull
+    private static String getStr(@NotNull JsonObject obj, @NotNull String key) {
+        if (obj.has(key) && !obj.get(key).isJsonNull()) {
+            return obj.get(key).getAsString();
+        }
+        return "";
+    }
+
+    private static long getLong(@NotNull JsonObject obj, @NotNull String key) {
+        if (obj.has(key) && !obj.get(key).isJsonNull()) {
+            return obj.get(key).getAsLong();
+        }
+        return 0;
+    }
+
+    private static int getInt(@NotNull JsonObject obj, @NotNull String key) {
+        if (obj.has(key) && !obj.get(key).isJsonNull()) {
+            return obj.get(key).getAsInt();
+        }
+        return 0;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
@@ -11,6 +11,7 @@ import com.github.catatafishen.agentbridge.psi.PsiBridgeService
 import com.github.catatafishen.agentbridge.services.ActiveAgentManager
 import com.github.catatafishen.agentbridge.services.AgentScratchTracker
 import com.github.catatafishen.agentbridge.services.AgentTabTracker
+import com.github.catatafishen.agentbridge.services.ToolCallStatisticsService
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
@@ -440,6 +441,11 @@ class PromptOrchestrator(
             turnToolCallCount, codeChanges[0], codeChanges[1], turnModelId, turnMultiplier
         )
 
+        recordTurnStatsToSqlite(
+            turnDuration, turnInputTokens, turnOutputTokens,
+            turnToolCallCount, codeChanges[0], codeChanges[1], turnMultiplier
+        )
+
         val nextMsg = PsiBridgeService.getInstance(project).nextQueuedMessage
         if (nextMsg != null) {
             ApplicationManager.getApplication().invokeLater {
@@ -783,6 +789,39 @@ class PromptOrchestrator(
                 }
             }
         }
+    }
+
+    private fun recordTurnStatsToSqlite(
+        durationMs: Long, inputTokens: Int, outputTokens: Int,
+        toolCallCount: Int, linesAdded: Int, linesRemoved: Int, multiplier: String
+    ) {
+        val sessionId = currentSessionId ?: return
+        val agentId = agentManager.activeProfileId
+        val premiumRequests = parsePremiumMultiplier(multiplier)
+        val now = java.time.Instant.now()
+        val date = java.time.LocalDate.now().toString()
+        val timestamp = now.toString()
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+            try {
+                val service = ToolCallStatisticsService.getInstance(project)
+                service.recordTurnStats(
+                    ToolCallStatisticsService.TurnStatsRecord(
+                        sessionId, agentId, date,
+                        inputTokens.toLong(), outputTokens.toLong(), toolCallCount,
+                        durationMs, linesAdded, linesRemoved, premiumRequests, timestamp
+                    )
+                )
+            } catch (e: Exception) {
+                log.warn("Failed to record turn stats to SQLite", e)
+            }
+        }
+    }
+
+    private fun parsePremiumMultiplier(multiplier: String): Double {
+        if (multiplier.isEmpty()) return 1.0
+        val cleaned = if (multiplier.endsWith("x")) multiplier.dropLast(1) else multiplier
+        return cleaned.toDoubleOrNull() ?: 1.0
     }
 
     private fun getModelMultiplier(modelId: String): String? =

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/UsageStatisticsLoader.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.ui.statistics;
 
 import com.github.catatafishen.agentbridge.services.AgentIdMapper;
+import com.github.catatafishen.agentbridge.services.ToolCallStatisticsService;
 import com.github.catatafishen.agentbridge.session.exporters.ExportUtils;
 import com.github.catatafishen.agentbridge.session.v2.EntryDataJsonAdapter;
 import com.github.catatafishen.agentbridge.session.v2.SessionStoreV2;
@@ -45,6 +46,88 @@ final class UsageStatisticsLoader {
         LocalDate startDate = range.startDate();
         LocalDate endDate = LocalDate.now();
 
+        // Try SQLite first — much faster than scanning JSONL files
+        UsageStatisticsData.StatisticsSnapshot sqliteResult =
+            loadFromSqlite(project, range, startDate, endDate);
+        if (sqliteResult != null) return sqliteResult;
+
+        // Fall back to JSONL scan (DB empty or not initialized)
+        return loadFromJsonl(project, range, startDate, endDate);
+    }
+
+    /**
+     * Loads statistics from the SQLite turn_stats table. Returns null if the
+     * table is empty (triggers JSONL fallback with backfill).
+     */
+    @Nullable
+    private static UsageStatisticsData.StatisticsSnapshot loadFromSqlite(
+        @NotNull Project project,
+        @NotNull UsageStatisticsData.TimeRange range,
+        @NotNull LocalDate startDate,
+        @NotNull LocalDate endDate) {
+
+        ToolCallStatisticsService service = ToolCallStatisticsService.getInstance(project);
+        if (service.getTurnStatsCount() == 0) return null;
+
+        String startStr = startDate.toString();
+        String endStr = endDate.toString();
+        List<ToolCallStatisticsService.DailyTurnAggregate> aggregates =
+            service.queryDailyTurnStats(startStr, endStr);
+        if (aggregates.isEmpty()) return null;
+
+        // Build agent display names from the sessions index
+        String basePath = project.getBasePath();
+        Map<String, String> agentDisplayNames = new LinkedHashMap<>();
+        Set<String> agentIds = new LinkedHashSet<>();
+
+        List<SessionStoreV2.SessionRecord> sessions =
+            SessionStoreV2.getInstance(project).listSessions(basePath);
+        for (SessionStoreV2.SessionRecord session : sessions) {
+            String agentId = toAgentId(session.agent());
+            agentIds.add(agentId);
+            agentDisplayNames.putIfAbsent(agentId, session.agent());
+        }
+
+        // Also include agents from the query results
+        for (ToolCallStatisticsService.DailyTurnAggregate agg : aggregates) {
+            agentIds.add(agg.agentId());
+        }
+
+        // Convert to DailyAgentStats
+        List<UsageStatisticsData.DailyAgentStats> dailyStats = new ArrayList<>();
+        for (ToolCallStatisticsService.DailyTurnAggregate agg : aggregates) {
+            dailyStats.add(new UsageStatisticsData.DailyAgentStats(
+                agg.date(), agg.agentId(),
+                agg.turns(), agg.inputTokens(), agg.outputTokens(),
+                agg.toolCalls(), agg.durationMs(),
+                agg.linesAdded(), agg.linesRemoved(), agg.premiumRequests()
+            ));
+        }
+
+        // For "all time", narrow start to earliest data date
+        if (range == UsageStatisticsData.TimeRange.ALL) {
+            LocalDate earliest = service.getEarliestTurnDate();
+            if (earliest != null) {
+                startDate = earliest;
+            }
+        }
+
+        LOG.info("Statistics (SQLite): loaded " + dailyStats.size() + " day/agent buckets, "
+            + dailyStats.stream().mapToInt(UsageStatisticsData.DailyAgentStats::turns).sum() + " total turns");
+
+        return new UsageStatisticsData.StatisticsSnapshot(
+            dailyStats, startDate, endDate, agentIds, agentDisplayNames);
+    }
+
+    /**
+     * Original JSONL-based loader — used as fallback when the SQLite table is empty.
+     */
+    private static UsageStatisticsData.StatisticsSnapshot loadFromJsonl(
+        @NotNull Project project,
+        @NotNull UsageStatisticsData.TimeRange range,
+        @NotNull LocalDate startDate,
+        @NotNull LocalDate endDate) {
+
         String basePath = project.getBasePath();
         List<SessionStoreV2.SessionRecord> sessions =
             SessionStoreV2.getInstance(project).listSessions(basePath);
@@ -76,12 +159,10 @@ final class UsageStatisticsLoader {
         }
 
         List<UsageStatisticsData.DailyAgentStats> dailyStats = buildDailyStats(accumulators);
-        LOG.info("Statistics: loaded " + sessions.size() + " sessions, "
+        LOG.info("Statistics (JSONL fallback): loaded " + sessions.size() + " sessions, "
             + accumulators.size() + " day/agent buckets, "
             + dailyStats.stream().mapToInt(UsageStatisticsData.DailyAgentStats::turns).sum() + " total turns");
 
-        // For "all time", start from the earliest data date instead of 2020-01-01
-        // to avoid creating thousands of zero-fill points in the chart
         if (range == UsageStatisticsData.TimeRange.ALL && !accumulators.isEmpty()) {
             startDate = accumulators.keySet().stream()
                 .map(DayAgentKey::date)

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/ToolCallStatisticsServiceTest.java
@@ -3,6 +3,7 @@ package com.github.catatafishen.agentbridge.services;
 import com.intellij.openapi.project.Project;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
@@ -12,9 +13,11 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -356,5 +359,157 @@ class ToolCallStatisticsServiceTest {
 
         ToolCallStatisticsService svc = new ToolCallStatisticsService(mockProject);
         assertThrows(IllegalStateException.class, svc::initialize);
+    }
+
+    // --- Turn stats tests ---
+
+    private static ToolCallStatisticsService.TurnStatsRecord turnRecord(
+        String sessionId, String agentId, String date,
+        long inputTokens, long outputTokens, int toolCalls,
+        long durationMs, int linesAdded, int linesRemoved,
+        double premiumRequests, String timestamp) {
+        return new ToolCallStatisticsService.TurnStatsRecord(
+            sessionId, agentId, date, inputTokens, outputTokens, toolCalls,
+            durationMs, linesAdded, linesRemoved, premiumRequests, timestamp);
+    }
+
+    @Test
+    @DisplayName("recordTurnStats inserts and getTurnStatsCount returns correct count")
+    void recordTurnStatsInsertsCorrectly() {
+        service.recordTurnStats(turnRecord("s1", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z"));
+
+        assertEquals(1, service.getTurnStatsCount());
+    }
+
+    @Test
+    @DisplayName("hasTurnStatsAt detects existing record by timestamp")
+    void hasTurnStatsAtFindsExisting() {
+        String ts = "2025-01-15T10:00:00Z";
+        service.recordTurnStats(turnRecord("s1", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, ts));
+
+        assertTrue(service.hasTurnStatsAt(ts));
+        assertFalse(service.hasTurnStatsAt("2025-01-15T11:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("queryDailyTurnStats aggregates multiple turns for same date/agent")
+    void queryDailyTurnStatsAggregates() {
+        service.recordTurnStats(turnRecord("s1", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z"));
+        service.recordTurnStats(turnRecord("s1", "copilot", "2025-01-15",
+            150, 300, 5, 7000, 20, 5, 0.5, "2025-01-15T10:05:00Z"));
+
+        var results = service.queryDailyTurnStats("2025-01-15", "2025-01-15");
+        assertEquals(1, results.size());
+
+        var agg = results.getFirst();
+        assertEquals(LocalDate.of(2025, 1, 15), agg.date());
+        assertEquals("copilot", agg.agentId());
+        assertEquals(2, agg.turns());
+        assertEquals(250, agg.inputTokens());
+        assertEquals(500, agg.outputTokens());
+        assertEquals(8, agg.toolCalls());
+        assertEquals(12000, agg.durationMs());
+        assertEquals(30, agg.linesAdded());
+        assertEquals(7, agg.linesRemoved());
+        assertEquals(1.5, agg.premiumRequests(), 0.001);
+    }
+
+    @Test
+    @DisplayName("queryDailyTurnStats separates different agents on same day")
+    void queryDailyTurnStatsSeparatesAgents() {
+        service.recordTurnStats(turnRecord("s1", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z"));
+        service.recordTurnStats(turnRecord("s2", "claude-cli", "2025-01-15",
+            50, 100, 1, 3000, 5, 1, 0.5, "2025-01-15T10:01:00Z"));
+
+        var results = service.queryDailyTurnStats("2025-01-15", "2025-01-15");
+        assertEquals(2, results.size());
+        assertEquals("claude-cli", results.get(0).agentId());
+        assertEquals("copilot", results.get(1).agentId());
+    }
+
+    @Test
+    @DisplayName("queryDailyTurnStats filters by date range")
+    void queryDailyTurnStatsDateFilter() {
+        service.recordTurnStats(turnRecord("s1", "copilot", "2025-01-14",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-14T10:00:00Z"));
+        service.recordTurnStats(turnRecord("s1", "copilot", "2025-01-15",
+            50, 100, 1, 3000, 5, 1, 1.0, "2025-01-15T10:00:00Z"));
+        service.recordTurnStats(turnRecord("s1", "copilot", "2025-01-16",
+            75, 150, 2, 4000, 8, 3, 1.0, "2025-01-16T10:00:00Z"));
+
+        var results = service.queryDailyTurnStats("2025-01-15", "2025-01-16");
+        assertEquals(2, results.size());
+        assertEquals(LocalDate.of(2025, 1, 15), results.get(0).date());
+        assertEquals(LocalDate.of(2025, 1, 16), results.get(1).date());
+    }
+
+    @Test
+    @DisplayName("getDistinctTurnAgents returns all unique agent IDs")
+    void getDistinctTurnAgentsReturnsAll() {
+        service.recordTurnStats(turnRecord("s1", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z"));
+        service.recordTurnStats(turnRecord("s2", "claude-cli", "2025-01-15",
+            50, 100, 1, 3000, 5, 1, 1.0, "2025-01-15T10:01:00Z"));
+        service.recordTurnStats(turnRecord("s3", "copilot", "2025-01-16",
+            75, 150, 2, 4000, 8, 3, 1.0, "2025-01-16T10:00:00Z"));
+
+        var agents = service.getDistinctTurnAgents();
+        assertEquals(2, agents.size());
+        assertTrue(agents.contains("copilot"));
+        assertTrue(agents.contains("claude-cli"));
+    }
+
+    @Test
+    @DisplayName("getEarliestTurnDate returns the earliest date")
+    void getEarliestTurnDateReturnsMin() {
+        service.recordTurnStats(turnRecord("s1", "copilot", "2025-01-16",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-16T10:00:00Z"));
+        service.recordTurnStats(turnRecord("s1", "copilot", "2025-01-14",
+            50, 100, 1, 3000, 5, 1, 1.0, "2025-01-14T10:00:00Z"));
+
+        assertEquals(LocalDate.of(2025, 1, 14), service.getEarliestTurnDate());
+    }
+
+    @Test
+    @DisplayName("getEarliestTurnDate returns null when table is empty")
+    void getEarliestTurnDateNullWhenEmpty() {
+        assertNull(service.getEarliestTurnDate());
+    }
+
+    @Test
+    @DisplayName("queryDailyTurnStats returns empty for no matching range")
+    void queryDailyTurnStatsEmptyRange() {
+        service.recordTurnStats(turnRecord("s1", "copilot", "2025-01-15",
+            100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z"));
+
+        var results = service.queryDailyTurnStats("2025-02-01", "2025-02-28");
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    @DisplayName("getTurnStatsCount with null connection returns 0")
+    void getTurnStatsCountNullConnectionReturnsZero() {
+        ToolCallStatisticsService nullService = new ToolCallStatisticsService();
+        assertEquals(0, nullService.getTurnStatsCount());
+    }
+
+    @Test
+    @DisplayName("hasTurnStatsAt with null connection returns false")
+    void hasTurnStatsAtNullConnectionReturnsFalse() {
+        ToolCallStatisticsService nullService = new ToolCallStatisticsService();
+        assertFalse(nullService.hasTurnStatsAt("2025-01-15T10:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("recordTurnStats with null connection does not throw")
+    void recordTurnStatsNullConnectionDoesNotThrow() {
+        ToolCallStatisticsService nullService = new ToolCallStatisticsService();
+        assertDoesNotThrow(() -> nullService.recordTurnStats(
+            turnRecord("s1", "copilot", "2025-01-15",
+                100, 200, 3, 5000, 10, 2, 1.0, "2025-01-15T10:00:00Z")));
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/TurnStatisticsBackfillTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/services/TurnStatisticsBackfillTest.java
@@ -1,0 +1,282 @@
+package com.github.catatafishen.agentbridge.services;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link TurnStatisticsBackfill} — verifies that turn stats entries
+ * are correctly extracted from session JSONL files and inserted into the SQLite database.
+ */
+class TurnStatisticsBackfillTest {
+
+    @TempDir
+    Path tempDir;
+
+    private ToolCallStatisticsService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Class.forName("org.sqlite.JDBC");
+        Path dbPath = tempDir.resolve("tool-stats.db");
+        Connection connection = DriverManager.getConnection("jdbc:sqlite:" + dbPath);
+        service = new ToolCallStatisticsService();
+        service.initializeWithConnection(connection);
+    }
+
+    @AfterEach
+    void tearDown() {
+        service.dispose();
+    }
+
+    @Test
+    @DisplayName("backfills turnStats entries from JSONL session files")
+    void backfillsTurnStatsEntries() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        createSessionJsonl(basePath, "session-1",
+            turnStatsEntry("2025-01-15T10:00:00Z", 100, 200, 3, 5000, 10, 2, "1x"),
+            turnStatsEntry("2025-01-15T10:05:00Z", 150, 300, 5, 7000, 20, 5, "0.5x"));
+
+        TurnStatisticsBackfill.BackfillResult result =
+            TurnStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(2, result.inserted());
+        assertEquals(0, result.skipped());
+        assertEquals(0, result.errors());
+        assertEquals(2, service.getTurnStatsCount());
+    }
+
+    @Test
+    @DisplayName("skips duplicate entries on re-run (idempotent)")
+    void idempotentBackfill() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        createSessionJsonl(basePath, "session-1",
+            turnStatsEntry("2025-01-15T10:00:00Z", 100, 200, 3, 5000, 10, 2, "1x"));
+
+        TurnStatisticsBackfill.backfill(service, basePath);
+        TurnStatisticsBackfill.BackfillResult result =
+            TurnStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(0, result.inserted());
+        assertEquals(1, result.skipped());
+        assertEquals(1, service.getTurnStatsCount());
+    }
+
+    @Test
+    @DisplayName("maps session agent to correct agentId via AgentIdMapper")
+    void mapsAgentToAgentId() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "Claude Code");
+        createSessionJsonl(basePath, "session-1",
+            turnStatsEntry("2025-01-15T10:00:00Z", 100, 200, 3, 5000, 10, 2, "1x"));
+
+        TurnStatisticsBackfill.backfill(service, basePath);
+
+        var agents = service.getDistinctTurnAgents();
+        assertEquals(1, agents.size());
+        assertTrue(agents.contains("claude-cli"));
+    }
+
+    @Test
+    @DisplayName("skips non-turnStats entries in JSONL")
+    void skipsNonTurnStatsEntries() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        createSessionJsonl(basePath, "session-1",
+            "{\"type\":\"tool\",\"title\":\"read_file\",\"status\":\"completed\",\"timestamp\":\"2025-01-15T10:00:00Z\"}",
+            turnStatsEntry("2025-01-15T10:01:00Z", 100, 200, 3, 5000, 10, 2, "1x"),
+            "{\"type\":\"assistant\",\"text\":\"Hello\",\"timestamp\":\"2025-01-15T10:02:00Z\"}");
+
+        TurnStatisticsBackfill.BackfillResult result =
+            TurnStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(1, result.inserted());
+        assertEquals(1, service.getTurnStatsCount());
+    }
+
+    @Test
+    @DisplayName("handles empty multiplier as 1.0 premium request")
+    void emptyMultiplierDefaultsToOne() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        createSessionJsonl(basePath, "session-1",
+            turnStatsEntry("2025-01-15T10:00:00Z", 100, 200, 3, 5000, 10, 2, ""));
+
+        TurnStatisticsBackfill.backfill(service, basePath);
+
+        var results = service.queryDailyTurnStats("2025-01-15", "2025-01-15");
+        assertEquals(1, results.size());
+        assertEquals(1.0, results.getFirst().premiumRequests(), 0.001);
+    }
+
+    @Test
+    @DisplayName("parses fractional premium multiplier (0.5x)")
+    void parsesFractionalMultiplier() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        createSessionJsonl(basePath, "session-1",
+            turnStatsEntry("2025-01-15T10:00:00Z", 100, 200, 3, 5000, 10, 2, "0.5x"));
+
+        TurnStatisticsBackfill.backfill(service, basePath);
+
+        var results = service.queryDailyTurnStats("2025-01-15", "2025-01-15");
+        assertEquals(0.5, results.getFirst().premiumRequests(), 0.001);
+    }
+
+    @Test
+    @DisplayName("handles multiple sessions with different agents")
+    void multipleSessions() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath,
+            new String[]{"session-1", "GitHub Copilot"},
+            new String[]{"session-2", "OpenCode"});
+        createSessionJsonl(basePath, "session-1",
+            turnStatsEntry("2025-01-15T10:00:00Z", 100, 200, 3, 5000, 10, 2, "1x"));
+        createSessionJsonl(basePath, "session-2",
+            turnStatsEntry("2025-01-15T11:00:00Z", 50, 100, 1, 3000, 5, 1, "1x"));
+
+        TurnStatisticsBackfill.BackfillResult result =
+            TurnStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(2, result.inserted());
+        var agents = service.getDistinctTurnAgents();
+        assertEquals(2, agents.size());
+        assertTrue(agents.contains("copilot"));
+        assertTrue(agents.contains("opencode"));
+    }
+
+    @Test
+    @DisplayName("no sessions returns empty result")
+    void noSessions() {
+        TurnStatisticsBackfill.BackfillResult result =
+            TurnStatisticsBackfill.backfill(service, tempDir.toString());
+
+        assertEquals(0, result.inserted());
+        assertEquals(0, result.skipped());
+        assertEquals(0, result.errors());
+    }
+
+    @Test
+    @DisplayName("missing JSONL file is silently skipped")
+    void missingJsonlFileIsSkipped() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-missing", "GitHub Copilot");
+
+        TurnStatisticsBackfill.BackfillResult result =
+            TurnStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(0, result.inserted());
+        assertEquals(0, result.errors());
+    }
+
+    @Test
+    @DisplayName("entry without timestamp uses fallback from previous entry")
+    void fallbackTimestamp() throws IOException {
+        String basePath = tempDir.toString();
+        createSessionIndex(basePath, "session-1", "GitHub Copilot");
+        createSessionJsonl(basePath, "session-1",
+            "{\"type\":\"assistant\",\"text\":\"Hello\",\"timestamp\":\"2025-01-15T10:00:00Z\"}",
+            turnStatsEntryNoTimestamp(100, 200, 3, 5000, 10, 2, "1x"));
+
+        TurnStatisticsBackfill.BackfillResult result =
+            TurnStatisticsBackfill.backfill(service, basePath);
+
+        assertEquals(1, result.inserted());
+        assertTrue(service.hasTurnStatsAt("2025-01-15T10:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("BackfillResult.toString() includes all field counts")
+    void backfillResultToString() {
+        TurnStatisticsBackfill.BackfillResult result =
+            new TurnStatisticsBackfill.BackfillResult(5, 3, 1);
+        assertEquals("BackfillResult{inserted=5, skipped=3, errors=1}", result.toString());
+    }
+
+    @Test
+    @DisplayName("private constructor enforces utility-class pattern")
+    void constructorThrowsUtilityClassException() throws Exception {
+        var constructor = TurnStatisticsBackfill.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        var ex = assertThrows(InvocationTargetException.class, constructor::newInstance);
+        assertInstanceOf(IllegalStateException.class, ex.getCause());
+    }
+
+    // --- Helper methods ---
+
+    private static String turnStatsEntry(String timestamp, long inputTokens, long outputTokens,
+                                         int toolCalls, long durationMs,
+                                         int linesAdded, int linesRemoved, String multiplier) {
+        return "{\"type\":\"turnStats\""
+            + ",\"timestamp\":\"" + timestamp + "\""
+            + ",\"inputTokens\":" + inputTokens
+            + ",\"outputTokens\":" + outputTokens
+            + ",\"toolCallCount\":" + toolCalls
+            + ",\"durationMs\":" + durationMs
+            + ",\"linesAdded\":" + linesAdded
+            + ",\"linesRemoved\":" + linesRemoved
+            + ",\"multiplier\":\"" + multiplier + "\""
+            + "}";
+    }
+
+    private static String turnStatsEntryNoTimestamp(long inputTokens, long outputTokens,
+                                                    int toolCalls, long durationMs,
+                                                    int linesAdded, int linesRemoved,
+                                                    String multiplier) {
+        return "{\"type\":\"turnStats\""
+            + ",\"inputTokens\":" + inputTokens
+            + ",\"outputTokens\":" + outputTokens
+            + ",\"toolCallCount\":" + toolCalls
+            + ",\"durationMs\":" + durationMs
+            + ",\"linesAdded\":" + linesAdded
+            + ",\"linesRemoved\":" + linesRemoved
+            + ",\"multiplier\":\"" + multiplier + "\""
+            + "}";
+    }
+
+    private static void createSessionIndex(String basePath, String sessionId,
+                                           String agent) throws IOException {
+        createSessionIndex(basePath, new String[]{sessionId, agent});
+    }
+
+    private static void createSessionIndex(String basePath,
+                                           String[]... sessions) throws IOException {
+        Path indexDir = Path.of(basePath, ".agent-work", "sessions");
+        Files.createDirectories(indexDir);
+
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < sessions.length; i++) {
+            if (i > 0) sb.append(",");
+            sb.append("{\"id\":\"").append(sessions[i][0]).append("\"")
+                .append(",\"agent\":\"").append(sessions[i][1]).append("\"")
+                .append(",\"name\":\"Test Session\"")
+                .append(",\"createdAt\":1736935200")
+                .append(",\"updatedAt\":1736942400")
+                .append(",\"turnCount\":5")
+                .append("}");
+        }
+        sb.append("]");
+        Files.writeString(indexDir.resolve("sessions-index.json"), sb.toString());
+    }
+
+    private static void createSessionJsonl(String basePath, String sessionId,
+                                           String... entries) throws IOException {
+        Path sessionsDir = Path.of(basePath, ".agent-work", "sessions");
+        Files.createDirectories(sessionsDir);
+        Files.writeString(sessionsDir.resolve(sessionId + ".jsonl"),
+            String.join("\n", entries) + "\n");
+    }
+}


### PR DESCRIPTION
## Summary

Migrate the Charts tab statistics from slow JSONL file scanning to SQLite storage in the existing `tool-stats.db` database.

### Problem

The statistics charts tab (`UsageStatisticsPanel`) loaded data by scanning ALL session JSONL files line-by-line on every open. This was O(n) with total session history size, causing noticeable delays with many sessions.

### Solution

Store per-turn statistics in a new `turn_stats` table in the existing SQLite database (`tool-stats.db`), with indexed date queries for fast chart rendering.

### Changes

**Schema & Service** (`ToolCallStatisticsService.java`):
- New `turn_stats` table with indexes on `date` and `session_id`
- `recordTurnStats()`, `hasTurnStatsAt()`, `getTurnStatsCount()` for writes/dedup
- `queryDailyTurnStats()`, `getDistinctTurnAgents()`, `getEarliestTurnDate()` for chart queries
- `TurnStatsRecord` and `DailyTurnAggregate` record types

**Backfill** (`TurnStatisticsBackfill.java`):
- Scans existing session JSONL files for `turnStats` entries
- Deduplicates by timestamp, maps agent names via `AgentIdMapper`
- Triggered automatically at service init (alongside existing tool call backfill)

**Loader** (`UsageStatisticsLoader.java`):
- `load()` tries SQLite first via `loadFromSqlite()`
- Falls back to original JSONL scanning if SQLite table is empty

**Write path** (`PromptOrchestrator.kt`):
- New `recordTurnStatsToSqlite()` writes to SQLite on pooled thread at turn completion
- Keeps existing JSONL write path for backwards compatibility

**Tests**:
- 15 new tests in `ToolCallStatisticsServiceTest` for turn stats CRUD
- 11 new tests in `TurnStatisticsBackfillTest` for backfill logic

Closes #232 (partially — performance improvement for statistics)