### PR TITLE
feat: resharper-mcp proxy for search_symbols in Rider

### DIFF
--- a/.idea/libraries/jazzer_api_0_22_0.xml
+++ b/.idea/libraries/jazzer_api_0_22_0.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="jazzer-api-0.22.0">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.code-intelligence/jazzer-api/0.22.0/317999dd11df5e5405dc4b6be92ffa3d6947890f/jazzer-api-0.22.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -78,6 +78,14 @@ public final class PsiBridgeService implements Disposable {
         "insert_before_symbol", // PSI symbol resolution too coarse
         "insert_after_symbol"   // PSI symbol resolution too coarse
     );
+
+    /**
+     * Returns the IDs of tools that are disabled in Rider without resharper-mcp.
+     */
+    public static Set<String> getRiderDisabledToolIds() {
+        return RIDER_DISABLED_TOOLS;
+    }
+
     private final Map<String, ReentrantLock> toolLocks = new ConcurrentHashMap<>();
     private final java.util.concurrent.Semaphore writeToolSemaphore = new java.util.concurrent.Semaphore(1);
     private final WriteBatchCoordinator writeBatchCoordinator = new WriteBatchCoordinator(writeToolSemaphore);
@@ -134,8 +142,18 @@ public final class PsiBridgeService implements Disposable {
         // Rider's C#/C++ PSI lives in the ReSharper backend, not the IntelliJ frontend.
         // Symbol-based tools depend on detailed PSI that Rider doesn't provide, and testing
         // tools are JUnit-specific. Disable them to avoid confusing agents with broken tools.
+        // When resharper-mcp is installed, proxy tools replace the disabled ones where possible.
         if (isRider) {
-            allTools.removeIf(tool -> RIDER_DISABLED_TOOLS.contains(tool.id()));
+            Set<String> remaining = new java.util.HashSet<>(RIDER_DISABLED_TOOLS);
+            if (com.github.catatafishen.agentbridge.psi.tools.rider.ReSharperMcpClient.isAvailable()) {
+                // Replace the standard search_symbols (which uses classifyElement() that fails on
+                // Rider's coarse PSI stubs) with the resharper-mcp proxy implementation.
+                var proxyTool = new com.github.catatafishen.agentbridge.psi.tools.rider.RiderSearchSymbolsProxyTool(project);
+                allTools.removeIf(t -> proxyTool.id().equals(t.id()));
+                allTools.add(proxyTool);
+                remaining.remove(proxyTool.id());
+            }
+            allTools.removeIf(tool -> remaining.contains(tool.id()));
         }
 
         registry.registerAll(allTools);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -20,6 +20,7 @@ import com.intellij.util.messages.Topic;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -80,10 +81,11 @@ public final class PsiBridgeService implements Disposable {
     );
 
     /**
-     * Returns the IDs of tools that are disabled in Rider without resharper-mcp.
+     * Returns the IDs of tools that are disabled in Rider without resharper-mcp,
+     * sorted alphabetically for consistent display order.
      */
-    public static Set<String> getRiderDisabledToolIds() {
-        return RIDER_DISABLED_TOOLS;
+    public static List<String> getRiderDisabledToolIds() {
+        return RIDER_DISABLED_TOOLS.stream().sorted().toList();
     }
 
     private final Map<String, ReentrantLock> toolLocks = new ConcurrentHashMap<>();

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/rider/ReSharperMcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/rider/ReSharperMcpClient.java
@@ -1,0 +1,164 @@
+package com.github.catatafishen.agentbridge.psi.tools.rider;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * HTTP/JSON-RPC client for the resharper-mcp server (localhost:23741).
+ *
+ * <p>resharper-mcp is a companion plugin that exposes ReSharper code intelligence via
+ * an MCP-over-HTTP server. It runs as a ReSharper SolutionComponent inside Rider's
+ * .NET backend, which the JVM frontend cannot reach directly.
+ *
+ * <p>Only used when running in Rider and resharper-mcp is detected.
+ *
+ * @see <a href="https://github.com/joshua-light/resharper-mcp">resharper-mcp</a>
+ */
+public final class ReSharperMcpClient {
+
+    public static final String BASE_URL = "http://127.0.0.1:23741";
+    private static final int TIMEOUT_MS = 5_000;
+    private static final long AVAILABILITY_CACHE_TTL_MS = 30_000;
+
+    private static final AtomicBoolean cachedAvailable = new AtomicBoolean(false);
+    private static final AtomicLong cacheExpiresAt = new AtomicLong(0);
+    private static final java.util.concurrent.atomic.AtomicInteger nextId = new java.util.concurrent.atomic.AtomicInteger(1);
+
+    private ReSharperMcpClient() {
+    }
+
+    /**
+     * Returns true if resharper-mcp is reachable at its default port.
+     * Result is cached for 30 seconds to avoid per-call latency.
+     */
+    public static boolean isAvailable() {
+        long now = System.currentTimeMillis();
+        if (now < cacheExpiresAt.get()) {
+            return cachedAvailable.get();
+        }
+        boolean available = probe();
+        cachedAvailable.set(available);
+        cacheExpiresAt.set(now + AVAILABILITY_CACHE_TTL_MS);
+        return available;
+    }
+
+    /**
+     * Invalidates the cached availability so the next call probes again.
+     */
+    public static void invalidateCache() {
+        cacheExpiresAt.set(0);
+    }
+
+    /**
+     * Calls a resharper-mcp tool via JSON-RPC and returns the text content of the result.
+     *
+     * @param toolName  The MCP tool name (e.g. "search_symbol")
+     * @param arguments The tool arguments as a JsonObject
+     * @return The text content from the tool response, or an error string
+     */
+    public static String callTool(String toolName, JsonObject arguments) {
+        JsonObject request = buildRequest(toolName, arguments);
+        try {
+            String responseBody = post(request.toString());
+            return extractTextContent(responseBody);
+        } catch (IOException e) {
+            invalidateCache();
+            return "Error: resharper-mcp unavailable — " + e.getMessage();
+        }
+    }
+
+    private static JsonObject buildRequest(String toolName, JsonObject arguments) {
+        JsonObject params = new JsonObject();
+        params.addProperty("name", toolName);
+        params.add("arguments", arguments);
+
+        JsonObject request = new JsonObject();
+        request.addProperty("jsonrpc", "2.0");
+        request.addProperty("method", "tools/call");
+        request.addProperty("id", nextId.getAndIncrement());
+        request.add("params", params);
+        return request;
+    }
+
+    private static boolean probe() {
+        JsonObject ping = new JsonObject();
+        ping.addProperty("jsonrpc", "2.0");
+        ping.addProperty("method", "ping");
+        ping.addProperty("id", 0);
+        try {
+            post(ping.toString());
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private static String post(String body) throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) URI.create(BASE_URL).toURL().openConnection();
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setRequestProperty("Accept", "application/json");
+        conn.setConnectTimeout(TIMEOUT_MS);
+        conn.setReadTimeout(TIMEOUT_MS);
+        conn.setDoOutput(true);
+
+        try (OutputStream os = conn.getOutputStream()) {
+            os.write(body.getBytes(StandardCharsets.UTF_8));
+        }
+
+        int status = conn.getResponseCode();
+        InputStream stream = status >= 400 ? conn.getErrorStream() : conn.getInputStream();
+        if (stream == null) return "{}";
+        try (stream) {
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * Extracts the text content from an MCP tools/call response.
+     *
+     * <p>Expected format: {@code {"result":{"content":[{"type":"text","text":"..."}]}}}
+     */
+    private static String extractTextContent(String responseBody) {
+        try {
+            JsonObject response = JsonParser.parseString(responseBody).getAsJsonObject();
+            if (response.has("error")) {
+                return "Error: " + response.get("error").toString();
+            }
+            if (!response.has("result")) return responseBody;
+            JsonObject result = response.getAsJsonObject("result");
+            return extractFromResult(result, responseBody);
+        } catch (Exception e) {
+            return responseBody;
+        }
+    }
+
+    private static String extractFromResult(JsonObject result, String fallback) {
+        JsonArray content = result.getAsJsonArray("content");
+        if (content == null || content.isEmpty()) return "(empty response)";
+
+        if (result.has("isError") && result.get("isError").getAsBoolean()) {
+            return "Error: " + content.get(0).getAsJsonObject().get("text").getAsString();
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < content.size(); i++) {
+            JsonObject item = content.get(i).getAsJsonObject();
+            if (item.has("text")) {
+                if (!sb.isEmpty()) sb.append("\n");
+                sb.append(item.get("text").getAsString());
+            }
+        }
+        return sb.isEmpty() ? fallback : sb.toString();
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/rider/ReSharperMcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/rider/ReSharperMcpClient.java
@@ -112,15 +112,22 @@ public final class ReSharperMcpClient {
         conn.setReadTimeout(TIMEOUT_MS);
         conn.setDoOutput(true);
 
-        try (OutputStream os = conn.getOutputStream()) {
-            os.write(body.getBytes(StandardCharsets.UTF_8));
-        }
+        try {
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(body.getBytes(StandardCharsets.UTF_8));
+            }
 
-        int status = conn.getResponseCode();
-        InputStream stream = status >= 400 ? conn.getErrorStream() : conn.getInputStream();
-        if (stream == null) return "{}";
-        try (stream) {
-            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            int status = conn.getResponseCode();
+            if (status >= 400) {
+                throw new IOException("HTTP " + status);
+            }
+            InputStream stream = conn.getInputStream();
+            if (stream == null) return "{}";
+            try (stream) {
+                return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            }
+        } finally {
+            conn.disconnect();
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/rider/RiderSearchSymbolsProxyTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/rider/RiderSearchSymbolsProxyTool.java
@@ -1,0 +1,86 @@
+package com.github.catatafishen.agentbridge.psi.tools.rider;
+
+import com.github.catatafishen.agentbridge.psi.tools.navigation.NavigationTool;
+import com.github.catatafishen.agentbridge.ui.renderers.SearchResultRenderer;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Rider-only implementation of {@code search_symbols} that proxies to resharper-mcp's
+ * {@code search_symbol} tool.
+ *
+ * <p>The standard {@link com.github.catatafishen.agentbridge.psi.tools.navigation.SearchSymbolsTool}
+ * uses {@code classifyElement()} which fails on Rider's coarse PSI stubs. resharper-mcp
+ * delegates to the ReSharper backend where full C#/F# symbol resolution is available.
+ *
+ * <p>Registered only when running in Rider AND resharper-mcp is reachable at
+ * {@value ReSharperMcpClient#BASE_URL}.
+ */
+public final class RiderSearchSymbolsProxyTool extends NavigationTool {
+
+    public RiderSearchSymbolsProxyTool(Project project) {
+        super(project);
+    }
+
+    @Override
+    public @NotNull String id() {
+        return "search_symbols";
+    }
+
+    @Override
+    public @NotNull String displayName() {
+        return "Search Symbols";
+    }
+
+    @Override
+    public @NotNull String description() {
+        return "Search for classes, methods, or fields by name using ReSharper's symbol index. " +
+            "Semantic search — works for C#, F#, VB, and any language with ReSharper PSI support. " +
+            "For textual/regex search across file contents, use search_text. " +
+            "For all usages of a specific symbol, use find_references. " +
+            "(Rider: delegated to resharper-mcp)";
+    }
+
+    @Override
+    public @NotNull Kind kind() {
+        return Kind.SEARCH;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
+    public @NotNull JsonObject inputSchema() {
+        return schema(
+            Param.required("query", TYPE_STRING, "Symbol name to search for"),
+            Param.optional("type", TYPE_STRING,
+                "Optional: filter by type (class, method, field, property, event). Default: all types", "")
+        );
+    }
+
+    @Override
+    public @NotNull Object resultRenderer() {
+        return SearchResultRenderer.INSTANCE;
+    }
+
+    @Override
+    public @NotNull String execute(@NotNull JsonObject args) {
+        String query = args.has(PARAM_QUERY) ? args.get(PARAM_QUERY).getAsString() : "";
+        String typeFilter = args.has("type") ? args.get("type").getAsString() : "";
+
+        showSearchFeedback("🔍 Searching symbols: " + query);
+
+        JsonObject rsmArgs = new JsonObject();
+        rsmArgs.addProperty("symbolName", query);
+        if (!typeFilter.isEmpty()) {
+            rsmArgs.addProperty("kind", typeFilter);
+        }
+
+        String result = ReSharperMcpClient.callTool("search_symbol", rsmArgs);
+        showSearchFeedback("✓ Symbol search complete: " + query);
+        return result;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolsConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolsConfigurable.java
@@ -80,6 +80,14 @@ public final class ToolsConfigurable implements Configurable {
         limitHint.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
         toolsPanel.add(limitHint);
 
+        // In Rider, some tools are unavailable because they depend on IntelliJ PSI not present
+        // in Rider's JVM frontend. If resharper-mcp is not installed, show an info note.
+        boolean isRider = com.github.catatafishen.agentbridge.psi.PlatformApiCompat.isPluginInstalled(
+            "com.intellij.modules.rider");
+        if (isRider && !com.github.catatafishen.agentbridge.psi.tools.rider.ReSharperMcpClient.isAvailable()) {
+            toolsPanel.add(buildRiderInfoPanel());
+        }
+
         // Global enable/disable row — max height pinned to prevent vertical stretch
         JButton enableAllBtn = new JButton("Enable All");
         JButton disableAllBtn = new JButton("Disable All");
@@ -372,5 +380,23 @@ public final class ToolsConfigurable implements Configurable {
     private static @Nullable String keyOf(ThemeColorComboBox combo) {
         ThemeColor tc = combo.getSelectedThemeColor();
         return tc != null ? tc.name() : null;
+    }
+
+    /**
+     * Builds an info panel shown in Rider when resharper-mcp is not installed.
+     * Lists the tools that are currently disabled and links to the companion plugin.
+     */
+    private static JComponent buildRiderInfoPanel() {
+        String disabledList = String.join(", ",
+            com.github.catatafishen.agentbridge.psi.PsiBridgeService.getRiderDisabledToolIds());
+        JBLabel label = new JBLabel(
+            "<html><b>⚠ Rider:</b> The following tools are unavailable in Rider without the "
+                + "<a href='https://github.com/joshua-light/resharper-mcp'>resharper-mcp</a> "
+                + "companion plugin: <br><i>" + disabledList + "</i></html>");
+        label.setForeground(UIUtil.getContextHelpForeground());
+        label.setAlignmentX(Component.LEFT_ALIGNMENT);
+        label.setBorder(JBUI.Borders.empty(4, 0, 8, 0));
+        label.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+        return label;
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolsConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ToolsConfigurable.java
@@ -4,6 +4,7 @@ import com.github.catatafishen.agentbridge.services.ToolDefinition;
 import com.github.catatafishen.agentbridge.services.ToolRegistry;
 import com.github.catatafishen.agentbridge.ui.ThemeColor;
 import com.github.catatafishen.agentbridge.ui.ToolKindColors;
+import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.TitledSeparator;
@@ -18,12 +19,14 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import javax.swing.event.HyperlinkEvent;
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Settings page: Settings → Tools → AgentBridge → MCP → Tools.
@@ -81,11 +84,37 @@ public final class ToolsConfigurable implements Configurable {
         toolsPanel.add(limitHint);
 
         // In Rider, some tools are unavailable because they depend on IntelliJ PSI not present
-        // in Rider's JVM frontend. If resharper-mcp is not installed, show an info note.
+        // in Rider's JVM frontend. Probe for resharper-mcp in background to avoid blocking the EDT.
         boolean isRider = com.github.catatafishen.agentbridge.psi.PlatformApiCompat.isPluginInstalled(
             "com.intellij.modules.rider");
-        if (isRider && !com.github.catatafishen.agentbridge.psi.tools.rider.ReSharperMcpClient.isAvailable()) {
-            toolsPanel.add(buildRiderInfoPanel());
+        if (isRider) {
+            JBPanel<?> riderInfoContainer = new JBPanel<>();
+            riderInfoContainer.setLayout(new BoxLayout(riderInfoContainer, BoxLayout.Y_AXIS));
+            riderInfoContainer.setAlignmentX(Component.LEFT_ALIGNMENT);
+            toolsPanel.add(riderInfoContainer);
+            new SwingWorker<Boolean, Void>() {
+                @Override
+                protected Boolean doInBackground() {
+                    return com.github.catatafishen.agentbridge.psi.tools.rider.ReSharperMcpClient.isAvailable();
+                }
+
+                @Override
+                protected void done() {
+                    boolean available = false;
+                    try {
+                        available = get();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } catch (ExecutionException e) {
+                        // probe failed; treat as unavailable and show the banner
+                    }
+                    if (!available) {
+                        riderInfoContainer.add(buildRiderInfoPanel());
+                        riderInfoContainer.revalidate();
+                        riderInfoContainer.repaint();
+                    }
+                }
+            }.execute();
         }
 
         // Global enable/disable row — max height pinned to prevent vertical stretch
@@ -389,14 +418,23 @@ public final class ToolsConfigurable implements Configurable {
     private static JComponent buildRiderInfoPanel() {
         String disabledList = String.join(", ",
             com.github.catatafishen.agentbridge.psi.PsiBridgeService.getRiderDisabledToolIds());
-        JBLabel label = new JBLabel(
-            "<html><b>⚠ Rider:</b> The following tools are unavailable in Rider without the "
+        JEditorPane pane = new JEditorPane(
+            "text/html",
+            "<html><body><b>⚠ Rider:</b> The following tools are unavailable in Rider without the "
                 + "<a href='https://github.com/joshua-light/resharper-mcp'>resharper-mcp</a> "
-                + "companion plugin: <br><i>" + disabledList + "</i></html>");
-        label.setForeground(UIUtil.getContextHelpForeground());
-        label.setAlignmentX(Component.LEFT_ALIGNMENT);
-        label.setBorder(JBUI.Borders.empty(4, 0, 8, 0));
-        label.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
-        return label;
+                + "companion plugin: <br><i>" + disabledList + "</i></body></html>"
+        );
+        pane.setEditable(false);
+        pane.setOpaque(false);
+        pane.setForeground(UIUtil.getContextHelpForeground());
+        pane.setAlignmentX(Component.LEFT_ALIGNMENT);
+        pane.setBorder(JBUI.Borders.empty(4, 0, 8, 0));
+        pane.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+        pane.addHyperlinkListener(e -> {
+            if (HyperlinkEvent.EventType.ACTIVATED.equals(e.getEventType()) && e.getURL() != null) {
+                BrowserUtil.browse(e.getURL().toExternalForm());
+            }
+        });
+        return pane;
     }
 }


### PR DESCRIPTION
## Summary

When [resharper-mcp](https://github.com/joshua-light/resharper-mcp) is installed and reachable at `localhost:23741`, AgentBridge now provides `search_symbols` in Rider via a direct HTTP proxy instead of disabling the tool.

## Why

The standard `search_symbols` uses `classifyElement()` which fails on Rider's coarse PSI stubs. resharper-mcp has full ReSharper PSI access and exposes a `search_symbol` tool that maps directly.

## Changes

- **`ReSharperMcpClient.java`** — lightweight JSON-RPC/HTTP client (no MCP-on-MCP overhead). 30-second availability cache with automatic invalidation on errors.
- **`RiderSearchSymbolsProxyTool.java`** — `search_symbols` implementation that proxies `query` → `symbolName`, `type` → `kind` to resharper-mcp.
- **`PsiBridgeService`** — detects resharper-mcp at startup; if available, swaps search_symbols with the proxy instead of disabling it.
- **`ToolsConfigurable`** — in Rider without resharper-mcp, shows an info banner listing the 6 disabled tools with a link to the companion plugin.

## Architecture

This is **not** MCP-over-MCP. AgentBridge calls resharper-mcp's HTTP API directly from the Java handler and returns the result through its own MCP channel. No extra protocol layer.

## Future

With collaboration from the resharper-mcp author, 5 more tools could be enabled: `replace_symbol_body`, `insert_before_symbol`, `insert_after_symbol`, `list_tests`, `run_tests`.