### PR TITLE
fix: wrap ConfigurationContext in ReadAction in RunTestsTool

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsTool.java
@@ -170,21 +170,20 @@ public final class RunTestsTool extends TestingTool {
 
     // ── Framework-agnostic runner via ConfigurationContext ────
 
-    /**
-     * Resolves the target to a PSI element and uses IntelliJ's {@link ConfigurationContext}
-     * to auto-detect the correct test framework (JUnit, TestNG, pytest, etc.).
-     * Returns null if the target cannot be resolved or no framework matches.
-     */
     private String tryRunViaConfigurationContext(String target) {
         try {
             PsiElement testElement = resolveTestPsiElement(target);
             if (testElement == null) return null;
 
-            ConfigurationContext context = new ConfigurationContext(testElement);
-            var configs = context.createConfigurationsFromContext();
-            if (configs == null || configs.isEmpty()) return null;
+            RunnerAndConfigurationSettings settings = ApplicationManager.getApplication()
+                .runReadAction((Computable<RunnerAndConfigurationSettings>) () -> {
+                    ConfigurationContext context = new ConfigurationContext(testElement);
+                    var configs = context.createConfigurationsFromContext();
+                    if (configs == null || configs.isEmpty()) return null;
+                    return configs.getFirst().getConfigurationSettings();
+                });
+            if (settings == null) return null;
 
-            RunnerAndConfigurationSettings settings = configs.getFirst().getConfigurationSettings();
             settings.setTemporary(true);
             RunManager.getInstance(project).addConfiguration(settings);
             return runTestConfigAndWait(settings);


### PR DESCRIPTION
## Bug

`RuntimeExceptionWithAttachments: Read access is allowed from inside read-action only` when `run_tests` resolves test configurations via `ConfigurationContext`.

**Stack trace:**
```
Thread[mcp-http] → ConfigurationContext.<init> → ModuleUtilCore.findModuleForPsiElement
→ ThreadingAssertions.softAssertReadAccess → BOOM
```

## Root Cause

`tryRunViaConfigurationContext()` calls `resolveTestPsiElement()` which correctly wraps PSI search in `ReadAction`, but then uses the returned `PsiElement` to construct `ConfigurationContext` **outside** the read action. `ConfigurationContext` constructor calls `findModuleForPsiElement` which requires read access.

## Fix

Wrap the `ConfigurationContext` creation and `createConfigurationsFromContext()` in `ReadAction.runReadAction()`. The subsequent config registration and test execution remain outside the read action since they involve write operations.