### PR TITLE
fix: pin Docker image by hash for Scorecard pinned-dependencies

### DIFF
--- a/oss-fuzz/Dockerfile
+++ b/oss-fuzz/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm@sha256:d4d8b420a4de8dcde2f2677f38b8ea4ba6f9f3bcb9773859ad3b3ca676351530
 
 RUN curl -sSfL -o /usr/local/bin/gradle https://services.gradle.org/distributions/gradle-8.14-bin.zip || true
 


### PR DESCRIPTION
Pin `gcr.io/oss-fuzz-base/base-builder-jvm` to its sha256 digest in `oss-fuzz/Dockerfile` so Scorecard's **Pinned-Dependencies** check scores 10/10 (was 9/10).

Also updated in the [OSS-Fuzz PR](https://github.com/google/oss-fuzz/pull/15377).