### PR TITLE
fix: better error messages for modal-blocked tools and nothing-to-commit

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -417,8 +417,9 @@ public final class PsiBridgeService implements Disposable {
             LOG.warn("Tool call error: " + toolName, e);
             success = false;
             if (writeRegistered) writeBatchCoordinator.unregisterWrite();
+            String modalDetail = EdtUtil.describeModalBlocker();
             errorMessage = buildErrorWithModalDetail(
-                "Error: " + e.getMessage(), EdtUtil.describeModalBlocker());
+                formatBaseErrorMessage(e, modalDetail), modalDetail);
             ToolChipRegistry.getInstance(project).storeMcpResult(toolName, arguments, errorMessage);
             return errorMessage;
         } finally {
@@ -760,6 +761,25 @@ public final class PsiBridgeService implements Disposable {
         return highlights != null
             ? writeResult + "\n\n--- Highlights (auto) ---\n" + highlights
             : writeResult;
+    }
+
+    /**
+     * Builds the base error message for an exception, avoiding the ugly {@code "Error: null"}
+     * output when {@link Throwable#getMessage()} is null or blank.
+     * <p>
+     * When a modal dialog is detected as the cause, returns a dedicated message so
+     * the agent knows the call was blocked rather than failing internally. Otherwise
+     * falls back to the exception class simple name.
+     */
+    static String formatBaseErrorMessage(@NotNull Throwable e, @NotNull String modalDetail) {
+        String msg = e.getMessage();
+        if (msg != null && !msg.isBlank() && !"null".equals(msg)) {
+            return "Error: " + msg;
+        }
+        if (!modalDetail.isEmpty()) {
+            return "Error: Operation blocked by modal dialog";
+        }
+        return "Error: " + e.getClass().getSimpleName();
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
@@ -85,14 +85,7 @@ public final class GitCommitTool extends GitTool {
         if (!isAmend) {
             String staged = runGitQuiet("diff", "--cached", "--name-only");
             if (staged != null && staged.isEmpty()) {
-                String unstaged = runGitQuiet("diff", "--name-only");
-                StringBuilder hint = new StringBuilder("Error: nothing to commit.");
-                if (unstaged != null && !unstaged.isEmpty()) {
-                    hint.append(" There are unstaged changes not picked up by --all (e.g. ignored files).");
-                } else {
-                    hint.append(" The working tree is clean.");
-                }
-                return hint.toString();
+                return buildNothingToCommitHint();
             }
         }
 
@@ -151,6 +144,41 @@ public final class GitCommitTool extends GitTool {
      */
     static boolean resolveAmend(JsonObject args) {
         return args.has(PARAM_AMEND) && args.get(PARAM_AMEND).getAsBoolean();
+    }
+
+    /**
+     * Builds a detailed hint for the "nothing to commit" case, listing which paths are
+     * unstaged/untracked/ignored so the agent knows exactly what to stage (or force-add).
+     */
+    private String buildNothingToCommitHint() {
+        String unstaged = runGitQuiet("diff", "--name-only");
+        String untracked = runGitQuiet("ls-files", "--others", "--exclude-standard");
+        String ignored = runGitQuiet("ls-files", "--others", "--ignored", "--exclude-standard");
+
+        boolean hasUnstaged = unstaged != null && !unstaged.isEmpty();
+        boolean hasUntracked = untracked != null && !untracked.isEmpty();
+        boolean hasIgnored = ignored != null && !ignored.isEmpty();
+
+        StringBuilder hint = new StringBuilder("Error: nothing to commit.");
+        if (!hasUnstaged && !hasUntracked && !hasIgnored) {
+            hint.append(" The working tree is clean.");
+            return hint.toString();
+        }
+
+        hint.append(" Changes exist but were not staged by --all:");
+        if (hasUnstaged) {
+            hint.append("\n  Modified (not staged): ").append(unstaged.replace("\n", ", "));
+        }
+        if (hasUntracked) {
+            hint.append("\n  Untracked: ").append(untracked.replace("\n", ", "));
+        }
+        if (hasIgnored) {
+            hint.append("\n  Gitignored: ").append(ignored.replace("\n", ", "))
+                .append("\n  (ignored files require explicit `git add -f <path>` — git_stage will not force-add them)");
+        }
+        hint.append("\nUse git_stage with an explicit path to include specific files, "
+            + "or update .gitignore if these should be tracked.");
+        return hint.toString();
     }
 
     /**

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/PsiBridgeServiceStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/PsiBridgeServiceStaticMethodsTest.java
@@ -658,6 +658,55 @@ class PsiBridgeServiceStaticMethodsTest {
     }
 
     // ---------------------------------------------------------------
+    // formatBaseErrorMessage
+    // ---------------------------------------------------------------
+    @Nested
+    class FormatBaseErrorMessageTest {
+
+        @Test
+        void nonNullMessageIsPrefixedWithError() {
+            Exception e = new IllegalStateException("boom");
+            assertEquals("Error: boom", PsiBridgeService.formatBaseErrorMessage(e, ""));
+        }
+
+        @Test
+        void nonNullMessageIsPreservedEvenWhenModalPresent() {
+            Exception e = new IllegalStateException("specific failure");
+            assertEquals("Error: specific failure",
+                PsiBridgeService.formatBaseErrorMessage(e, "Modal dialog blocking: 'Settings'"));
+        }
+
+        @Test
+        void nullMessageWithModalDetailReturnsModalError() {
+            Exception e = new NullPointerException();
+            String result = PsiBridgeService.formatBaseErrorMessage(e, "Modal dialog blocking: 'Settings'");
+            assertEquals("Error: Operation blocked by modal dialog", result);
+            assertFalse(result.contains("null"), "Must not contain literal 'null'");
+        }
+
+        @Test
+        void nullMessageWithoutModalFallsBackToExceptionClass() {
+            Exception e = new NullPointerException();
+            assertEquals("Error: NullPointerException",
+                PsiBridgeService.formatBaseErrorMessage(e, ""));
+        }
+
+        @Test
+        void blankMessageIsTreatedAsMissing() {
+            Exception e = new IllegalStateException("   ");
+            assertEquals("Error: IllegalStateException",
+                PsiBridgeService.formatBaseErrorMessage(e, ""));
+        }
+
+        @Test
+        void literalNullStringMessageIsTreatedAsMissing() {
+            Exception e = new IllegalStateException("null");
+            assertEquals("Error: IllegalStateException",
+                PsiBridgeService.formatBaseErrorMessage(e, ""));
+        }
+    }
+
+    // ---------------------------------------------------------------
     // isSyncCategory
     // ---------------------------------------------------------------
     @Nested

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitToolsTest.java
@@ -524,12 +524,15 @@ public class GitToolsTest extends BasePlatformTestCase {
 
         assertNotNull(result);
         assertTrue("Expected 'nothing to commit' error", result.startsWith("Error: nothing to commit."));
-        // The hint appended after the base message must contain a guidance phrase.
+        // The hint appended after the base message must contain actionable guidance.
         // • "The working tree is clean." when no changes exist
-        // • "There are unstaged changes not picked up by --all" for edge cases
+        // • A path listing ("Modified", "Untracked", or "Gitignored") when changes are unstaged
         boolean containsHint =
             result.contains("working tree")
-                || result.contains("unstaged");
+                || result.contains("Modified")
+                || result.contains("Untracked")
+                || result.contains("Gitignored")
+                || result.contains("git_stage");
         assertTrue("Error must include actionable guidance, got: " + result, containsHint);
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitToolsTest.java
@@ -536,6 +536,46 @@ public class GitToolsTest extends BasePlatformTestCase {
         assertTrue("Error must include actionable guidance, got: " + result, containsHint);
     }
 
+    /**
+     * When there is a modified-but-not-staged file, the "nothing to commit" hint must
+     * list it under "Modified (not staged):" so the agent knows exactly what to stage.
+     */
+    public void testGitCommitHintListsUnstagedModification() throws Exception {
+        // Modify the tracked README.md without staging it.
+        Path readme = Path.of(basePath, "README.md");
+        Files.writeString(readme, "# Modified\n");
+
+        GitCommitTool tool = new GitCommitTool(getProject());
+        String result = tool.execute(args("message", "test: must not be committed", "all", "false"));
+
+        assertNotNull(result);
+        assertTrue("Expected 'nothing to commit' error, got: " + result,
+            result.startsWith("Error: nothing to commit."));
+        assertTrue("Hint must list the unstaged file under 'Modified', got: " + result,
+            result.contains("Modified") && result.contains("README.md"));
+        assertTrue("Hint must include git_stage guidance, got: " + result,
+            result.contains("git_stage"));
+    }
+
+    /**
+     * When there is a new untracked file, the "nothing to commit" hint must list it
+     * under "Untracked:" so the agent knows it exists but needs explicit staging.
+     */
+    public void testGitCommitHintListsUntrackedFile() throws Exception {
+        // Create a new untracked file that has never been staged.
+        Path newFile = Path.of(basePath, "new-untracked.txt");
+        Files.writeString(newFile, "untracked content\n");
+
+        GitCommitTool tool = new GitCommitTool(getProject());
+        String result = tool.execute(args("message", "test: must not be committed", "all", "false"));
+
+        assertNotNull(result);
+        assertTrue("Expected 'nothing to commit' error, got: " + result,
+            result.startsWith("Error: nothing to commit."));
+        assertTrue("Hint must list the untracked file under 'Untracked', got: " + result,
+            result.contains("Untracked") && result.contains("new-untracked.txt"));
+    }
+
     // ── GitLogTool — additional format/filter tests ───────────────────────────────
 
     /**


### PR DESCRIPTION
Two small quality-of-life fixes surfaced by the tool-call error stats (last ~24h, 2321 calls, 71 errors):

## 1. `edit_text` — `Error: null\nModal dialog blocking: 'Settings'`

When the user opens Settings (or any modal) while the agent is editing, the IDE throws a message-less exception because the write action can't dispatch. The catch block in `PsiBridgeService` formatted it as `Error: ` + `e.getMessage()` = literal `Error: null`, then appended the modal hint below — confusing output.

New helper `formatBaseErrorMessage` picks a sensible base:
- Non-null message → `Error: <message>` (unchanged)
- Null + modal visible → `Error: Operation blocked by modal dialog`
- Null + no modal → `Error: <ExceptionClassSimpleName>`

This is a pure defensive-formatting fix — no threading changes. The existing `describeModalBlocker` call remains in the catch block (already off-EDT-safe via `Window.getWindows()` snapshot) and still appends the `Use interact_with_modal...` hint via `buildErrorWithModalDetail`.

**Note**: as the user flagged, this *doesn't* prevent the root cause — a user opening Settings mid-edit will still block the write action. That's an inherent IntelliJ platform behaviour and fixing it would require dispatching writes around modality (risky). This just makes the resulting error message clear and actionable.

## 2. `git_commit` — `nothing to commit` hint was vague

Previously: `Error: nothing to commit. There are unstaged changes not picked up by --all (e.g. ignored files).` — correct but didn't tell the agent *what* or *how to fix*.

Now lists paths per category, using `git diff`, `ls-files --others`, and `ls-files --others --ignored`:
```
Error: nothing to commit. Changes exist but were not staged by --all:
  Modified (not staged): foo.txt
  Untracked: bar.txt
  Gitignored: build/out.log
  (ignored files require explicit `git add -f <path>` — git_stage will not force-add them)
Use git_stage with an explicit path to include specific files, or update .gitignore if these should be tracked.
```

## Tests
- New `FormatBaseErrorMessageTest` nested class in `PsiBridgeServiceStaticMethodsTest` (6 cases: non-null, non-null with modal, null with modal, null without modal, blank message, literal "null" message).
- Updated `GitToolsTest.testGitCommitNothingStagedErrorContainsHint` to accept the new hint phrasing.
- Full `GitToolsTest` + `PsiBridgeServiceStaticMethodsTest` suites pass.

## Performance / threading
Both changes are pure string formatting in existing code paths — no new threads, locks, write actions, or EDT dispatches. The `describeModalBlocker()` call was already on the path; we're just consuming its result more intelligently.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>