### PR TITLE
feat: OSS-Fuzz onboarding — 5 new fuzz targets + config

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -43,7 +43,7 @@ jobs:
           cache-disabled: true
 
       - name: Build test classpath
-        run: ./gradlew :plugin-core:testClasses --no-daemon --quiet
+        run: ./gradlew :plugin-core:testClasses :mcp-server:testClasses --no-daemon --quiet
 
       - name: Download Jazzer
         env:
@@ -58,8 +58,9 @@ jobs:
       - name: Resolve test classpath
         id: classpath
         run: |
-          CP=$(./gradlew :plugin-core:printFuzzClasspath --no-daemon -q | tail -1)
-          echo "cp=$CP" >> "$GITHUB_OUTPUT"
+          CP_CORE=$(./gradlew :plugin-core:printFuzzClasspath --no-daemon -q | tail -1)
+          CP_MCP=$(./gradlew :mcp-server:printFuzzClasspath --no-daemon -q | tail -1)
+          echo "cp=${CP_CORE}:${CP_MCP}" >> "$GITHUB_OUTPUT"
 
       - name: Run Jazzer fuzz targets
         env:
@@ -69,6 +70,11 @@ jobs:
           TARGETS=(
             com.github.catatafishen.agentbridge.fuzz.AgentIdMapperFuzz
             com.github.catatafishen.agentbridge.fuzz.MarkdownRendererFuzz
+            com.github.catatafishen.agentbridge.fuzz.TimeArgParserFuzz
+            com.github.catatafishen.agentbridge.fuzz.AbuseDetectorFuzz
+            com.github.catatafishen.agentbridge.fuzz.NewSessionResponseFuzz
+            com.github.catatafishen.agentbridge.fuzz.JunitXmlParserFuzz
+            com.github.copilot.mcp.McpStdioProxyFuzz
           )
           FAILED=0
 

--- a/mcp-server/build.gradle.kts
+++ b/mcp-server/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:${providers.gradleProperty("junitVersion").get()}")
+    testImplementation("com.code-intelligence:jazzer-api:${providers.gradleProperty("jazzerVersion").get()}")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
@@ -23,6 +24,15 @@ tasks.jar {
 tasks.test {
     useJUnitPlatform()
     finalizedBy(tasks.named("jacocoTestReport"))
+}
+
+tasks.register("printFuzzClasspath") {
+    description = "Print the test runtime classpath for standalone Jazzer fuzz runs"
+    group = "verification"
+    dependsOn("testClasses")
+    doLast {
+        println(sourceSets.test.get().runtimeClasspath.asPath)
+    }
 }
 
 tasks.named<JacocoReport>("jacocoTestReport") {

--- a/mcp-server/src/test/java/com/github/copilot/mcp/McpStdioProxyFuzz.java
+++ b/mcp-server/src/test/java/com/github/copilot/mcp/McpStdioProxyFuzz.java
@@ -1,0 +1,34 @@
+package com.github.copilot.mcp;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+/**
+ * Jazzer fuzz target for {@link McpStdioProxy#extractJsonRpcId(String)} and
+ * {@link McpStdioProxy#buildErrorResponse(String, String)}.
+ *
+ * <p>These are hand-rolled JSON parsers on the critical path — every MCP message
+ * from an agent flows through them. Malformed JSON (unclosed strings, nested "id"
+ * keys, UTF-8 edge cases) could cause index-out-of-bounds or response injection.
+ *
+ * <p>To run: {@code java -jar jazzer.jar --cp=<test-classpath>
+ * --target_class=com.github.copilot.mcp.fuzz.McpStdioProxyFuzz}
+ */
+public class McpStdioProxyFuzz {
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        String message = data.consumeString(data.remainingBytes() / 2);
+        String errorMessage = data.consumeRemainingAsString();
+
+        // extractJsonRpcId must never throw — it returns "null" for unparseable input
+        String id = McpStdioProxy.extractJsonRpcId(message);
+        if (id == null) {
+            throw new AssertionError("extractJsonRpcId returned null (should return \"null\" string)");
+        }
+
+        // buildErrorResponse must produce valid-ish JSON for any input
+        String response = McpStdioProxy.buildErrorResponse(message, errorMessage);
+        if (response == null || response.isEmpty()) {
+            throw new AssertionError("buildErrorResponse returned null/empty");
+        }
+    }
+}

--- a/oss-fuzz/Dockerfile
+++ b/oss-fuzz/Dockerfile
@@ -1,0 +1,8 @@
+FROM gcr.io/oss-fuzz-base/base-builder-jvm
+
+RUN curl -sSfL -o /usr/local/bin/gradle https://services.gradle.org/distributions/gradle-8.14-bin.zip || true
+
+RUN git clone --depth 1 https://github.com/catatafishen/agentbridge.git /src/agentbridge
+WORKDIR /src/agentbridge
+
+COPY build.sh $SRC/

--- a/oss-fuzz/build.sh
+++ b/oss-fuzz/build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -eu
+#
+# OSS-Fuzz build script for AgentBridge (IntelliJ Copilot Plugin).
+# Called inside the Docker container by OSS-Fuzz infrastructure.
+# $SRC, $OUT, and $JAVA_HOME are set by the base image.
+
+cd /src/agentbridge
+
+# Build all test classes (includes fuzz targets)
+./gradlew :plugin-core:testClasses :mcp-server:testClasses --no-daemon --quiet
+
+# Resolve full test runtime classpath for each module
+CP_CORE=$(./gradlew :plugin-core:printFuzzClasspath --no-daemon -q | tail -1)
+CP_MCP=$(./gradlew :mcp-server:printFuzzClasspath --no-daemon -q | tail -1)
+FULL_CP="${CP_CORE}:${CP_MCP}"
+
+# Fuzz target classes — each has a fuzzerTestOneInput(FuzzedDataProvider) entry point
+TARGETS=(
+  com.github.catatafishen.agentbridge.fuzz.AgentIdMapperFuzz
+  com.github.catatafishen.agentbridge.fuzz.MarkdownRendererFuzz
+  com.github.catatafishen.agentbridge.fuzz.TimeArgParserFuzz
+  com.github.catatafishen.agentbridge.fuzz.AbuseDetectorFuzz
+  com.github.catatafishen.agentbridge.fuzz.NewSessionResponseFuzz
+  com.github.catatafishen.agentbridge.fuzz.JunitXmlParserFuzz
+  com.github.copilot.mcp.McpStdioProxyFuzz
+)
+
+for target in "${TARGETS[@]}"; do
+  short_name="${target##*.}"
+  # $JAZZER_FUZZ_TARGET_CLASS is read by the Jazzer driver
+  cat > "$OUT/${short_name}.sh" <<EOF
+#!/bin/bash
+export JAZZER_FUZZ_TARGET_CLASS=${target}
+this_dir=\$(dirname "\$0")
+"\$this_dir/${short_name}_driver" "\$@"
+EOF
+  chmod +x "$OUT/${short_name}.sh"
+
+  # Package Jazzer driver + classpath into a single archive
+  "$JAVA_HOME/bin/jar" cf "$OUT/${short_name}_seed_corpus.zip" -C /dev/null . 2>/dev/null || true
+  compile_java_fuzzer "$SRC/agentbridge" "$target" "$OUT/${short_name}" "$FULL_CP"
+done

--- a/oss-fuzz/project.yaml
+++ b/oss-fuzz/project.yaml
@@ -1,0 +1,10 @@
+homepage: "https://github.com/catatafishen/agentbridge"
+language: jvm
+primary_contact: "catatafishen@users.noreply.github.com"
+main_repo: "https://github.com/catatafishen/agentbridge.git"
+fuzzing_engines:
+  - jazzer
+sanitizers:
+  - address
+vendor_ccs:
+  - "catatafishen@users.noreply.github.com"

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/JunitXmlParser.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/JunitXmlParser.java
@@ -14,7 +14,7 @@ import java.util.List;
  * Utility class for parsing JUnit XML test reports and test target strings.
  * All methods are stateless and have no IntelliJ dependencies.
  */
-final class JunitXmlParser {
+public final class JunitXmlParser {
 
     private static final String BUILD_DIR = "build";
     private static final String ATTR_MESSAGE = "message";
@@ -106,15 +106,15 @@ final class JunitXmlParser {
 
     // ── Single XML file parsing ──────────────────────────────
 
-    record TestSuiteResult(int tests, int failed, int errors, int skipped,
-                           double time, List<String> failures) {
+    public record TestSuiteResult(int tests, int failed, int errors, int skipped,
+                                  double time, List<String> failures) {
     }
 
     /**
      * Parses a single JUnit XML test suite report file.
      * Returns {@code null} if parsing fails.
      */
-    static TestSuiteResult parseTestSuiteXml(Path xmlFile) {
+    public static TestSuiteResult parseTestSuiteXml(Path xmlFile) {
         try {
             var dbf = DocumentBuilderFactory.newInstance();
             //noinspection HttpUrlsUsage - XML feature URI, not an actual URL

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/fuzz/AbuseDetectorFuzz.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/fuzz/AbuseDetectorFuzz.java
@@ -1,0 +1,29 @@
+package com.github.catatafishen.agentbridge.fuzz;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.github.catatafishen.agentbridge.permissions.AbuseDetector;
+
+/**
+ * Jazzer fuzz target for {@link AbuseDetector}.
+ *
+ * <p>The AbuseDetector uses a hand-rolled JSON field extractor ({@code extractCommand})
+ * that scans for {@code "command"} by index and uses a custom {@code findClosingQuote}
+ * that doesn't handle double-escaped backslashes. This is security-critical — it
+ * determines whether a tool call is denied. Crafted JSON could bypass detection.
+ *
+ * <p>To run: {@code java -jar jazzer.jar --cp=<test-classpath>
+ * --target_class=com.github.catatafishen.agentbridge.fuzz.AbuseDetectorFuzz}
+ */
+public class AbuseDetectorFuzz {
+
+    private static final AbuseDetector DETECTOR = new AbuseDetector();
+    private static final String[] TOOL_IDS = {"run_command", "run_in_terminal", "write_terminal_input"};
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        String toolId = data.pickValue(TOOL_IDS);
+        String arguments = data.consumeRemainingAsString();
+
+        // check() must never throw — it returns null for "no abuse detected"
+        DETECTOR.check(toolId, arguments);
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/fuzz/JunitXmlParserFuzz.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/fuzz/JunitXmlParserFuzz.java
@@ -1,0 +1,41 @@
+package com.github.catatafishen.agentbridge.fuzz;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.github.catatafishen.agentbridge.psi.tools.testing.JunitXmlParser;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Jazzer fuzz target for {@link JunitXmlParser}.
+ *
+ * <p>Parses JUnit XML test reports. The parser uses {@code DocumentBuilderFactory}
+ * with XXE protection, but could still be tested for billion laughs variants, huge
+ * attribute values, and malformed XML that causes uncaught NumberFormatException
+ * in {@code intAttr()} / {@code doubleAttr()}.
+ *
+ * <p>To run: {@code java -jar jazzer.jar --cp=<test-classpath>
+ * --target_class=com.github.catatafishen.agentbridge.fuzz.JunitXmlParserFuzz}
+ */
+public class JunitXmlParserFuzz {
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        byte[] xmlBytes = data.consumeRemainingAsBytes();
+        Path tempFile = null;
+        try {
+            tempFile = Files.createTempFile("fuzz-junit-", ".xml");
+            Files.write(tempFile, xmlBytes);
+            JunitXmlParser.parseTestSuiteXml(tempFile);
+        } catch (Exception ignored) {
+            // XML parse errors, IO errors, and format errors are expected
+        } finally {
+            if (tempFile != null) {
+                try {
+                    Files.deleteIfExists(tempFile);
+                } catch (Exception ignored) {
+                    // cleanup best-effort
+                }
+            }
+        }
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/fuzz/NewSessionResponseFuzz.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/fuzz/NewSessionResponseFuzz.java
@@ -1,0 +1,35 @@
+package com.github.catatafishen.agentbridge.fuzz;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.github.catatafishen.agentbridge.acp.model.NewSessionResponse;
+import com.github.catatafishen.agentbridge.acp.model.NewSessionResponseDeserializer;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+
+/**
+ * Jazzer fuzz target for {@link NewSessionResponseDeserializer}.
+ *
+ * <p>This deserializer normalises 3+ wire formats for models, modes, and configOptions
+ * from different ACP agents. Type confusion between arrays, objects, primitives, and null
+ * values at every level could cause ClassCastException or NullPointerException.
+ *
+ * <p>To run: {@code java -jar jazzer.jar --cp=<test-classpath>
+ * --target_class=com.github.catatafishen.agentbridge.fuzz.NewSessionResponseFuzz}
+ */
+public class NewSessionResponseFuzz {
+
+    private static final Gson GSON = new GsonBuilder()
+        .registerTypeAdapter(NewSessionResponse.class, new NewSessionResponseDeserializer())
+        .create();
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        String json = data.consumeRemainingAsString();
+        try {
+            GSON.fromJson(json, NewSessionResponse.class);
+        } catch (JsonParseException ignored) {
+            // Expected for malformed JSON — Gson's contract
+        }
+        // Any other exception type (NPE, ClassCastException, etc.) is a bug
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/fuzz/TimeArgParserFuzz.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/fuzz/TimeArgParserFuzz.java
@@ -1,0 +1,28 @@
+package com.github.catatafishen.agentbridge.fuzz;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.github.catatafishen.agentbridge.psi.TimeArgParser;
+
+/**
+ * Jazzer fuzz target for {@link TimeArgParser#parseLocalDateTime(String)}.
+ *
+ * <p>TimeArgParser accepts 7+ date/time formats (relative, ISO 8601, date-only, time-only).
+ * Waterfall parsing with multiple catch-and-fallthrough blocks makes it vulnerable to
+ * edge cases: overflow in relative amounts ({@code 999999999999h}), unexpected format
+ * interactions, and log injection via the error message.
+ *
+ * <p>To run: {@code java -jar jazzer.jar --cp=<test-classpath>
+ * --target_class=com.github.catatafishen.agentbridge.fuzz.TimeArgParserFuzz}
+ */
+public class TimeArgParserFuzz {
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        String value = data.consumeRemainingAsString();
+        try {
+            TimeArgParser.parseLocalDateTime(value);
+        } catch (IllegalArgumentException ignored) {
+            // Expected for unparseable input — the contract says so
+        }
+        // Any other exception type is a genuine bug
+    }
+}


### PR DESCRIPTION
## Summary

Adds 5 new Jazzer fuzz targets and the OSS-Fuzz project configuration for Scorecard Fuzzing score improvement.

### New Fuzz Targets

| Target | Module | What it fuzzes |
|--------|--------|----------------|
| `McpStdioProxyFuzz` | mcp-server | Hand-rolled JSON parser for `extractJsonRpcId`/`buildErrorResponse` — critical path for all MCP messages |
| `AbuseDetectorFuzz` | plugin-core | Security-critical command extraction from tool arguments (`extractCommand`/`findClosingQuote`) |
| `TimeArgParserFuzz` | plugin-core | Waterfall date/time parser with 7+ formats — overflow and edge case potential |
| `NewSessionResponseFuzz` | plugin-core | Multi-format JSON normalization for ACP session responses |
| `JunitXmlParserFuzz` | plugin-core | JUnit XML test report parsing with XXE protection testing |

### Infrastructure Changes

- **mcp-server/build.gradle.kts**: Added `jazzer-api` dependency and `printFuzzClasspath` task
- **fuzz.yml workflow**: Builds both `plugin-core` and `mcp-server` test classes, resolves combined classpath, expanded targets from 2→7
- **JunitXmlParser.java**: Made class, record, and method `public` for cross-package fuzz access
- **oss-fuzz/**: Project config (project.yaml, Dockerfile, build.sh) ready for google/oss-fuzz PR submission

### OSS-Fuzz Onboarding

The `oss-fuzz/` directory contains the configuration needed to submit a PR to [google/oss-fuzz](https://github.com/google/oss-fuzz). Once accepted, OSS-Fuzz runs fuzz targets continuously and the Scorecard Fuzzing check score improves.

Closes #192