### PR TITLE
fix: nudge append duplicates original content in bubble

### DIFF
--- a/plugin-core/chat-ui/src/ChatController.ts
+++ b/plugin-core/chat-ui/src/ChatController.ts
@@ -825,7 +825,7 @@ const ChatController = {
         if (existing) {
             const bubble = existing.querySelector('message-bubble');
             if (bubble) {
-                bubble.textContent = (bubble.textContent || '') + '\n\n' + text;
+                bubble.textContent = text;
                 this._container()?.scrollIfNeeded();
             }
             return;


### PR DESCRIPTION
## Bug

When appending to a pending nudge (e.g. user sends a second nudge while the first is still pending), the original nudge text gets duplicated in the UI bubble.

**Example:** Nudge "A" then nudge "B" → bubble shows "A\n\nA\n\nB" instead of "A\n\nB".

## Root Cause

Double-concatenation across two layers:

1. **Kotlin** (`submitNudge` in `ChatToolWindowContent.kt:831`): Correctly builds the full combined text `pendingNudgeText = existing + "\n\n" + text` and passes it to `showNudgeBubble(id, pendingNudgeText)`

2. **JS** (`showNudgeBubble` in `ChatController.ts:828`): Also appends to the existing bubble text: `bubble.textContent = (bubble.textContent || '') + '\n\n' + text`

So Kotlin sends `"A\n\nB"` but JS treats it as a new fragment and appends it to `"A"`, producing `"A\n\nA\n\nB"`.

## Fix

One-line change: JS update path now **replaces** `textContent` instead of appending, since the Kotlin side already passes the full accumulated text.

Note: The PsiBridge layer (`setPendingNudge`) correctly receives only the new fragment and merges via `mergeNudges()` — no change needed there.