### PR TITLE
fix: layered JCEF monitor-switch recovery for macOS lid-close (#237)

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -1292,68 +1292,30 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
         browser?.setPageBackgroundColor("rgb(${panelBg.red},${panelBg.green},${panelBg.blue})")
     }
 
+    private var monitorRecovery: MonitorSwitchRecovery? = null
+
     /**
-     * Detects when the panel moves to a different monitor (or the underlying display
-     * changes) by watching for [java.awt.GraphicsConfiguration] reference changes.
-     *
-     * Two listeners cover complementary scenarios:
-     * - **HierarchyBoundsListener**: fires when the IDE window is dragged between monitors.
-     * - **PropertyChangeListener on "graphicsConfiguration"**: fires when a display is
-     *   connected/disconnected (e.g. closing a MacBook lid), which may not produce
-     *   hierarchy bounds events.
-     *
-     * On monitor switch:
-     * 1. Recalculates CSS font/color vars so sizes match the new display's DPI.
-     * 2. Calls [org.cef.browser.CefBrowser.notifyScreenInfoChanged] so CEF re-queries
-     *    the device scale factor from its render handler.
-     * 3. Once the component is showing at its final size, calls
-     *    [org.cef.browser.CefBrowser.wasResized] to recreate the OSR backing surface.
+     * Manually trigger JCEF monitor-switch recovery. Exposed for the
+     * `AgentBridge: Force JCEF Refresh` diagnostic action — gives users a
+     * recovery path when the panel renders with wrong DPI or freezes on
+     * monitor switch (issue #237), without needing to restart the IDE.
+     */
+    fun forceJcefRefresh() {
+        monitorRecovery?.forceRefresh()
+    }
+
+    /**
+     * Detects when the panel moves to a different monitor (or the underlying
+     * display changes) and forces JCEF's OSR renderer to recover. All logic
+     * lives in [MonitorSwitchRecovery]; see issue #237.
      */
     private fun setupMonitorChangeListener() {
         val b = browser ?: return
-        var lastGc: java.awt.GraphicsConfiguration? = null
-
-        fun checkGc() {
-            val gc = b.component.graphicsConfiguration ?: return
-            if (gc !== lastGc) {
-                lastGc = gc
-                onMonitorChanged()
-            }
-        }
-
-        b.component.addHierarchyBoundsListener(object : java.awt.event.HierarchyBoundsListener {
-            override fun ancestorMoved(e: java.awt.event.HierarchyEvent?) = checkGc()
-            override fun ancestorResized(e: java.awt.event.HierarchyEvent?) = checkGc()
-        })
-
-        b.component.addPropertyChangeListener("graphicsConfiguration") { checkGc() }
-    }
-
-    private fun onMonitorChanged() {
-        updateThemeColors()
-        val b = browser ?: return
-        if (!browserReady) return
-        b.cefBrowser.notifyScreenInfoChanged()
-        refreshOsrWhenStable(b, 0)
-    }
-
-    /**
-     * Waits until the browser component is showing at its final non-zero size, then
-     * forces JCEF's OSR renderer to recreate its backing surface. Retries up to 5 times
-     * with 100 ms delay — closing the MacBook lid can leave the component temporarily
-     * non-showing or 0×0 during the display transition.
-     */
-    private fun refreshOsrWhenStable(b: JBCefBrowser, attempt: Int) {
-        javax.swing.SwingUtilities.invokeLater {
-            val comp = b.component
-            if (comp.isShowing && comp.width > 0 && comp.height > 0) {
-                b.cefBrowser.wasResized(comp.width, comp.height)
-                b.cefBrowser.invalidate()
-            } else if (attempt < 5) {
-                javax.swing.Timer(100) { refreshOsrWhenStable(b, attempt + 1) }
-                    .apply { isRepeats = false; start() }
-            }
-        }
+        monitorRecovery = MonitorSwitchRecovery(
+            browser = b,
+            onRecovered = { updateThemeColors() },
+            parentDisposable = this,
+        ).also { it.install() }
     }
 
     // ── Permission requests ────────────────────────────────────────

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ForceJcefRefreshAction.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ForceJcefRefreshAction.kt
@@ -1,0 +1,33 @@
+package com.github.catatafishen.agentbridge.ui
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
+
+/**
+ * Diagnostic action that forces the chat panel's JCEF OSR renderer to recover.
+ *
+ * Provides a user-facing recovery path for issue #237 (JCEF chat panel freezes
+ * or renders at wrong DPI after monitor switch / MacBook lid close). The
+ * automatic [MonitorSwitchRecovery] should handle this, but if a listener
+ * misses the event the user can invoke this action from *Find Action* instead
+ * of restarting the IDE.
+ *
+ * Also serves as an A/B diagnostic: if this fixes the hang, our handler works
+ * but its triggers are missing; if it does not, the handler itself is
+ * insufficient.
+ */
+class ForceJcefRefreshAction : AnAction(), DumbAware {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabled = e.project != null
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        ChatConsolePanel.getInstance(project)?.forceJcefRefresh()
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/MonitorSwitchRecovery.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/MonitorSwitchRecovery.kt
@@ -1,0 +1,223 @@
+package com.github.catatafishen.agentbridge.ui
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.util.Disposer
+import com.intellij.ui.jcef.JBCefBrowser
+import java.awt.*
+import java.awt.event.*
+import java.beans.PropertyChangeListener
+import javax.swing.SwingUtilities
+import javax.swing.Timer
+
+/**
+ * Handles the JCEF chat panel's recovery when the OS relocates the window to a
+ * different display, or the display topology changes (lid close/open, monitor
+ * hot-plug, scale factor change). See issue #237.
+ *
+ * The JCEF OSR (off-screen render) pipeline caches its device scale and backing
+ * surface; without an explicit recovery sequence the panel renders at the wrong
+ * DPI ("jagged fonts") or freezes entirely.
+ *
+ * We layer multiple event sources because no single one fires reliably across
+ * all scenarios on macOS:
+ *
+ * - [HierarchyBoundsListener] on the browser component — user drag across monitors.
+ * - [PropertyChangeListener] on the **top-level [Window]** for the
+ *   `"graphicsConfiguration"` property — lid-close / display disconnect. AWT
+ *   only fires this PCE from [Window.setGraphicsConfiguration]; lightweight
+ *   [javax.swing.JComponent]s inherit their GC from the peer and never fire.
+ * - [java.awt.event.ComponentListener] on the top-level [Window] — catches
+ *   macOS forced window relocation (`componentMoved`).
+ * - Polling [GraphicsEnvironment.getScreenDevices] on each trigger — detects
+ *   display-count changes even when the GC reference is reused.
+ *
+ * When any source fires, we compare a [Fingerprint] of
+ * (gc identity, scale, bounds, screen count). Any change triggers recovery:
+ *
+ *  1. `cefBrowser.setWindowVisibility(false)` + `setWindowVisibility(true)` —
+ *     tears down the OSR compositor so CEF rebuilds its `CALayer` on the new
+ *     display.
+ *  2. `cefBrowser.notifyScreenInfoChanged()` — CEF re-reads the device scale.
+ *  3. `cefBrowser.wasResized(w, h)` — recreates the backing surface.
+ *  4. `cefBrowser.invalidate()` — forces a paint.
+ *  5. [onRecovered] callback (e.g. `updateThemeColors`) — runs **after** the
+ *     OSR surface is live, so CSS writes actually reach the screen.
+ *
+ * Stability check: retry up to 20 × 150 ms (~3 s) until the component is
+ * showing at non-zero size and the scale factor has remained constant across
+ * two consecutive samples. macOS lid-close can take 800–1500 ms to settle
+ * (window server relocation, Dock resolution, `CGDisplayReconfigurationCallback`).
+ */
+internal class MonitorSwitchRecovery(
+    private val browser: JBCefBrowser,
+    private val onRecovered: () -> Unit,
+    parentDisposable: Disposable,
+) : Disposable {
+
+    private data class Fingerprint(
+        val gcId: Int,
+        val scaleX: Double,
+        val scaleY: Double,
+        val bounds: Rectangle,
+        val screenCount: Int,
+    )
+
+    private val log = Logger.getInstance(MonitorSwitchRecovery::class.java)
+    private val component: Component get() = browser.component
+    private var last: Fingerprint? = null
+    private var attachedWindow: Window? = null
+
+    private val windowGcListener: PropertyChangeListener = PropertyChangeListener { e ->
+        log.info("[monitor] window PCE '${e.propertyName}' old=${e.oldValue} new=${e.newValue}")
+        check("window-pce:${e.propertyName}")
+    }
+    private val componentGcListener: PropertyChangeListener = PropertyChangeListener {
+        check("component-pce:graphicsConfiguration")
+    }
+    private val windowComponentListener = object : ComponentAdapter() {
+        override fun componentMoved(e: ComponentEvent?) = check("window-moved")
+        override fun componentResized(e: ComponentEvent?) = check("window-resized")
+    }
+    private val hierarchyBoundsListener = object : HierarchyBoundsListener {
+        override fun ancestorMoved(e: HierarchyEvent?) = check("ancestor-moved")
+        override fun ancestorResized(e: HierarchyEvent?) = check("ancestor-resized")
+    }
+    private val hierarchyListener = HierarchyListener { e ->
+        val flags = e.changeFlags
+        val relevant = (HierarchyEvent.SHOWING_CHANGED or HierarchyEvent.PARENT_CHANGED).toLong()
+        if (flags and relevant != 0L) syncWindowListeners()
+    }
+
+    init {
+        Disposer.register(parentDisposable, this)
+    }
+
+    fun install() {
+        component.addHierarchyBoundsListener(hierarchyBoundsListener)
+        component.addHierarchyListener(hierarchyListener)
+        component.addPropertyChangeListener("graphicsConfiguration", componentGcListener)
+        syncWindowListeners()
+        last = currentFingerprint()
+        log.info("[monitor] installed; baseline=$last")
+    }
+
+    /** Manually trigger recovery (e.g. from a diagnostic action). */
+    fun forceRefresh() {
+        log.info("[monitor] forceRefresh() requested")
+        last = currentFingerprint()
+        triggerRecovery("manual")
+    }
+
+    override fun dispose() {
+        runCatching { component.removeHierarchyBoundsListener(hierarchyBoundsListener) }
+        runCatching { component.removeHierarchyListener(hierarchyListener) }
+        runCatching { component.removePropertyChangeListener("graphicsConfiguration", componentGcListener) }
+        detachWindowListeners()
+    }
+
+    private fun syncWindowListeners() {
+        val w = SwingUtilities.getWindowAncestor(component)
+        if (w === attachedWindow) return
+        detachWindowListeners()
+        if (w != null) {
+            w.addPropertyChangeListener("graphicsConfiguration", windowGcListener)
+            w.addComponentListener(windowComponentListener)
+            attachedWindow = w
+            log.info("[monitor] attached to window ${System.identityHashCode(w)} (${w.javaClass.simpleName})")
+        }
+    }
+
+    private fun detachWindowListeners() {
+        attachedWindow?.let { w ->
+            runCatching { w.removePropertyChangeListener("graphicsConfiguration", windowGcListener) }
+            runCatching { w.removeComponentListener(windowComponentListener) }
+            log.info("[monitor] detached from window ${System.identityHashCode(w)}")
+        }
+        attachedWindow = null
+    }
+
+    private fun currentFingerprint(): Fingerprint? {
+        val gc: GraphicsConfiguration = component.graphicsConfiguration ?: return null
+        val tx = gc.defaultTransform
+        val screens = runCatching {
+            GraphicsEnvironment.getLocalGraphicsEnvironment().screenDevices.size
+        }.getOrDefault(-1)
+        return Fingerprint(
+            gcId = System.identityHashCode(gc),
+            scaleX = tx.scaleX,
+            scaleY = tx.scaleY,
+            bounds = gc.bounds,
+            screenCount = screens,
+        )
+    }
+
+    private fun check(reason: String) {
+        val fp = currentFingerprint() ?: return
+        val prev = last
+        if (prev == fp) return
+        log.info("[monitor] change detected reason=$reason prev=$prev curr=$fp")
+        last = fp
+        triggerRecovery(reason)
+    }
+
+    private fun triggerRecovery(reason: String) {
+        log.info(
+            "[monitor] recovery triggered reason=$reason " +
+                "isShowing=${component.isShowing} size=${component.width}x${component.height}"
+        )
+        val cef = browser.cefBrowser
+        // Tear down the OSR compositor before resize; forces CEF to rebuild
+        // its CALayer on the new display.
+        runCatching { cef.setWindowVisibility(false) }
+        runCatching { cef.setWindowVisibility(true) }
+        // Tell CEF the device scale factor may have changed so it re-queries it
+        // from the render handler before the next paint.
+        runCatching { cef.notifyScreenInfoChanged() }
+        refreshOsrWhenStable(attempt = 0, lastScale = -1.0, stableCount = 0)
+    }
+
+    private fun refreshOsrWhenStable(attempt: Int, lastScale: Double, stableCount: Int) {
+        SwingUtilities.invokeLater {
+            val comp = component
+            val scale = comp.graphicsConfiguration?.defaultTransform?.scaleX ?: -1.0
+            val ready = comp.isShowing && comp.width > 0 && comp.height > 0 && scale > 0
+            val scaleStable = ready && scale == lastScale
+            when {
+                scaleStable && stableCount >= 1 -> applyOsrRefresh(attempt, comp, scale)
+                attempt < MAX_ATTEMPTS -> {
+                    val nextStable = if (scaleStable) stableCount + 1 else 0
+                    Timer(RETRY_INTERVAL_MS) {
+                        refreshOsrWhenStable(attempt + 1, scale, nextStable)
+                    }.apply { isRepeats = false; start() }
+                }
+
+                else -> giveUp(attempt, comp, scale, ready)
+            }
+        }
+    }
+
+    private fun applyOsrRefresh(attempt: Int, comp: Component, scale: Double) {
+        val cef = browser.cefBrowser
+        runCatching { cef.wasResized(comp.width, comp.height) }
+        runCatching { cef.invalidate() }
+        runCatching { cef.notifyScreenInfoChanged() }
+        log.info("[monitor] OSR refreshed after $attempt attempts; size=${comp.width}x${comp.height} scale=$scale")
+        runCatching { onRecovered() }
+    }
+
+    private fun giveUp(attempt: Int, comp: Component, scale: Double, ready: Boolean) {
+        log.warn("[monitor] OSR stabilisation gave up after $attempt attempts; ready=$ready scale=$scale")
+        if (comp.width > 0 && comp.height > 0) {
+            val cef = browser.cefBrowser
+            runCatching { cef.wasResized(comp.width, comp.height) }
+            runCatching { cef.invalidate() }
+        }
+        runCatching { onRecovered() }
+    }
+
+    private companion object {
+        const val MAX_ATTEMPTS = 20
+        const val RETRY_INTERVAL_MS = 150
+    }
+}

--- a/plugin-core/src/main/resources/META-INF/plugin.xml
+++ b/plugin-core/src/main/resources/META-INF/plugin.xml
@@ -316,5 +316,9 @@ GitHub Copilot, Claude Code, OpenAI Codex, JetBrains Junie, Amazon Kiro, and Ope
             description="Show all available chat prompt keyboard shortcuts">
       <keyboard-shortcut keymap="$default" first-keystroke="ctrl SLASH"/>
     </action>
+    <action id="AgentBridge.ForceJcefRefresh"
+            class="com.github.catatafishen.agentbridge.ui.ForceJcefRefreshAction"
+            text="AgentBridge: Force JCEF Refresh"
+            description="Diagnostic: force the chat panel to re-query its display scale and rebuild its OSR surface (recovers from monitor-switch freezes; issue #237)"/>
   </actions>
 </idea-plugin>


### PR DESCRIPTION
Closes gap left by v1.63.1 for issue #237 — MacBook lid-close still freezes the chat panel and renders with wrong DPI.

See `.agent-work/issue-237-investigation.md` for the full analysis. Short version:

### Why v1.63.1 wasn't enough

1. `PropertyChangeListener("graphicsConfiguration")` on the browser's lightweight `JComponent` **never fires**. AWT only synthesises that PCE from `Window.setGraphicsConfiguration`. The lid-close disconnect was therefore only seen via `HierarchyBoundsListener`, which fires with a **stale GC** during the async window-server relocation.
2. The GC identity comparison early-exits when the same GC is reused with a new scale/bounds — common on display-count changes.
3. The 5 × 100 ms retry budget expires well before macOS finishes the relocation (lid-close settle time is 800–1500 ms in practice).

### What this PR does

Extracts the recovery state machine into `MonitorSwitchRecovery` and layers the event sources so none of the above gaps remain:

- **`HierarchyBoundsListener`** on the browser component — drag across monitors.
- **`PropertyChangeListener("graphicsConfiguration")` on the top-level `Window`** — lid-close. Reattached via `HierarchyListener` when the ancestor window changes.
- **`ComponentListener` on the `Window`** — forced relocation (`componentMoved`).
- **Polls `GraphicsEnvironment.screenDevices.size`** on every trigger so a display-count change still fires recovery even when the GC reference is reused.

Fingerprint now compares `(gc identity, scaleX, scaleY, bounds, screenCount)` — any difference triggers recovery.

### Recovery sequence

1. `cefBrowser.setWindowVisibility(false)` + `setWindowVisibility(true)` — tears down the OSR compositor so CEF rebuilds its CALayer on the new display.
2. `notifyScreenInfoChanged()` — CEF re-reads the device scale.
3. Wait until component is showing, non-zero, and scale has been stable across two consecutive samples (up to 20 × 150 ms ≈ 3 s).
4. `wasResized()` + `invalidate()` + `notifyScreenInfoChanged()`.
5. `updateThemeColors()` — deliberately **after** the OSR surface is live, so CSS writes actually reach the screen (matches the user's "fonts look broken but I can still type" symptom).

Every decision point emits an INFO log line — next user report will contain usable diagnostics without a debug build.

### Diagnostic action

New action `AgentBridge: Force JCEF Refresh` (available via *Find Action*). Gives users a recovery path without restarting the IDE and serves as an A/B diagnostic:
- If it fixes the hang → our handler is correct, a listener trigger is missing.
- If it does not → the handler itself is insufficient (dispose+recreate browser would be the next step).

### Files

- New: `plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/MonitorSwitchRecovery.kt`
- New: `plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ForceJcefRefreshAction.kt`
- Modified: `ChatConsolePanel.kt` — delegates to the helper; `onMonitorChanged` / `refreshOsrWhenStable` removed.
- Modified: `plugin.xml` — registers the diagnostic action.

### Tested

- `plugin-core` compiles clean.
- Automated repro for lid-close requires the reporter's hardware; investigation doc lists follow-up questions for `@m-reuter`.

Refs #237.