### PR TITLE
fix: remove broken attestation file collection from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,16 +177,6 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
         with:
           subject-path: '${{ steps.artifacts.outputs.dir }}/*.zip'
-          push-to-registry: false
-
-      - name: Collect provenance attestations
-        if: steps.version.outputs.skip != 'true'
-        env:
-          ARTIFACTS_DIR: ${{ steps.artifacts.outputs.dir }}
-        run: |
-          # Move attestation files (created in current directory) to artifacts directory
-          mv *.attestation "$ARTIFACTS_DIR/" 2>/dev/null || true
-          ls -la "$ARTIFACTS_DIR"
 
       - name: Install cosign
         if: steps.version.outputs.skip != 'true'
@@ -223,5 +213,4 @@ jobs:
             --title "Release $TAG" \
             --notes-file build/release-notes.md \
             "$ARTIFACTS_DIR"/*.zip \
-            "$ARTIFACTS_DIR"/*.sigstore.json \
-            "$ARTIFACTS_DIR"/*.attestation
+            "$ARTIFACTS_DIR"/*.sigstore.json


### PR DESCRIPTION
## Root Cause

The release workflow failed at step "Create tag and GitHub release" because `$ARTIFACTS_DIR/*.attestation` matched no files.

**What happened:**
1. `attest-build-provenance` with `push-to-registry: false` stores attestations in GitHub's attestation store (API), **not** as local files
2. The "Collect provenance attestations" step (`mv *.attestation ...`) silently did nothing (`|| true`)
3. The `*.attestation` glob in `gh release create` expanded to a literal nonexistent path → exit code 1

**Fix:**
- Remove `push-to-registry: false` — the default (GitHub attestation store) is correct for Scorecard
- Remove the broken "Collect provenance attestations" step
- Remove `*.attestation` from the release upload globs

Attestations are still generated and stored in the GitHub attestation store (verifiable via `gh attestation verify`).