### PR TITLE
fix: SqliteJarStripper cleanup and Gradle lazy config

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,10 +4,22 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <compositeConfiguration>
+          <compositeBuild compositeDefinitionSource="SCRIPT">
+            <builds>
+              <build path="$PROJECT_DIR$/buildSrc" name="buildSrc">
+                <projects>
+                  <project path="$PROJECT_DIR$/buildSrc" />
+                </projects>
+              </build>
+            </builds>
+          </compositeBuild>
+        </compositeConfiguration>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/buildSrc" />
             <option value="$PROJECT_DIR$/integration-tests" />
             <option value="$PROJECT_DIR$/mcp-server" />
             <option value="$PROJECT_DIR$/plugin-core" />

--- a/buildSrc/src/main/java/SqliteJarStripper.java
+++ b/buildSrc/src/main/java/SqliteJarStripper.java
@@ -1,35 +1,42 @@
-import java.io.*;
-import java.nio.file.*;
-import java.util.zip.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
 
 /**
  * Strips unused native libraries from sqlite-jdbc JAR.
- * 
+ * <p>
  * sqlite-jdbc bundles 24 platform/architecture combinations (~14 MB).
  * This utility keeps only:
- * - Linux x86_64
+ * - Linux amd64 (x86_64)
  * - macOS aarch64
  * - Windows x86_64
- * 
+ * <p>
  * All other native libraries are removed, typically saving ~10 MB.
  */
 public class SqliteJarStripper {
-    
+
     public void strip(File inputJar, File outputJar) throws IOException {
-        outputJar.getParentFile().mkdirs();
-        
-        long originalSize = 0;
-        long strippedSize = 0;
-        
+        File parentDir = outputJar.getParentFile();
+        if (parentDir != null && !parentDir.exists() && !parentDir.mkdirs()) {
+            throw new IOException("Failed to create output directory: " + parentDir);
+        }
+
+        long originalSize;
+        long strippedSize;
+
         try (ZipInputStream zis = new ZipInputStream(new FileInputStream(inputJar));
              ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(outputJar))) {
-            
+
             originalSize = inputJar.length();
-            
+
             ZipEntry entry;
             while ((entry = zis.getNextEntry()) != null) {
                 String entryPath = entry.getName();
-                
+
                 // Keep entries that are either:
                 // 1. Not native libraries (don't start with org/sqlite/native/)
                 // 2. Supported platform native libraries
@@ -37,14 +44,14 @@ public class SqliteJarStripper {
                     entryPath.contains("Linux/amd64/") ||
                     entryPath.contains("Mac/aarch64/") ||
                     entryPath.contains("Windows/x86_64/");
-                
+
                 if (keep) {
                     ZipEntry newEntry = new ZipEntry(entryPath);
                     newEntry.setTime(entry.getTime());
                     newEntry.setCompressedSize(-1);
-                    
+
                     zos.putNextEntry(newEntry);
-                    
+
                     if (!entry.isDirectory()) {
                         byte[] buffer = new byte[8192];
                         int bytesRead;
@@ -52,20 +59,17 @@ public class SqliteJarStripper {
                             zos.write(buffer, 0, bytesRead);
                         }
                     }
-                    
+
                     zos.closeEntry();
                 }
             }
         }
-        
+
         strippedSize = outputJar.length();
         long savedMB = (originalSize - strippedSize) / (1024 * 1024);
         long originalMB = originalSize / (1024 * 1024);
         long strippedMB = strippedSize / (1024 * 1024);
-        
-        System.out.println(String.format(
-            "SQLite JAR stripped: %dMB → %dMB (−%dMB)", 
-            originalMB, strippedMB, savedMB
-        ));
+
+        System.out.printf("SQLite JAR stripped: %dMB → %dMB (−%dMB)%n", originalMB, strippedMB, savedMB);
     }
 }

--- a/plugin-core/build.gradle.kts
+++ b/plugin-core/build.gradle.kts
@@ -90,18 +90,16 @@ val stripSqliteNatives = tasks.register("stripSqliteNatives") {
     group = "build"
     description = "Strip unused native libraries from sqlite-jdbc JAR"
 
-    val sqliteJdbcConfig = configurations.runtimeClasspath.get()
-    val sqliteJar = sqliteJdbcConfig.find { it.name.startsWith("sqlite-jdbc-") }
-        ?: error("sqlite-jdbc not found in runtime classpath")
+    val runtimeClasspath = configurations.named("runtimeClasspath")
+    val outputJar = layout.buildDirectory.file("libs/sqlite-jdbc-stripped.jar")
 
-    val buildDir = layout.buildDirectory.asFile.get()
-    val outputJar = File(buildDir, "libs/sqlite-jdbc-stripped.jar")
-
-    inputs.file(sqliteJar)
+    inputs.files(runtimeClasspath)
     outputs.file(outputJar)
 
     doLast {
-        SqliteJarStripper().strip(sqliteJar, outputJar)
+        val sqliteJar = runtimeClasspath.get().find { it.name.startsWith("sqlite-jdbc-") }
+            ?: error("sqlite-jdbc not found in runtime classpath")
+        SqliteJarStripper().strip(sqliteJar, outputJar.get().asFile)
     }
 }
 


### PR DESCRIPTION
Follow-up to #256 addressing review comments 1, 3, and 4.

## Changes

### `buildSrc/src/main/java/SqliteJarStripper.java`
- Replace wildcard imports (`java.io.*`, `java.util.zip.*`) with specific imports
- Remove unused `java.nio.file.*` import
- Fix class comment: "Linux x86_64" → "Linux amd64 (x86_64)" (the JAR path uses `amd64`, not `x86_64`)
- Fix `mkdirs()` return value — now throws `IOException` if directory creation fails

### `plugin-core/build.gradle.kts`
- `stripSqliteNatives` task: resolve `runtimeClasspath` lazily via `configurations.named()`
- Move JAR lookup and resolution into `doLast` to avoid evaluating dependencies at configuration time
- Use `layout.buildDirectory.file(...)` (lazy `Provider`) instead of eagerly resolving `buildDirectory`

Closes review comments: catatafishen/agentbridge#256 (comments on SqliteJarStripper.java)