### PR TITLE
fix(mcp): correct plugin ID lookup so Junie/Kiro can locate mcp-server.jar

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
@@ -1262,24 +1262,16 @@ public abstract class AcpClient extends AbstractAgentClient {
         return true;
     }
 
-    /**
-     * Builds a JsonObject for a stdio MCP server entry for use in the {@code mcpServers} array
-     * of {@code session/new} params. Uses separate {@code command} (string) and {@code args}
-     * (array) fields as required by Junie and Kiro.
-     *
-     * @return the server entry, or {@code null} if the jar or Java binary cannot be located
-     */
     @Nullable
     protected final JsonObject buildMcpStdioServer(String serverName, int mcpPort) {
-        String javaExe = System.getProperty("os.name", "").toLowerCase().contains("win") ? "java.exe" : "java";
-        String javaPath = System.getProperty("java.home") + File.separator + "bin" + File.separator + javaExe;
-        if (!new File(javaPath).exists()) {
-            LOG.warn("Java binary not found at " + javaPath + " — cannot build stdio MCP server config");
+        String javaPath = resolveJavaBinaryPath();
+        if (javaPath == null) {
+            LOG.warn("Java binary not resolvable from java.home/JAVA_HOME — cannot build stdio MCP server config");
             return null;
         }
         String jarPath = McpServerJarLocator.findMcpServerJar();
         if (jarPath == null) {
-            LOG.warn("mcp-server.jar not found — cannot build stdio MCP server config");
+            LOG.warn("mcp-server.jar not found in plugin lib — cannot build stdio MCP server config");
             return null;
         }
 
@@ -1295,6 +1287,58 @@ public abstract class AcpClient extends AbstractAgentClient {
         server.add("args", args);
         server.add("env", new JsonArray());
         return server;
+    }
+
+    /**
+     * Builds a human-readable diagnostic message describing why {@link #buildMcpStdioServer}
+     * returned {@code null}. Intended for inclusion in exception messages so users see which
+     * dependency is missing instead of the generic "Java binary or mcp-server.jar not found".
+     */
+    protected final @NotNull String describeMcpStdioServerFailure() {
+        StringBuilder sb = new StringBuilder();
+        String javaPath = resolveJavaBinaryPath();
+        if (javaPath == null) {
+            sb.append("Java binary not found (checked java.home=")
+                .append(System.getProperty("java.home"))
+                .append(" and JAVA_HOME=")
+                .append(System.getenv("JAVA_HOME"))
+                .append(")");
+        } else {
+            sb.append("Java binary ok at ").append(javaPath);
+        }
+        sb.append("; ");
+        String jarPath = McpServerJarLocator.findMcpServerJar();
+        if (jarPath == null) {
+            sb.append("mcp-server.jar not found in plugin lib directory (plugin may not be fully installed; try rebuilding or reinstalling)");
+        } else {
+            sb.append("mcp-server.jar ok at ").append(jarPath);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Resolves the path to a usable {@code java} binary. Tries {@code java.home/bin/java} first
+     * (the JVM running this IDE), then falls back to {@code JAVA_HOME/bin/java}.
+     *
+     * @return absolute path to an existing java executable, or {@code null} if none found
+     */
+    private static @Nullable String resolveJavaBinaryPath() {
+        boolean isWindows = System.getProperty("os.name", "").toLowerCase().contains("win");
+        String javaExe = isWindows ? "java.exe" : "java";
+
+        String javaHome = System.getProperty("java.home");
+        if (javaHome != null && !javaHome.isEmpty()) {
+            File candidate = new File(javaHome + File.separator + "bin" + File.separator + javaExe);
+            if (candidate.exists()) return candidate.getAbsolutePath();
+        }
+
+        String envJavaHome = System.getenv("JAVA_HOME");
+        if (envJavaHome != null && !envJavaHome.isEmpty()) {
+            File candidate = new File(envJavaHome + File.separator + "bin" + File.separator + javaExe);
+            if (candidate.exists()) return candidate.getAbsolutePath();
+        }
+
+        return null;
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/JunieClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/JunieClient.java
@@ -185,7 +185,8 @@ public final class JunieClient extends AcpClient {
         // Junie injects MCP via session/new mcpServers array using stdio (command + args)
         JsonObject server = buildMcpStdioServer("agentbridge", mcpPort);
         if (server == null) {
-            throw new IllegalStateException("Cannot configure Junie MCP server — Java binary or mcp-server.jar not found");
+            throw new IllegalStateException(
+                "Cannot configure Junie MCP server — " + describeMcpStdioServerFailure());
         }
         JsonArray servers = new JsonArray();
         servers.add(server);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/KiroClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/KiroClient.java
@@ -283,7 +283,8 @@ public final class KiroClient extends AcpClient {
         // Kiro requires mcpServers in session/new params (field is mandatory)
         JsonObject server = buildMcpStdioServer("agentbridge", mcpPort);
         if (server == null) {
-            throw new IllegalStateException("Cannot configure Kiro MCP server — Java binary or mcp-server.jar not found");
+            throw new IllegalStateException(
+                "Cannot configure Kiro MCP server — " + describeMcpStdioServerFailure());
         }
         JsonArray servers = new JsonArray();
         servers.add(server);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/bridge/McpServerJarLocator.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/bridge/McpServerJarLocator.java
@@ -14,6 +14,11 @@ public final class McpServerJarLocator {
 
     private static final Logger LOG = Logger.getInstance(McpServerJarLocator.class);
 
+    /**
+     * The plugin ID as declared in plugin.xml ({@code <id>}).
+     */
+    public static final String PLUGIN_ID = "com.github.catatafishen.ideagentforcopilot";
+
     private McpServerJarLocator() {
     }
 
@@ -26,8 +31,7 @@ public final class McpServerJarLocator {
     public static String findMcpServerJar() {
         // Strategy 1: Use PlatformApiCompat to find plugin directory
         try {
-            java.nio.file.Path pluginPath = PlatformApiCompat
-                .getPluginPath("com.github.catatafishen.agentbridge");
+            java.nio.file.Path pluginPath = PlatformApiCompat.getPluginPath(PLUGIN_ID);
             if (pluginPath != null) {
                 File libDir = pluginPath.resolve("lib").toFile();
                 File mcpJar = new File(libDir, "mcp-server.jar");

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/project/GetProjectInfoTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/project/GetProjectInfoTool.java
@@ -1,5 +1,6 @@
 package com.github.catatafishen.agentbridge.psi.tools.project;
 
+import com.github.catatafishen.agentbridge.bridge.McpServerJarLocator;
 import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
 import com.github.catatafishen.agentbridge.ui.renderers.ProjectInfoRenderer;
 import com.google.gson.JsonObject;
@@ -88,7 +89,7 @@ public final class GetProjectInfoTool extends ProjectTool {
             sb.append("IDE: unavailable\n");
         }
         try {
-            String pluginInfo = PlatformApiCompat.getPluginVersionInfo("com.github.catatafishen.agentbridge");
+            String pluginInfo = PlatformApiCompat.getPluginVersionInfo(McpServerJarLocator.PLUGIN_ID);
             if (pluginInfo != null) {
                 sb.append("Plugin: ").append(pluginInfo).append("\n");
             }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/bridge/McpServerJarLocatorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/bridge/McpServerJarLocatorTest.java
@@ -1,0 +1,49 @@
+package com.github.catatafishen.agentbridge.bridge;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Regression test for the Junie/Kiro "Cannot configure MCP server" bug.
+ *
+ * <p>The bug was caused by {@link McpServerJarLocator#PLUGIN_ID} drifting from the
+ * {@code <id>} declared in plugin.xml. When the constant doesn't match, every call to
+ * {@code PlatformApiCompat.getPluginPath(PLUGIN_ID)} returns null and stdio-based MCP
+ * agents silently fail to inject mcp-server.jar into their session/new params.</p>
+ */
+class McpServerJarLocatorTest {
+
+    @Test
+    void pluginIdConstantMatchesManifest() throws Exception {
+        String manifestId = readPluginIdFromManifest();
+        assertNotNull(manifestId, "plugin.xml must contain an <id> element");
+        assertEquals(McpServerJarLocator.PLUGIN_ID, manifestId,
+            "McpServerJarLocator.PLUGIN_ID must match the <id> in plugin.xml — "
+                + "otherwise PlatformApiCompat.getPluginPath() returns null and "
+                + "stdio MCP agents (Junie, Kiro) cannot locate mcp-server.jar.");
+    }
+
+    @Test
+    void pluginIdIsNotBlank() {
+        assertNotNull(McpServerJarLocator.PLUGIN_ID);
+        assertFalse(McpServerJarLocator.PLUGIN_ID.isEmpty());
+    }
+
+    private static String readPluginIdFromManifest() throws Exception {
+        // plugin.xml is on the test classpath via plugin-core's main resources.
+        try (InputStream in = McpServerJarLocatorTest.class
+            .getResourceAsStream("/META-INF/plugin.xml")) {
+            assertNotNull(in, "plugin.xml should be on the test classpath");
+            String xml = new String(in.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+            Matcher m = Pattern.compile("<id>([^<]+)</id>").matcher(xml);
+            return m.find() ? m.group(1).trim() : null;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Junie and Kiro sessions failed with:

```
IllegalStateException: Cannot configure Junie MCP server — Java binary or mcp-server.jar not found
```

…even though `mcp-server.jar` was correctly bundled into the plugin's `lib/` directory by `prepareSandbox` / `buildPlugin`.

## Root cause

`McpServerJarLocator` called:

```java
PlatformApiCompat.getPluginPath("com.github.catatafishen.agentbridge")
```

but the actual `<id>` declared in `plugin.xml` is:

```xml
<id>com.github.catatafishen.ideagentforcopilot</id>
```

Because the IDs didn't match, `PluginManagerCore.getPlugin()` returned `null`, Strategy 1 silently failed, and we fell back to the classloader strategy. In `runIde` the plugin classes load from a `classes/` directory rather than `lib/plugin-core.jar`, so Strategy 2 looked for `mcp-server.jar` next to the `.class` files — which also failed.

The error message was generic ("Java binary **or** mcp-server.jar"), so there was no way to tell that the jar-lookup path was actually the culprit.

## Fix

- Extract the plugin ID to `McpServerJarLocator.PLUGIN_ID` (single source of truth) and use it in both the locator and `GetProjectInfoTool`.
- Improve `buildMcpStdioServer` diagnostics: new `describeMcpStdioServerFailure()` reports which piece is missing (Java binary vs jar) and the paths we searched, so users see an actionable exception message.
- Also try `JAVA_HOME` when `java.home/bin/java` is absent.
- `JunieClient` and `KiroClient` now include the diagnostic in their `IllegalStateException` messages.

## Regression test

`McpServerJarLocatorTest` reads `<id>` from `plugin.xml` on the classpath and fails if it drifts from the constant — preventing this exact regression from ever silently recurring.