### PR TITLE
fix: sort tool statistics table columns numerically

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/BytesTableCellRenderer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/BytesTableCellRenderer.java
@@ -1,0 +1,26 @@
+package com.github.catatafishen.agentbridge.ui.statistics;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableCellRenderer;
+import java.awt.*;
+
+/**
+ * Renders a {@code Long} byte value as a human-readable size (e.g., "1.5 KB", "2.0 MB").
+ * Right-aligned to match numeric column conventions.
+ */
+final class BytesTableCellRenderer extends DefaultTableCellRenderer {
+
+    BytesTableCellRenderer() {
+        setHorizontalAlignment(SwingConstants.RIGHT);
+    }
+
+    @Override
+    public Component getTableCellRendererComponent(
+            JTable table, Object value, boolean isSelected, boolean hasFocus,
+            int row, int column) {
+        if (value instanceof Long bytes) {
+            value = ToolStatisticsTableModel.formatBytes(bytes);
+        }
+        return super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/PercentTableCellRenderer.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/PercentTableCellRenderer.java
@@ -1,0 +1,26 @@
+package com.github.catatafishen.agentbridge.ui.statistics;
+
+import javax.swing.*;
+import javax.swing.table.DefaultTableCellRenderer;
+import java.awt.*;
+
+/**
+ * Renders a {@code Double} value as a one-decimal-place percentage string (e.g., "12.5").
+ * Right-aligned to match numeric column conventions.
+ */
+final class PercentTableCellRenderer extends DefaultTableCellRenderer {
+
+    PercentTableCellRenderer() {
+        setHorizontalAlignment(SwingConstants.RIGHT);
+    }
+
+    @Override
+    public Component getTableCellRendererComponent(
+            JTable table, Object value, boolean isSelected, boolean hasFocus,
+            int row, int column) {
+        if (value instanceof Double pct) {
+            value = String.format("%.1f", pct);
+        }
+        return super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/ToolStatisticsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/ToolStatisticsPanel.java
@@ -80,6 +80,12 @@ public class ToolStatisticsPanel extends JPanel {
         table.getColumnModel().getColumn(6).setPreferredWidth(90);  // Total Output
         table.getColumnModel().getColumn(7).setPreferredWidth(80);  // Error Rate
 
+        var bytesRenderer = new BytesTableCellRenderer();
+        table.getColumnModel().getColumn(ToolStatisticsTableModel.COL_AVG_DATA).setCellRenderer(bytesRenderer);
+        table.getColumnModel().getColumn(ToolStatisticsTableModel.COL_TOTAL_INPUT).setCellRenderer(bytesRenderer);
+        table.getColumnModel().getColumn(ToolStatisticsTableModel.COL_TOTAL_OUTPUT).setCellRenderer(bytesRenderer);
+        table.getColumnModel().getColumn(ToolStatisticsTableModel.COL_ERROR_RATE).setCellRenderer(new PercentTableCellRenderer());
+
         return new JBScrollPane(table);
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/ToolStatisticsTableModel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/statistics/ToolStatisticsTableModel.java
@@ -12,8 +12,21 @@ import java.util.List;
  * Avg Duration (ms), Avg Data, Total Input, Total Output, Error Rate (%).
  * The Client column is omitted — it is redundant because the client filter
  * is shown in the toolbar dropdown above the table.
+ *
+ * <p>Numeric columns (Calls, Avg Duration, byte sizes, Error Rate) return raw
+ * {@code Long} or {@code Double} values so that {@code TableRowSorter} sorts
+ * them numerically. The panel applies custom cell renderers for display formatting.</p>
  */
 public class ToolStatisticsTableModel extends AbstractTableModel {
+
+    static final int COL_TOOL = 0;
+    static final int COL_CATEGORY = 1;
+    static final int COL_CALLS = 2;
+    static final int COL_AVG_DURATION = 3;
+    static final int COL_AVG_DATA = 4;
+    static final int COL_TOTAL_INPUT = 5;
+    static final int COL_TOTAL_OUTPUT = 6;
+    static final int COL_ERROR_RATE = 7;
 
     private static final String[] COLUMN_NAMES = {
         "Tool", "Category", "Calls", "Avg Duration (ms)",
@@ -22,7 +35,7 @@ public class ToolStatisticsTableModel extends AbstractTableModel {
 
     private static final Class<?>[] COLUMN_TYPES = {
         String.class, String.class, Long.class, Long.class,
-        String.class, String.class, String.class, String.class
+        Long.class, Long.class, Long.class, Double.class
     };
 
     private final List<ToolAggregate> data = new ArrayList<>();
@@ -51,16 +64,16 @@ public class ToolStatisticsTableModel extends AbstractTableModel {
     public Object getValueAt(int rowIndex, int columnIndex) {
         ToolAggregate row = data.get(rowIndex);
         return switch (columnIndex) {
-            case 0 -> row.toolName();
-            case 1 -> row.category() != null ? row.category() : "—";
-            case 2 -> row.callCount();
-            case 3 -> row.avgDurationMs();
-            case 4 -> formatBytes(row.avgTotalBytes());
-            case 5 -> formatBytes(row.totalInputBytes());
-            case 6 -> formatBytes(row.totalOutputBytes());
-            case 7 -> row.callCount() > 0
-                ? String.format("%.1f", 100.0 * row.errorCount() / row.callCount())
-                : "0.0";
+            case COL_TOOL -> row.toolName();
+            case COL_CATEGORY -> row.category() != null ? row.category() : "—";
+            case COL_CALLS -> row.callCount();
+            case COL_AVG_DURATION -> row.avgDurationMs();
+            case COL_AVG_DATA -> row.avgTotalBytes();
+            case COL_TOTAL_INPUT -> row.totalInputBytes();
+            case COL_TOTAL_OUTPUT -> row.totalOutputBytes();
+            case COL_ERROR_RATE -> row.callCount() > 0
+                ? 100.0 * row.errorCount() / row.callCount()
+                : 0.0;
             default -> "";
         };
     }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/statistics/ToolStatisticsTableModelTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/statistics/ToolStatisticsTableModelTest.java
@@ -1,14 +1,22 @@
 package com.github.catatafishen.agentbridge.ui.statistics;
 
+import com.github.catatafishen.agentbridge.services.ToolCallStatisticsService.ToolAggregate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import javax.swing.*;
+import javax.swing.table.TableRowSorter;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests for {@link ToolStatisticsTableModel} — column rendering, byte formatting, error rate.
+ * Tests for {@link ToolStatisticsTableModel} — byte formatting, column types,
+ * and numeric sort correctness.
  */
-@DisplayName("ToolStatisticsTableModel – formatBytes")
+@DisplayName("ToolStatisticsTableModel")
 class ToolStatisticsTableModelTest {
 
     @Test
@@ -51,5 +59,78 @@ class ToolStatisticsTableModelTest {
     @DisplayName("1572864 bytes → '1.5 MB'")
     void formatBytes_oneAndHalfMegabytes() {
         assertEquals("1.5 MB", ToolStatisticsTableModel.formatBytes(1_572_864));
+    }
+
+    @Test
+    @DisplayName("byte columns return Long values for numeric sorting")
+    void byteColumnsReturnLong() {
+        var model = new ToolStatisticsTableModel();
+        model.setData(List.of(aggregate("tool_a", 10, 500, 99_000, 1_100_000, 50_000, 0)));
+
+        assertInstanceOf(Long.class, model.getValueAt(0, ToolStatisticsTableModel.COL_AVG_DATA));
+        assertInstanceOf(Long.class, model.getValueAt(0, ToolStatisticsTableModel.COL_TOTAL_INPUT));
+        assertInstanceOf(Long.class, model.getValueAt(0, ToolStatisticsTableModel.COL_TOTAL_OUTPUT));
+    }
+
+    @Test
+    @DisplayName("error rate column returns Double for numeric sorting")
+    void errorRateReturnsDouble() {
+        var model = new ToolStatisticsTableModel();
+        model.setData(List.of(aggregate("tool_a", 10, 500, 100, 200, 50, 2)));
+
+        Object errorRate = model.getValueAt(0, ToolStatisticsTableModel.COL_ERROR_RATE);
+        assertInstanceOf(Double.class, errorRate);
+        assertEquals(20.0, (Double) errorRate, 0.001);
+    }
+
+    @Test
+    @DisplayName("error rate is 0.0 when call count is zero")
+    void errorRateZeroCalls() {
+        var model = new ToolStatisticsTableModel();
+        model.setData(List.of(aggregate("tool_a", 0, 0, 0, 0, 0, 0)));
+
+        assertEquals(0.0, (Double) model.getValueAt(0, ToolStatisticsTableModel.COL_ERROR_RATE), 0.001);
+    }
+
+    @Test
+    @DisplayName("column classes are numeric for sortable columns")
+    void columnClassesAreNumeric() {
+        var model = new ToolStatisticsTableModel();
+        assertEquals(Long.class, model.getColumnClass(ToolStatisticsTableModel.COL_AVG_DATA));
+        assertEquals(Long.class, model.getColumnClass(ToolStatisticsTableModel.COL_TOTAL_INPUT));
+        assertEquals(Long.class, model.getColumnClass(ToolStatisticsTableModel.COL_TOTAL_OUTPUT));
+        assertEquals(Double.class, model.getColumnClass(ToolStatisticsTableModel.COL_ERROR_RATE));
+    }
+
+    @Test
+    @DisplayName("TableRowSorter sorts byte columns numerically — 1 MB > 99 KB")
+    void rowSorterSortsByteColumnsNumerically() {
+        var model = new ToolStatisticsTableModel();
+        // 99 KB = 101_376 bytes, 1 MB = 1_048_576 bytes
+        model.setData(List.of(
+            aggregate("big_kb", 5, 100, 101_376, 101_376, 101_376, 0),
+            aggregate("small_mb", 5, 100, 1_048_576, 1_048_576, 1_048_576, 0)
+        ));
+
+        var sorter = new TableRowSorter<>(model);
+        // Sort ascending by Total Input (col 5)
+        sorter.setSortKeys(List.of(new RowSorter.SortKey(
+            ToolStatisticsTableModel.COL_TOTAL_INPUT, SortOrder.ASCENDING)));
+        sorter.sort();
+
+        // Row 0 after sorting should be the smaller value (99 KB)
+        int firstModelRow = sorter.convertRowIndexToModel(0);
+        int secondModelRow = sorter.convertRowIndexToModel(1);
+        long firstBytes = (Long) model.getValueAt(firstModelRow, ToolStatisticsTableModel.COL_TOTAL_INPUT);
+        long secondBytes = (Long) model.getValueAt(secondModelRow, ToolStatisticsTableModel.COL_TOTAL_INPUT);
+
+        assertTrue(firstBytes < secondBytes,
+            "Expected 99 KB (" + firstBytes + ") < 1 MB (" + secondBytes + ") after ascending sort");
+    }
+
+    private static ToolAggregate aggregate(String name, long calls, long avgDuration,
+                                           long totalInput, long totalOutput,
+                                           long avgTotal, long errors) {
+        return new ToolAggregate(name, null, calls, avgDuration, totalInput, totalOutput, avgTotal, errors);
     }
 }


### PR DESCRIPTION
## Problem

Byte-size columns (Avg Data, Total Input, Total Output) and Error Rate (%) in the Tool Statistics table were sorted lexicographically because the table model returned pre-formatted strings. This caused **99 KB to sort as larger than 1 MB**.

## Fix

- **`ToolStatisticsTableModel`**: Changed columns 4–7 to return raw `Long`/`Double` values instead of formatted strings. `TableRowSorter` now uses `getColumnClass()` to sort numerically.
- **`BytesTableCellRenderer`**: New renderer that formats `Long` byte values as human-readable sizes ("1.5 KB", "2.0 MB") for display.
- **`PercentTableCellRenderer`**: New renderer that formats `Double` percentages as "12.5" for display.
- Both renderers are right-aligned to match numeric column conventions.

## Tests

Added 5 new tests to `ToolStatisticsTableModelTest`:
- `byteColumnsReturnLong` — verifies raw `Long` return type
- `errorRateReturnsDouble` — verifies raw `Double` return type and value
- `errorRateZeroCalls` — edge case: 0 calls → 0.0
- `columnClassesAreNumeric` — verifies column class declarations
- `rowSorterSortsByteColumnsNumerically` — end-to-end: 99 KB sorts before 1 MB