### PR TITLE
Enhance project agents and renderers with XML-style preprocessing for opencode

### DIFF
--- a/plugin-core/chat-ui/src/renderMarkdown.ts
+++ b/plugin-core/chat-ui/src/renderMarkdown.ts
@@ -55,6 +55,20 @@ function formatInline(text: string): string {
     return result.join('');
 }
 
+const THINK_TAG_PATTERN = /<(think|thinking)>([\s\S]*?)<\/\1>/gi;
+const WRAPPER_TAG_LINE_PATTERN = /^\s*<\/?(task_result|commentary|example|code)>\s*$/gim;
+
+function buildThinkingBlockHtml(content: string): string {
+    const normalized = content.trim() || 'No reasoning returned';
+    return `<thinking-block><div class="thinking-content">${escHtmlMd(normalized).replaceAll('\r\n', '\n').replaceAll('\r', '\n').replaceAll('\n', '<br>')}</div></thinking-block>`;
+}
+
+function preprocessXmlTags(text: string): string {
+    return text
+        .replace(THINK_TAG_PATTERN, (_match, _tag, content) => buildThinkingBlockHtml(content))
+        .replace(WRAPPER_TAG_LINE_PATTERN, '');
+}
+
 /**
  * Convert a Markdown string to an HTML string.
  *
@@ -72,7 +86,7 @@ function formatInline(text: string): string {
  * blocks, unclosed lists, etc.) by closing all open constructs at the end.
  */
 export function renderMarkdown(text: string): string {
-    const lines = text.split('\n');
+    const lines = preprocessXmlTags(text).split('\n');
     const out: string[] = [];
     let inCode = false;
     let inList = false;
@@ -102,6 +116,12 @@ export function renderMarkdown(text: string): string {
 
     for (const line of lines) {
         const t = line.trim();
+
+        if (t.startsWith('<thinking-block')) {
+            closeAllInline();
+            out.push(t);
+            continue;
+        }
 
         // ── Code fence ─────────────────────────────────────────────
         if (t.startsWith('```')) {

--- a/plugin-core/chat-ui/src/renderMarkdown.ts
+++ b/plugin-core/chat-ui/src/renderMarkdown.ts
@@ -69,6 +69,38 @@ function preprocessXmlTags(text: string): string {
         .replace(WRAPPER_TAG_LINE_PATTERN, '');
 }
 
+function preprocessXmlTagsOutsideCodeFences(text: string): string {
+    const lines = text.split('\n');
+    const processed: string[] = [];
+    const segment: string[] = [];
+    let inCodeFence = false;
+
+    const flushSegment = (): void => {
+        if (segment.length === 0) {
+            return;
+        }
+        processed.push(...preprocessXmlTags(segment.join('\n')).split('\n'));
+        segment.length = 0;
+    };
+
+    for (const line of lines) {
+        if (line.trim().startsWith('```')) {
+            flushSegment();
+            processed.push(line);
+            inCodeFence = !inCodeFence;
+            continue;
+        }
+        if (inCodeFence) {
+            processed.push(line);
+            continue;
+        }
+        segment.push(line);
+    }
+
+    flushSegment();
+    return processed.join('\n');
+}
+
 /**
  * Convert a Markdown string to an HTML string.
  *
@@ -86,7 +118,7 @@ function preprocessXmlTags(text: string): string {
  * blocks, unclosed lists, etc.) by closing all open constructs at the end.
  */
 export function renderMarkdown(text: string): string {
-    const lines = preprocessXmlTags(text).split('\n');
+    const lines = preprocessXmlTagsOutsideCodeFences(text).split('\n');
     const out: string[] = [];
     let inCode = false;
     let inList = false;

--- a/plugin-core/js-tests/render-markdown.test.js
+++ b/plugin-core/js-tests/render-markdown.test.js
@@ -27,4 +27,16 @@ describe('renderMarkdown XML tag preprocessing', () => {
         expect(html).toContain('&lt;think&gt;');
         expect(html).not.toContain('<thinking-block>');
     });
+
+    it('does not preprocess think or wrapper tags inside fenced code blocks', () => {
+        const html = renderMarkdown('```md\n<think>Reasoning</think>\n<task_result>\n```');
+        expect(html).toContain('&lt;think&gt;Reasoning&lt;/think&gt;');
+        expect(html).toContain('&lt;task_result&gt;');
+        expect(html).not.toContain('<thinking-block>');
+    });
+
+    it('renders empty think tags with fallback text', () => {
+        const html = renderMarkdown('<think>\r\n\r\n</think>');
+        expect(html).toContain('No reasoning returned');
+    });
 });

--- a/plugin-core/js-tests/render-markdown.test.js
+++ b/plugin-core/js-tests/render-markdown.test.js
@@ -1,0 +1,30 @@
+import {describe, expect, it} from 'vitest';
+import {renderMarkdown} from '../chat-ui/src/renderMarkdown.ts';
+
+describe('renderMarkdown XML tag preprocessing', () => {
+    it('renders think tags as thinking blocks', () => {
+        const html = renderMarkdown('Before\n<think>Step 1\nStep 2</think>\nAfter');
+        expect(html).toContain('<thinking-block><div class="thinking-content">Step 1<br>Step 2</div></thinking-block>');
+        expect(html).toContain('<p>Before</p>');
+        expect(html).toContain('<p>After</p>');
+    });
+
+    it('renders thinking tags as thinking blocks', () => {
+        const html = renderMarkdown('<thinking>Reasoning</thinking>');
+        expect(html).toContain('<thinking-block><div class="thinking-content">Reasoning</div></thinking-block>');
+    });
+
+    it('strips standalone wrapper tags', () => {
+        const html = renderMarkdown('<task_result>\nResult body\n</task_result>\n<example>\nExample body\n</example>');
+        expect(html).not.toContain('task_result');
+        expect(html).not.toContain('example');
+        expect(html).toContain('<p>Result body</p>');
+        expect(html).toContain('<p>Example body</p>');
+    });
+
+    it('leaves unclosed think tags escaped as plain text', () => {
+        const html = renderMarkdown('<think>\nunfinished');
+        expect(html).toContain('&lt;think&gt;');
+        expect(html).not.toContain('<thinking-block>');
+    });
+});

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClient.java
@@ -125,33 +125,27 @@ public final class OpenCodeClient extends AcpClient {
 
     @Override
     protected Map<String, String> buildEnvironment(int mcpPort, String cwd) {
-        return buildPermissionConfig(resolveDefaultPrimaryAgent());
+        return buildPermissionConfig();
     }
 
     /**
      * Builds the OPENCODE_CONFIG_CONTENT environment variable denying native tools.
+     *
+     * <p>NOTE: We do NOT set {@code "default_agent"} here. OpenCode v1.4.10+ rejects
+     * subagent slugs (like "build", "plan", "explore") as the {@code default_agent} value,
+     * causing {@code session/new} to fail with
+     * {@code "default agent \"build\" is a subagent"}. OpenCode selects its own default
+     * agent internally — the plugin's agent dropdown controls which agent to start via
+     * the session/create flow instead.</p>
      */
     static Map<String, String> buildPermissionConfig() {
-        return buildPermissionConfig(BUILD_AGENT);
-    }
-
-    static Map<String, String> buildPermissionConfig(@Nullable String defaultAgentSlug) {
         JsonObject permission = new JsonObject();
         for (String tool : NATIVE_TOOLS_TO_DENY) {
             permission.addProperty(tool, "deny");
         }
         JsonObject config = new JsonObject();
         config.add("permission", permission);
-        if (defaultAgentSlug != null && !defaultAgentSlug.isBlank()) {
-            config.addProperty("default_agent", defaultAgentSlug);
-        }
         return Map.of("OPENCODE_CONFIG_CONTENT", new Gson().toJson(config));
-    }
-
-    private @Nullable String resolveDefaultPrimaryAgent() {
-        String current = getCurrentAgentSlug();
-        if (PLAN_AGENT.equals(current)) return PLAN_AGENT;
-        return BUILD_AGENT;
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClient.java
@@ -1,5 +1,7 @@
 package com.github.catatafishen.agentbridge.acp.client;
 
+import com.github.catatafishen.agentbridge.agent.AbstractAgentClient;
+import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
@@ -8,8 +10,10 @@ import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * OpenCode ACP client.
@@ -22,10 +26,17 @@ import java.util.Map;
 public final class OpenCodeClient extends AcpClient {
 
     private static final String AGENT_ID = "opencode";
+    private static final String BUILD_AGENT = "build";
+    private static final String PLAN_AGENT = "plan";
+    private static final String GENERAL_AGENT = "general";
+    private static final String EXPLORE_AGENT = "explore";
+    private static final String PROJECT_AGENT_DIR = ".opencode/agent";
+    private static final String PROJECT_AGENTS_DIR = ".opencode/agents";
 
     private static final String KEY_RAW_INPUT = "rawInput";
     private static final List<String> NATIVE_TOOLS_TO_DENY = List.of(
-        "grep", "glob", "ls", "read", "write", "edit", "patch", "bash"
+        "grep", "glob", "ls", "read", "write", "edit", "patch", "bash",
+        "lsp", "websearch", "webfetch", "codesearch", "todoread", "todowrite"
     );
 
     static List<String> nativeToolsToDeny() {
@@ -44,6 +55,35 @@ public final class OpenCodeClient extends AcpClient {
     @Override
     public String displayName() {
         return "OpenCode";
+    }
+
+    @Override
+    public @Nullable String defaultAgentSlug() {
+        return BUILD_AGENT;
+    }
+
+    @Override
+    public List<AbstractAgentClient.AgentMode> getAvailableAgents() {
+        List<AbstractAgentClient.AgentMode> agents = new ArrayList<>(builtInAgents());
+        String basePath = project.getBasePath();
+        if (basePath != null) {
+            agents.addAll(ProjectAgentScanner.scanAgentDirectories(
+                Path.of(basePath),
+                Set.of(BUILD_AGENT, PLAN_AGENT, GENERAL_AGENT, EXPLORE_AGENT),
+                PROJECT_AGENT_DIR,
+                PROJECT_AGENTS_DIR
+            ));
+        }
+        return agents;
+    }
+
+    static List<AbstractAgentClient.AgentMode> builtInAgents() {
+        return List.of(
+            new AbstractAgentClient.AgentMode(BUILD_AGENT, "Build", "Default primary agent with full tool access"),
+            new AbstractAgentClient.AgentMode(PLAN_AGENT, "Plan", "Read-only planning mode with guarded edits and bash"),
+            new AbstractAgentClient.AgentMode(GENERAL_AGENT, "General", "General-purpose subagent for complex tasks"),
+            new AbstractAgentClient.AgentMode(EXPLORE_AGENT, "Explore", "Fast read-only subagent for codebase exploration")
+        );
     }
 
     @Override
@@ -83,20 +123,33 @@ public final class OpenCodeClient extends AcpClient {
 
     @Override
     protected Map<String, String> buildEnvironment(int mcpPort, String cwd) {
-        return buildPermissionConfig();
+        return buildPermissionConfig(resolveDefaultPrimaryAgent());
     }
 
     /**
      * Builds the OPENCODE_CONFIG_CONTENT environment variable denying native tools.
      */
     static Map<String, String> buildPermissionConfig() {
+        return buildPermissionConfig(BUILD_AGENT);
+    }
+
+    static Map<String, String> buildPermissionConfig(@Nullable String defaultAgentSlug) {
         JsonObject permission = new JsonObject();
         for (String tool : NATIVE_TOOLS_TO_DENY) {
             permission.addProperty(tool, "deny");
         }
         JsonObject config = new JsonObject();
         config.add("permission", permission);
-        return Map.of("OPENCODE_CONFIG_CONTENT", new com.google.gson.Gson().toJson(config));
+        if (defaultAgentSlug != null && !defaultAgentSlug.isBlank()) {
+            config.addProperty("default_agent", defaultAgentSlug);
+        }
+        return Map.of("OPENCODE_CONFIG_CONTENT", new Gson().toJson(config));
+    }
+
+    private @Nullable String resolveDefaultPrimaryAgent() {
+        String current = getCurrentAgentSlug();
+        if (PLAN_AGENT.equals(current)) return PLAN_AGENT;
+        return BUILD_AGENT;
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClient.java
@@ -32,6 +32,7 @@ public final class OpenCodeClient extends AcpClient {
     private static final String EXPLORE_AGENT = "explore";
     private static final String PROJECT_AGENT_DIR = ".opencode/agent";
     private static final String PROJECT_AGENTS_DIR = ".opencode/agents";
+    private static final String DEPLOYED_AGENT_DIR = ".agent-work/opencode/agent";
 
     private static final String KEY_RAW_INPUT = "rawInput";
     private static final List<String> NATIVE_TOOLS_TO_DENY = List.of(
@@ -71,7 +72,8 @@ public final class OpenCodeClient extends AcpClient {
                 Path.of(basePath),
                 Set.of(BUILD_AGENT, PLAN_AGENT, GENERAL_AGENT, EXPLORE_AGENT),
                 PROJECT_AGENT_DIR,
-                PROJECT_AGENTS_DIR
+                PROJECT_AGENTS_DIR,
+                DEPLOYED_AGENT_DIR
             ));
         }
         return agents;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/ProjectAgentScanner.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/ProjectAgentScanner.java
@@ -49,9 +49,19 @@ final class ProjectAgentScanner {
      */
     static @NotNull List<AgentMode> scanProjectAgents(@NotNull Path projectBasePath,
                                                       @NotNull Set<String> builtInSlugs) {
+        return scanAgentDirectories(projectBasePath, builtInSlugs, AGENT_DIRS);
+    }
+
+    /**
+     * Scans the provided relative directories for {@code .md} agent files and returns
+     * an {@link AgentMode} for each one. Earlier directories win on slug collisions.
+     */
+    static @NotNull List<AgentMode> scanAgentDirectories(@NotNull Path projectBasePath,
+                                                         @NotNull Set<String> builtInSlugs,
+                                                         @NotNull String... relativeDirs) {
         Map<String, AgentMode> discovered = new LinkedHashMap<>();
 
-        for (String relDir : AGENT_DIRS) {
+        for (String relDir : relativeDirs) {
             Path dir = projectBasePath.resolve(relDir);
             if (!Files.isDirectory(dir)) continue;
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/bridge/OpenCodeAgentConfig.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/bridge/OpenCodeAgentConfig.java
@@ -42,7 +42,8 @@ final class OpenCodeAgentConfig extends ProfileBasedAgentConfig {
      */
     private static final List<String> NATIVE_TOOLS = List.of(
         "grep", "glob", "ls", "read", "write", "edit", "patch",
-        "bash", "webfetch", "task", "todoread", "todowrite"
+        "bash", "webfetch", "task", "todoread", "todowrite",
+        "lsp", "websearch", "codesearch"
     );
 
     OpenCodeAgentConfig(@NotNull AgentProfile profile,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -8,8 +8,8 @@ import com.github.catatafishen.agentbridge.session.SessionSwitchService
 import com.github.catatafishen.agentbridge.session.migration.V1ToV2Migrator
 import com.github.catatafishen.agentbridge.session.v2.SessionStoreV2
 import com.github.catatafishen.agentbridge.settings.ChatHistorySettings
-import com.intellij.ide.ActivityTracker
 import com.intellij.icons.AllIcons
+import com.intellij.ide.ActivityTracker
 import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.actionSystem.ex.ComboBoxAction
 import com.intellij.openapi.actionSystem.ex.CustomComponentAction
@@ -1328,7 +1328,10 @@ class ChatToolWindowContent(
 
             // OpenCode
             val openCodeGroup = DefaultActionGroup()
-            addGlobSection(openCodeGroup, base, ".agent-work/opencode/agent", "*.md")
+            addLabeledGlobSection(openCodeGroup, base, "Project Agents", "*.md", ".opencode/agent", ".opencode/agents")
+            addLabeledGlobSection(openCodeGroup, base, "Skills", "*/SKILL.md", ".opencode/skills")
+            addLabeledGlobSection(openCodeGroup, base, "Commands", "*.md", ".opencode/commands")
+            addLabeledGlobSection(openCodeGroup, base, "Deployed", "*.md", ".agent-work/opencode/agent")
             if (openCodeGroup.childrenCount > 0) {
                 if (group.childrenCount > 0) group.addSeparator()
                 group.addSeparator("OpenCode")
@@ -1406,6 +1409,37 @@ class ChatToolWindowContent(
 
             files.forEach { file ->
                 val relPath = file.relativeTo(java.io.File(base)).path
+                val extension = file.extension
+                val icon = com.intellij.openapi.fileTypes.FileTypeManager.getInstance()
+                    .getFileTypeByExtension(extension).icon
+
+                group.add(object : AnAction(file.nameWithoutExtension, "Open ${file.name}", icon) {
+                    override fun getActionUpdateThread() = ActionUpdateThread.BGT
+                    override fun actionPerformed(e: AnActionEvent) = openProjectFile(relPath)
+                })
+            }
+        }
+
+        private fun addLabeledGlobSection(
+            group: DefaultActionGroup,
+            base: String,
+            label: String,
+            pattern: String,
+            vararg dirPaths: String
+        ) {
+            val baseDir = java.io.File(base)
+            val files = linkedMapOf<String, java.io.File>()
+            dirPaths.forEach { dirPath ->
+                findMatchingFiles(java.io.File(base, dirPath), pattern).forEach { file ->
+                    val relPath = file.relativeTo(baseDir).path
+                    files.putIfAbsent(relPath, file)
+                }
+            }
+            if (files.isEmpty()) return
+
+            group.addSeparator(label)
+            files.values.sortedBy { it.relativeTo(baseDir).path.lowercase() }.forEach { file ->
+                val relPath = file.relativeTo(baseDir).path
                 val extension = file.extension
                 val icon = com.intellij.openapi.fileTypes.FileTypeManager.getInstance()
                     .getFileTypeByExtension(extension).icon

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/MarkdownRenderer.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/MarkdownRenderer.kt
@@ -10,6 +10,7 @@ object MarkdownRenderer {
     private const val HTML_TABLE_CLOSE = "</table>"
     private const val HTML_BLOCKQUOTE_CLOSE = "</blockquote>"
     private const val HTML_CODE_BLOCK_CLOSE = "</code></pre>"
+    private const val THINKING_FALLBACK = "No reasoning returned"
     private val FILE_PATH_REGEX: Regex = run {
         // Split into named parts so S5843 (regex complexity) analysis doesn't flag the combined form.
         val absolutePath = """/[\w.\-]+(?:/[\w.\-]+)*\.\w+"""
@@ -19,6 +20,11 @@ object MarkdownRenderer {
     }
     private val GIT_SHA_REGEX = Regex("""^[0-9a-f]{7,40}$""")
     private val BARE_GIT_SHA_REGEX = Regex("""\b([0-9a-f]{7,12})\b""")
+    private val THINK_TAG_REGEX =
+        Regex("""<(think|thinking)>(.*?)</\1>""", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
+    private val WRAPPER_TAG_LINE_REGEX = Regex(
+        """(?im)^\s*</?(?:task_result|commentary|example|code)>\s*$\r?\n?"""
+    )
 
     data class MarkdownState(
         var inCode: Boolean = false,
@@ -35,13 +41,19 @@ object MarkdownRenderer {
         resolveFilePath: (String) -> String? = { null },
         isGitCommit: (String) -> Boolean = { false }
     ): String {
-        val lines = text.lines()
+        val lines = preprocessXmlTags(text).lines()
         val sb = StringBuilder()
         val state = MarkdownState()
 
         for (line in lines) {
             val t = line.trim()
             when {
+                t.startsWith("<thinking-block") -> {
+                    closeImplicitCode(sb, state)
+                    closeAllInlineBlocks(sb, state)
+                    sb.append(t)
+                }
+
                 t.startsWith("```") -> {
                     closeImplicitCode(sb, state)
                     handleCodeFence(sb, state, t)
@@ -85,6 +97,23 @@ object MarkdownRenderer {
 
         closeAllBlocks(sb, state)
         return sb.toString()
+    }
+
+    private fun preprocessXmlTags(text: String): String {
+        var processed = THINK_TAG_REGEX.replace(text) { match ->
+            buildThinkingBlockHtml(match.groupValues[2])
+        }
+        processed = WRAPPER_TAG_LINE_REGEX.replace(processed, "")
+        return processed
+    }
+
+    private fun buildThinkingBlockHtml(content: String): String {
+        val normalized = content.trim()
+            .ifEmpty { THINKING_FALLBACK }
+            .replace("\r\n", "\n")
+            .replace("\r", "\n")
+        val escaped = escapeHtml(normalized).replace("\n", "<br>")
+        return "<thinking-block><div class=\"thinking-content\">$escaped</div></thinking-block>"
     }
 
     private fun handleCodeFence(sb: StringBuilder, state: MarkdownState, fenceLine: String) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/MarkdownRenderer.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/MarkdownRenderer.kt
@@ -41,7 +41,7 @@ object MarkdownRenderer {
         resolveFilePath: (String) -> String? = { null },
         isGitCommit: (String) -> Boolean = { false }
     ): String {
-        val lines = preprocessXmlTags(text).lines()
+        val lines = preprocessXmlTagsOutsideCodeBlocks(text)
         val sb = StringBuilder()
         val state = MarkdownState()
 
@@ -104,6 +104,53 @@ object MarkdownRenderer {
             buildThinkingBlockHtml(match.groupValues[2])
         }
         processed = WRAPPER_TAG_LINE_REGEX.replace(processed, "")
+        return processed
+    }
+
+    private fun preprocessXmlTagsOutsideCodeBlocks(text: String): List<String> {
+        val rawLines = text.lines()
+        val processed = mutableListOf<String>()
+        val segment = mutableListOf<String>()
+        var inFence = false
+        var inImplicit = false
+
+        fun flushSegment() {
+            if (segment.isEmpty()) return
+            processed += preprocessXmlTags(segment.joinToString("\n")).lines()
+            segment.clear()
+        }
+
+        for (line in rawLines) {
+            val trimmed = line.trim()
+            if (trimmed.startsWith("```")) {
+                flushSegment()
+                processed += line
+                inFence = !inFence
+                inImplicit = false
+                continue
+            }
+            if (inFence) {
+                processed += line
+                continue
+            }
+            if (inImplicit) {
+                if (trimmed.isEmpty() || isMajorBlockElement(trimmed)) {
+                    inImplicit = false
+                } else {
+                    processed += line
+                    continue
+                }
+            }
+            if (isCodeLikeLine(trimmed)) {
+                flushSegment()
+                processed += line
+                inImplicit = true
+                continue
+            }
+            segment += line
+        }
+
+        flushSegment()
         return processed
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/HtmlToolRendererSupport.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/HtmlToolRendererSupport.kt
@@ -1,7 +1,9 @@
 package com.github.catatafishen.agentbridge.ui.renderers
 
+import com.github.catatafishen.agentbridge.ui.FileNavigator
 import com.github.catatafishen.agentbridge.ui.MarkdownRenderer
 import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import java.awt.Dimension
@@ -33,12 +35,22 @@ object HtmlToolRendererSupport {
             isOpaque = false
             border = JBUI.Borders.emptyTop(4)
             alignmentX = JComponent.LEFT_ALIGNMENT
-            addHyperlinkListener { event ->
-                if (event.eventType == HyperlinkEvent.EventType.ACTIVATED && event.url != null) {
-                    BrowserUtil.browse(event.url.toExternalForm())
+            addHyperlinkListener(::handleActivatedLink)
+            maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
+        }
+    }
+
+    private fun handleActivatedLink(event: HyperlinkEvent) {
+        if (event.eventType != HyperlinkEvent.EventType.ACTIVATED) return
+        val href = event.description ?: event.url?.toExternalForm() ?: return
+        when {
+            href.startsWith("openfile://") || href.startsWith("gitshow://") -> {
+                ProjectManager.getInstance().openProjects.firstOrNull { !it.isDisposed }?.let { project ->
+                    FileNavigator(project).handleFileLink(href)
                 }
             }
-            maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
+
+            href.startsWith("http://") || href.startsWith("https://") -> BrowserUtil.browse(href)
         }
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/HtmlToolRendererSupport.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/HtmlToolRendererSupport.kt
@@ -1,0 +1,44 @@
+package com.github.catatafishen.agentbridge.ui.renderers
+
+import com.github.catatafishen.agentbridge.ui.MarkdownRenderer
+import com.intellij.ide.BrowserUtil
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import java.awt.Dimension
+import javax.swing.JComponent
+import javax.swing.JEditorPane
+import javax.swing.event.HyperlinkEvent
+
+object HtmlToolRendererSupport {
+    fun markdownPane(markdown: String): JComponent {
+        val font = UIUtil.getLabelFont()
+        val html = MarkdownRenderer.markdownToHtml(markdown)
+        return JEditorPane(
+            "text/html",
+            """
+            <html>
+              <head>
+                <style>
+                  body { font-family: '${font.family}'; font-size: ${font.size}pt; margin: 0; }
+                  p, ul, table, blockquote, pre { margin-top: 0; margin-bottom: 6px; }
+                  code, pre { font-family: 'JetBrains Mono', 'Consolas', monospace; }
+                </style>
+              </head>
+              <body>$html</body>
+            </html>
+            """.trimIndent()
+        ).apply {
+            putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, true)
+            isEditable = false
+            isOpaque = false
+            border = JBUI.Borders.emptyTop(4)
+            alignmentX = JComponent.LEFT_ALIGNMENT
+            addHyperlinkListener { event ->
+                if (event.eventType == HyperlinkEvent.EventType.ACTIVATED && event.url != null) {
+                    BrowserUtil.browse(event.url.toExternalForm())
+                }
+            }
+            maximumSize = Dimension(Int.MAX_VALUE, preferredSize.height)
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/TaskToolRenderer.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/TaskToolRenderer.kt
@@ -6,6 +6,7 @@ import javax.swing.JComponent
 
 object TaskToolRenderer : ToolResultRenderer {
     private val TASK_ID_LINE = Regex("""^task_id:\s*(.+?)(?:\s+\(.*\))?\s*$""")
+    private val TASK_RESULT_WRAPPER_LINE = Regex("""^\s*</?task_result>\s*$""")
 
     data class ParsedTaskResult(val taskId: String?, val content: String)
 
@@ -23,12 +24,11 @@ object TaskToolRenderer : ToolResultRenderer {
 
         val content = lines
             .dropWhile { it.isBlank() }
+            .filterNot { TASK_RESULT_WRAPPER_LINE.matches(it) }
             .joinToString("\n")
-            .replace("<task_result>", "")
-            .replace("</task_result>", "")
             .trim()
 
-        return ParsedTaskResult(taskId, if (content.isNotBlank()) content else trimmed)
+        return ParsedTaskResult(taskId, content.ifBlank { trimmed })
     }
 
     override fun render(output: String): JComponent? {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/TaskToolRenderer.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/TaskToolRenderer.kt
@@ -1,0 +1,64 @@
+package com.github.catatafishen.agentbridge.ui.renderers
+
+import com.intellij.ui.components.JBTextField
+import com.intellij.util.ui.JBUI
+import javax.swing.JComponent
+
+object TaskToolRenderer : ToolResultRenderer {
+    private val TASK_ID_LINE = Regex("""^task_id:\s*(.+?)(?:\s+\(.*\))?\s*$""")
+
+    data class ParsedTaskResult(val taskId: String?, val content: String)
+
+    fun parseTaskOutput(output: String): ParsedTaskResult {
+        val trimmed = output.trim()
+        if (trimmed.isEmpty()) {
+            return ParsedTaskResult(null, "")
+        }
+
+        val lines = trimmed.lines().toMutableList()
+        val taskId = TASK_ID_LINE.find(lines.firstOrNull()?.trim().orEmpty())?.groupValues?.getOrNull(1)?.trim()
+        if (taskId != null && lines.isNotEmpty()) {
+            lines.removeAt(0)
+        }
+
+        val content = lines
+            .dropWhile { it.isBlank() }
+            .joinToString("\n")
+            .replace("<task_result>", "")
+            .replace("</task_result>", "")
+            .trim()
+
+        return ParsedTaskResult(taskId, if (content.isNotBlank()) content else trimmed)
+    }
+
+    override fun render(output: String): JComponent? {
+        val parsed = parseTaskOutput(output)
+        if (parsed.taskId == null && parsed.content.isBlank()) return null
+
+        val panel = ToolRenderers.listPanel()
+        panel.add(ToolRenderers.statusHeader(ToolIcons.EXECUTE, "Subagent Result", ToolRenderers.INFO_COLOR))
+
+        if (parsed.taskId != null) {
+            val row = ToolRenderers.rowPanel()
+            row.border = JBUI.Borders.emptyTop(2)
+            row.add(ToolRenderers.mutedLabel("Task ID"))
+            row.add(JBTextField(parsed.taskId).apply {
+                isEditable = false
+                border = JBUI.Borders.empty(0, 4)
+                columns = parsed.taskId.length.coerceIn(12, 36)
+                maximumSize = preferredSize
+            })
+            panel.add(row)
+        }
+
+        if (parsed.content.isNotBlank()) {
+            panel.add(HtmlToolRendererSupport.markdownPane(parsed.content))
+        } else {
+            panel.add(ToolRenderers.mutedLabel("No subagent output").apply {
+                alignmentX = JComponent.LEFT_ALIGNMENT
+            })
+        }
+
+        return panel
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/ToolResultRenderer.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/ToolResultRenderer.kt
@@ -87,8 +87,15 @@ object ToolRenderers {
         "write_file" to WriteFileRenderer,
         "create_file" to WriteFileRenderer,
         // OpenCode / Claude built-in tools
+        "task" to TaskToolRenderer,
+        "bash" to RunCommandRenderer,
         "todowrite" to TodoRenderer,
         "TodoWrite" to TodoRenderer,
+        "list" to ListProjectFilesRenderer,
+        "ls" to ListProjectFilesRenderer,
+        "patch" to WriteFileRenderer,
+        "webfetch" to WebFetchRenderer,
+        "websearch" to WebSearchRenderer,
         "grep" to GlobRenderer,  // similar list output format
         "Grep" to GlobRenderer,
     )

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/WebFetchRenderer.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/WebFetchRenderer.kt
@@ -1,0 +1,86 @@
+package com.github.catatafishen.agentbridge.ui.renderers
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import javax.swing.JComponent
+
+object WebFetchRenderer : ToolResultRenderer {
+    data class FetchContent(val url: String?, val status: String?, val body: String)
+
+    override fun render(output: String): JComponent? {
+        val parsed = parseOutput(output) ?: return null
+        val panel = ToolRenderers.listPanel()
+        val header = ToolRenderers.statusHeader(ToolIcons.SEARCH, "Fetched URL", ToolRenderers.INFO_COLOR)
+        parsed.status?.takeIf { it.isNotBlank() }?.let { header.add(ToolRenderers.mutedLabel(it)) }
+        panel.add(header)
+
+        parsed.url?.takeIf { it.isNotBlank() }?.let {
+            val row = ToolRenderers.rowPanel()
+            row.add(ToolRenderers.mutedLabel("URL"))
+            row.add(ToolRenderers.monoLabel(it))
+            panel.add(row)
+        }
+
+        if (parsed.body.isNotBlank()) {
+            panel.add(HtmlToolRendererSupport.markdownPane(parsed.body))
+        }
+        return panel
+    }
+
+    private fun parseOutput(output: String): FetchContent? {
+        val trimmed = output.trim()
+        if (trimmed.isEmpty()) return null
+
+        parseJson(trimmed)?.let { return it }
+
+        val lines = trimmed.lines()
+        var url: String? = null
+        var status: String? = null
+        var bodyStart = 0
+        for ((index, line) in lines.withIndex()) {
+            val trimmedLine = line.trim()
+            if (trimmedLine.isEmpty()) {
+                bodyStart = index + 1
+                break
+            }
+            when {
+                trimmedLine.startsWith("URL:", ignoreCase = true) -> url = trimmedLine.substringAfter(":").trim()
+                trimmedLine.startsWith("Status:", ignoreCase = true) -> status = trimmedLine.substringAfter(":").trim()
+                url == null && (trimmedLine.startsWith("http://") || trimmedLine.startsWith("https://")) -> url =
+                    trimmedLine
+            }
+        }
+        val body = lines.drop(bodyStart).joinToString("\n").trim().ifBlank { trimmed }
+        return FetchContent(url, status, body)
+    }
+
+    private fun parseJson(raw: String): FetchContent? {
+        return try {
+            val root = JsonParser.parseString(raw)
+            if (!root.isJsonObject) return null
+            val obj = root.asJsonObject
+            val url = firstString(obj, "url", "finalUrl", "link")
+            val status = firstString(obj, "status", "statusCode", "code")
+            val body = firstString(obj, "markdown", "content", "body", "text", "snippet")
+            if (url == null && status == null && body == null) null else FetchContent(url, status, body ?: raw)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun firstString(obj: JsonObject, vararg keys: String): String? {
+        for (key in keys) {
+            val element = obj.get(key) ?: continue
+            val value = elementToText(element)
+            if (!value.isNullOrBlank()) return value
+        }
+        return null
+    }
+
+    private fun elementToText(element: JsonElement): String? = when {
+        element.isJsonNull -> null
+        element.isJsonPrimitive -> element.asString
+        else -> element.toString()
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/WebFetchRenderer.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/WebFetchRenderer.kt
@@ -37,21 +37,43 @@ object WebFetchRenderer : ToolResultRenderer {
         val lines = trimmed.lines()
         var url: String? = null
         var status: String? = null
-        var bodyStart = 0
+        var bodyStart = lines.size
+        var lastHeaderIndex = -1
         for ((index, line) in lines.withIndex()) {
             val trimmedLine = line.trim()
             if (trimmedLine.isEmpty()) {
                 bodyStart = index + 1
                 break
             }
-            when {
-                trimmedLine.startsWith("URL:", ignoreCase = true) -> url = trimmedLine.substringAfter(":").trim()
-                trimmedLine.startsWith("Status:", ignoreCase = true) -> status = trimmedLine.substringAfter(":").trim()
-                url == null && (trimmedLine.startsWith("http://") || trimmedLine.startsWith("https://")) -> url =
-                    trimmedLine
+            val isHeaderLine = when {
+                trimmedLine.startsWith("URL:", ignoreCase = true) -> {
+                    url = trimmedLine.substringAfter(":").trim()
+                    true
+                }
+
+                trimmedLine.startsWith("Status:", ignoreCase = true) -> {
+                    status = trimmedLine.substringAfter(":").trim()
+                    true
+                }
+
+                url == null && (trimmedLine.startsWith("http://") || trimmedLine.startsWith("https://")) -> {
+                    url = trimmedLine
+                    true
+                }
+
+                else -> false
             }
+            if (isHeaderLine) {
+                lastHeaderIndex = index
+                continue
+            }
+            bodyStart = index
+            break
         }
-        val body = lines.drop(bodyStart).joinToString("\n").trim().ifBlank { trimmed }
+        if (bodyStart == lines.size && lastHeaderIndex >= 0) {
+            bodyStart = lastHeaderIndex + 1
+        }
+        val body = lines.drop(bodyStart.coerceAtMost(lines.size)).joinToString("\n").trim().ifBlank { trimmed }
         return FetchContent(url, status, body)
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/WebSearchRenderer.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/WebSearchRenderer.kt
@@ -1,0 +1,108 @@
+package com.github.catatafishen.agentbridge.ui.renderers
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import javax.swing.JComponent
+
+object WebSearchRenderer : ToolResultRenderer {
+    private data class SearchResult(val title: String, val url: String?, val snippet: String?)
+    private data class SearchContent(val query: String?, val results: List<SearchResult>, val fallbackBody: String?)
+
+    override fun render(output: String): JComponent? {
+        val parsed = parseOutput(output) ?: return null
+        val panel = ToolRenderers.listPanel()
+        if (parsed.results.isNotEmpty()) {
+            panel.add(ToolRenderers.headerPanel(ToolIcons.SEARCH, parsed.results.size, "results"))
+            parsed.query?.takeIf { it.isNotBlank() }?.let {
+                val row = ToolRenderers.rowPanel()
+                row.add(ToolRenderers.mutedLabel("Query"))
+                row.add(ToolRenderers.monoLabel(it))
+                panel.add(row)
+            }
+            panel.add(HtmlToolRendererSupport.markdownPane(buildResultsMarkdown(parsed.results)))
+        } else {
+            panel.add(ToolRenderers.statusHeader(ToolIcons.SEARCH, "Web Search", ToolRenderers.INFO_COLOR))
+            parsed.fallbackBody?.takeIf { it.isNotBlank() }?.let { panel.add(HtmlToolRendererSupport.markdownPane(it)) }
+        }
+        return panel
+    }
+
+    private fun parseOutput(output: String): SearchContent? {
+        val trimmed = output.trim()
+        if (trimmed.isEmpty()) return null
+
+        parseJson(trimmed)?.let { return it }
+        return SearchContent(null, emptyList(), trimmed)
+    }
+
+    private fun parseJson(raw: String): SearchContent? {
+        return try {
+            val root = JsonParser.parseString(raw)
+            when {
+                root.isJsonArray -> SearchContent(null, parseResults(root.asJsonArray), null)
+                root.isJsonObject -> {
+                    val obj = root.asJsonObject
+                    val query = firstString(obj, "query", "search", "prompt")
+                    val results = parseResults(firstArray(obj, "results", "items", "entries"))
+                    if (results.isEmpty()) null else SearchContent(query, results, null)
+                }
+
+                else -> null
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun buildResultsMarkdown(results: List<SearchResult>): String {
+        return results.joinToString("\n\n") { result ->
+            buildString {
+                append("- ")
+                if (!result.url.isNullOrBlank()) {
+                    append("[").append(result.title).append("](").append(result.url).append(")")
+                } else {
+                    append(result.title)
+                }
+                result.snippet?.takeIf { it.isNotBlank() }?.let {
+                    append("\n  ").append(it.trim())
+                }
+            }
+        }
+    }
+
+    private fun parseResults(resultsArray: JsonArray?): List<SearchResult> {
+        if (resultsArray == null) return emptyList()
+        return resultsArray.mapNotNull { element ->
+            val obj = element.takeIf { it.isJsonObject }?.asJsonObject ?: return@mapNotNull null
+            val title = firstString(obj, "title", "name", "label") ?: return@mapNotNull null
+            val url = firstString(obj, "url", "link")
+            val snippet = firstString(obj, "snippet", "description", "content", "text")
+            SearchResult(title, url, snippet)
+        }
+    }
+
+    private fun firstArray(obj: JsonObject, vararg keys: String): JsonArray? {
+        for (key in keys) {
+            val element = obj.get(key) ?: continue
+            if (element.isJsonArray) return element.asJsonArray
+        }
+        return null
+    }
+
+    private fun firstString(obj: JsonObject, vararg keys: String): String? {
+        for (key in keys) {
+            val element = obj.get(key) ?: continue
+            val value = elementToText(element)
+            if (!value.isNullOrBlank()) return value
+        }
+        return null
+    }
+
+    private fun elementToText(element: JsonElement): String? = when {
+        element.isJsonNull -> null
+        element.isJsonPrimitive -> element.asString
+        else -> element.toString()
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/WebSearchRenderer.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/renderers/WebSearchRenderer.kt
@@ -4,6 +4,10 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import com.intellij.ide.BrowserUtil
+import com.intellij.ui.HyperlinkLabel
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.JBUI
 import javax.swing.JComponent
 
 object WebSearchRenderer : ToolResultRenderer {
@@ -21,7 +25,12 @@ object WebSearchRenderer : ToolResultRenderer {
                 row.add(ToolRenderers.monoLabel(it))
                 panel.add(row)
             }
-            panel.add(HtmlToolRendererSupport.markdownPane(buildResultsMarkdown(parsed.results)))
+            val displayResults = parsed.results.take(ToolRenderers.MAX_LIST_ENTRIES)
+            displayResults.forEach { panel.add(renderResultSection(it)) }
+            val remaining = parsed.results.size - displayResults.size
+            if (remaining > 0) {
+                ToolRenderers.addTruncationIndicator(panel, remaining, "results")
+            }
         } else {
             panel.add(ToolRenderers.statusHeader(ToolIcons.SEARCH, "Web Search", ToolRenderers.INFO_COLOR))
             parsed.fallbackBody?.takeIf { it.isNotBlank() }?.let { panel.add(HtmlToolRendererSupport.markdownPane(it)) }
@@ -45,7 +54,7 @@ object WebSearchRenderer : ToolResultRenderer {
                 root.isJsonObject -> {
                     val obj = root.asJsonObject
                     val query = firstString(obj, "query", "search", "prompt")
-                    val results = parseResults(firstArray(obj, "results", "items", "entries"))
+                    val results = parseResults(extractResultsArray(obj))
                     if (results.isEmpty()) null else SearchContent(query, results, null)
                 }
 
@@ -56,20 +65,41 @@ object WebSearchRenderer : ToolResultRenderer {
         }
     }
 
-    private fun buildResultsMarkdown(results: List<SearchResult>): String {
-        return results.joinToString("\n\n") { result ->
-            buildString {
-                append("- ")
-                if (!result.url.isNullOrBlank()) {
-                    append("[").append(result.title).append("](").append(result.url).append(")")
-                } else {
-                    append(result.title)
-                }
-                result.snippet?.takeIf { it.isNotBlank() }?.let {
-                    append("\n  ").append(it.trim())
-                }
-            }
+    private fun renderResultSection(result: SearchResult): JComponent {
+        val section = ToolRenderers.listPanel().apply {
+            border = JBUI.Borders.emptyTop(4)
+            alignmentX = JComponent.LEFT_ALIGNMENT
         }
+        val row = ToolRenderers.rowPanel()
+        val normalizedTitle = normalizeInlineText(result.title)
+        val normalizedUrl = result.url?.let(::normalizeInlineText)
+        if (!normalizedUrl.isNullOrBlank()) {
+            row.add(HyperlinkLabel(normalizedTitle).apply {
+                addHyperlinkListener { BrowserUtil.browse(normalizedUrl) }
+            })
+            row.add(ToolRenderers.mutedLabel(normalizedUrl))
+        } else {
+            row.add(JBLabel(normalizedTitle))
+        }
+        section.add(row)
+
+        result.snippet
+            ?.let(::normalizeInlineText)
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { snippet ->
+                section.add(ToolRenderers.mutedLabel(snippet).apply {
+                    alignmentX = JComponent.LEFT_ALIGNMENT
+                    border = JBUI.Borders.emptyLeft(8)
+                })
+            }
+        return section
+    }
+
+    private fun normalizeInlineText(value: String): String {
+        return value.lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .joinToString(" ")
     }
 
     private fun parseResults(resultsArray: JsonArray?): List<SearchResult> {
@@ -83,12 +113,12 @@ object WebSearchRenderer : ToolResultRenderer {
         }
     }
 
-    private fun firstArray(obj: JsonObject, vararg keys: String): JsonArray? {
-        for (key in keys) {
-            val element = obj.get(key) ?: continue
-            if (element.isJsonArray) return element.asJsonArray
-        }
-        return null
+    private fun extractResultsArray(obj: JsonObject): JsonArray? {
+        return listOf("results", "items", "entries")
+            .asSequence()
+            .mapNotNull(obj::get)
+            .firstOrNull { it.isJsonArray }
+            ?.asJsonArray
     }
 
     private fun firstString(obj: JsonObject, vararg keys: String): String? {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClientBehaviorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClientBehaviorTest.java
@@ -28,22 +28,19 @@ class OpenCodeClientBehaviorTest {
     Path tempDir;
 
     @Test
-    void buildPermissionConfigOmitsDefaultAgentWhenNullOrBlank() {
-        JsonObject nullConfig = GSON.fromJson(
-            OpenCodeClient.buildPermissionConfig(null).get("OPENCODE_CONFIG_CONTENT"),
-            JsonObject.class
-        );
-        JsonObject blankConfig = GSON.fromJson(
-            OpenCodeClient.buildPermissionConfig("   ").get("OPENCODE_CONFIG_CONTENT"),
+    void buildPermissionConfigNeverIncludesDefaultAgent() {
+        // default_agent is intentionally omitted because OpenCode v1.4.10+ rejects
+        // subagent slugs (like "build") as the default_agent value.
+        JsonObject config = GSON.fromJson(
+            OpenCodeClient.buildPermissionConfig().get("OPENCODE_CONFIG_CONTENT"),
             JsonObject.class
         );
 
-        assertFalse(nullConfig.has("default_agent"));
-        assertFalse(blankConfig.has("default_agent"));
+        assertFalse(config.has("default_agent"));
     }
 
     @Test
-    void buildEnvironmentUsesSelectedPlanAgent() throws Exception {
+    void buildEnvironmentNeverIncludesDefaultAgent() throws Exception {
         OpenCodeClient client = new OpenCodeClient(mock(Project.class));
         client.setCurrentAgentSlug("plan");
 
@@ -52,20 +49,26 @@ class OpenCodeClientBehaviorTest {
             JsonObject.class
         );
 
-        assertEquals("plan", config.get("default_agent").getAsString());
+        // Even with a specific agent selected, OPENCODE_CONFIG_CONTENT should not
+        // include default_agent — the plugin controls agent selection via session/create.
+        assertFalse(config.has("default_agent"));
     }
 
     @Test
-    void buildEnvironmentFallsBackToBuildForNonPlanSelection() throws Exception {
+    void buildEnvironmentContainsPermissionDenyEntries() throws Exception {
         OpenCodeClient client = new OpenCodeClient(mock(Project.class));
-        client.setCurrentAgentSlug("custom-agent");
 
         JsonObject config = GSON.fromJson(
             invokeBuildEnvironment(client).get("OPENCODE_CONFIG_CONTENT"),
             JsonObject.class
         );
 
-        assertEquals("build", config.get("default_agent").getAsString());
+        assertTrue(config.has("permission"));
+        JsonObject permission = config.getAsJsonObject("permission");
+        for (String tool : OpenCodeClient.nativeToolsToDeny()) {
+            assertTrue(permission.has(tool), "Missing tool: " + tool);
+            assertEquals("deny", permission.get(tool).getAsString());
+        }
     }
 
     @Test

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClientBehaviorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClientBehaviorTest.java
@@ -1,0 +1,116 @@
+package com.github.catatafishen.agentbridge.acp.client;
+
+import com.github.catatafishen.agentbridge.agent.AbstractAgentClient;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.project.Project;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OpenCodeClientBehaviorTest {
+
+    private static final Gson GSON = new Gson();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void buildPermissionConfigOmitsDefaultAgentWhenNullOrBlank() {
+        JsonObject nullConfig = GSON.fromJson(
+            OpenCodeClient.buildPermissionConfig(null).get("OPENCODE_CONFIG_CONTENT"),
+            JsonObject.class
+        );
+        JsonObject blankConfig = GSON.fromJson(
+            OpenCodeClient.buildPermissionConfig("   ").get("OPENCODE_CONFIG_CONTENT"),
+            JsonObject.class
+        );
+
+        assertFalse(nullConfig.has("default_agent"));
+        assertFalse(blankConfig.has("default_agent"));
+    }
+
+    @Test
+    void buildEnvironmentUsesSelectedPlanAgent() throws Exception {
+        OpenCodeClient client = new OpenCodeClient(mock(Project.class));
+        client.setCurrentAgentSlug("plan");
+
+        JsonObject config = GSON.fromJson(
+            invokeBuildEnvironment(client).get("OPENCODE_CONFIG_CONTENT"),
+            JsonObject.class
+        );
+
+        assertEquals("plan", config.get("default_agent").getAsString());
+    }
+
+    @Test
+    void buildEnvironmentFallsBackToBuildForNonPlanSelection() throws Exception {
+        OpenCodeClient client = new OpenCodeClient(mock(Project.class));
+        client.setCurrentAgentSlug("custom-agent");
+
+        JsonObject config = GSON.fromJson(
+            invokeBuildEnvironment(client).get("OPENCODE_CONFIG_CONTENT"),
+            JsonObject.class
+        );
+
+        assertEquals("build", config.get("default_agent").getAsString());
+    }
+
+    @Test
+    void getAvailableAgentsIncludesProjectAgentsWithoutShadowingBuiltIns() throws Exception {
+        Project project = mock(Project.class);
+        when(project.getBasePath()).thenReturn(tempDir.toString());
+
+        Files.createDirectories(tempDir.resolve(".opencode/agent"));
+        Files.createDirectories(tempDir.resolve(".opencode/agents"));
+        Files.writeString(
+            tempDir.resolve(".opencode/agent/shared.md"),
+            "---\nname: Shared Primary\ndescription: First\n---\n",
+            StandardCharsets.UTF_8
+        );
+        Files.writeString(
+            tempDir.resolve(".opencode/agents/shared.md"),
+            "---\nname: Shared Secondary\ndescription: Second\n---\n",
+            StandardCharsets.UTF_8
+        );
+        Files.writeString(
+            tempDir.resolve(".opencode/agents/local.md"),
+            "---\nname: Local Agent\ndescription: Local description\n---\n",
+            StandardCharsets.UTF_8
+        );
+        Files.writeString(
+            tempDir.resolve(".opencode/agents/build.md"),
+            "---\nname: Shadow Build\n---\n",
+            StandardCharsets.UTF_8
+        );
+
+        OpenCodeClient client = new OpenCodeClient(project);
+        List<AbstractAgentClient.AgentMode> agents = client.getAvailableAgents();
+
+        assertEquals(
+            List.of("build", "plan", "general", "explore", "shared", "local"),
+            agents.stream().map(AbstractAgentClient.AgentMode::slug).toList()
+        );
+        assertEquals("Shared Primary", agents.get(4).name());
+        assertTrue(agents.stream().noneMatch(agent -> "Shadow Build".equals(agent.name())));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> invokeBuildEnvironment(OpenCodeClient client) throws Exception {
+        Method method = OpenCodeClient.class.getDeclaredMethod("buildEnvironment", int.class, String.class);
+        method.setAccessible(true);
+        return (Map<String, String>) method.invoke(client, 8123, tempDir.toString());
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClientStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClientStaticMethodsTest.java
@@ -9,7 +9,11 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for the package-private static helpers in {@link OpenCodeClient}.
@@ -112,7 +116,35 @@ class OpenCodeClientStaticMethodsTest {
         @Test
         @DisplayName("native tools list has 8 entries")
         void nativeToolsCount() {
-            assertEquals(8, OpenCodeClient.nativeToolsToDeny().size());
+            assertEquals(14, OpenCodeClient.nativeToolsToDeny().size());
+        }
+
+        @Test
+        @DisplayName("config defaults to the native build agent")
+        void defaultAgentIsBuild() {
+            Map<String, String> result = OpenCodeClient.buildPermissionConfig();
+            JsonObject config = new Gson().fromJson(result.get("OPENCODE_CONFIG_CONTENT"), JsonObject.class);
+
+            assertEquals("build", config.get("default_agent").getAsString());
+        }
+    }
+
+    @Nested
+    @DisplayName("builtInAgents")
+    class BuiltInAgents {
+
+        @Test
+        @DisplayName("returns OpenCode's 4 native agents in display order")
+        void returnsNativeAgents() {
+            var agents = OpenCodeClient.builtInAgents();
+
+            assertEquals(4, agents.size());
+            assertEquals("build", agents.get(0).slug());
+            assertEquals("plan", agents.get(1).slug());
+            assertEquals("general", agents.get(2).slug());
+            assertEquals("explore", agents.get(3).slug());
+            assertEquals("Build", agents.get(0).name());
+            assertEquals("Plan", agents.get(1).name());
         }
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClientStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/OpenCodeClientStaticMethodsTest.java
@@ -120,12 +120,13 @@ class OpenCodeClientStaticMethodsTest {
         }
 
         @Test
-        @DisplayName("config defaults to the native build agent")
-        void defaultAgentIsBuild() {
+        @DisplayName("config does NOT include default_agent (rejected by OpenCode v1.4.10+)")
+        void noDefaultAgent() {
             Map<String, String> result = OpenCodeClient.buildPermissionConfig();
             JsonObject config = new Gson().fromJson(result.get("OPENCODE_CONFIG_CONTENT"), JsonObject.class);
 
-            assertEquals("build", config.get("default_agent").getAsString());
+            assertFalse(config.has("default_agent"),
+                "default_agent must not be set — OpenCode v1.4.10+ rejects subagent slugs");
         }
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/ProjectAgentScannerDirectoryScanTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/ProjectAgentScannerDirectoryScanTest.java
@@ -1,0 +1,56 @@
+package com.github.catatafishen.agentbridge.acp.client;
+
+import com.github.catatafishen.agentbridge.agent.AbstractAgentClient.AgentMode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ProjectAgentScannerDirectoryScanTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void scanAgentDirectoriesPrefersEarlierDirsAndExcludesBuiltIns() throws Exception {
+        Files.createDirectories(tempDir.resolve("custom-primary"));
+        Files.createDirectories(tempDir.resolve("custom-secondary"));
+        Files.writeString(
+            tempDir.resolve("custom-primary/shared.md"),
+            "---\nname: Primary\n---\n",
+            StandardCharsets.UTF_8
+        );
+        Files.writeString(
+            tempDir.resolve("custom-secondary/shared.md"),
+            "---\nname: Secondary\n---\n",
+            StandardCharsets.UTF_8
+        );
+        Files.writeString(
+            tempDir.resolve("custom-secondary/extra.md"),
+            "plain markdown agent",
+            StandardCharsets.UTF_8
+        );
+        Files.writeString(
+            tempDir.resolve("custom-secondary/build.md"),
+            "---\nname: Build Shadow\n---\n",
+            StandardCharsets.UTF_8
+        );
+
+        List<AgentMode> agents = ProjectAgentScanner.scanAgentDirectories(
+            tempDir,
+            Set.of("build"),
+            "custom-primary",
+            "custom-secondary"
+        );
+
+        assertEquals(List.of("shared", "extra"), agents.stream().map(AgentMode::slug).toList());
+        assertEquals("Primary", agents.get(0).name());
+        assertEquals("extra", agents.get(1).name());
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/MarkdownRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/MarkdownRendererTest.java
@@ -1268,6 +1268,54 @@ class MarkdownRendererTest {
         }
     }
 
+    @Nested
+    class XmlTagPreprocessing {
+        @Test
+        void thinkTagRendersAsThinkingBlock() {
+            String html = render("Before\n<think>Step 1\nStep 2</think>\nAfter");
+            assertTrue(html.contains("<thinking-block><div class=\"thinking-content\">Step 1<br>Step 2</div></thinking-block>"), html);
+            assertTrue(html.contains("<p>Before</p>"), html);
+            assertTrue(html.contains("<p>After</p>"), html);
+        }
+
+        @Test
+        void thinkingTagRendersAsThinkingBlock() {
+            String html = render("<thinking>Reasoning</thinking>");
+            assertTrue(html.contains("<thinking-block><div class=\"thinking-content\">Reasoning</div></thinking-block>"), html);
+        }
+
+        @Test
+        void unclosedThinkTagFallsBackToEscapedText() {
+            String html = render("<think>\nunfinished");
+            assertTrue(html.contains("&lt;think&gt;"), html);
+            assertFalse(html.contains("<thinking-block>"), html);
+        }
+
+        @Test
+        void wrapperTagsAreStrippedFromStandaloneLines() {
+            String html = render(String.join("\n",
+                "<task_result>",
+                "<commentary>",
+                "Result body",
+                "</commentary>",
+                "</task_result>",
+                "<example>",
+                "Example body",
+                "</example>",
+                "<code>",
+                "Code wrapper body",
+                "</code>"
+            ));
+            assertFalse(html.contains("task_result"), html);
+            assertFalse(html.contains("commentary"), html);
+            assertFalse(html.contains("example"), html);
+            assertFalse(html.contains("&lt;code&gt;"), html);
+            assertTrue(html.contains("<p>Result body</p>"), html);
+            assertTrue(html.contains("<p>Example body</p>"), html);
+            assertTrue(html.contains("<p>Code wrapper body</p>"), html);
+        }
+    }
+
     // ── Utility ─────────────────────────────────────────────────────────
 
     private static int countOccurrences(String str, String sub) {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/MarkdownRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/MarkdownRendererTest.java
@@ -1314,6 +1314,37 @@ class MarkdownRendererTest {
             assertTrue(html.contains("<p>Example body</p>"), html);
             assertTrue(html.contains("<p>Code wrapper body</p>"), html);
         }
+
+        @Test
+        void thinkTagInsideFencedCodeIsPreserved() {
+            String html = render(String.join("\n",
+                "```md",
+                "<think>Reasoning</think>",
+                "<task_result>",
+                "```"
+            ));
+            assertTrue(html.contains("&lt;think&gt;Reasoning&lt;/think&gt;"), html);
+            assertTrue(html.contains("&lt;task_result&gt;"), html);
+            assertFalse(html.contains("<thinking-block>"), html);
+        }
+
+        @Test
+        void tagsInsideImplicitCodeArePreserved() {
+            String html = render(String.join("\n",
+                "// start",
+                "<think>Reasoning</think>",
+                "<task_result>"
+            ));
+            assertTrue(html.contains("&lt;think&gt;Reasoning&lt;/think&gt;"), html);
+            assertTrue(html.contains("&lt;task_result&gt;"), html);
+            assertFalse(html.contains("<thinking-block>"), html);
+        }
+
+        @Test
+        void emptyThinkTagUsesFallbackText() {
+            String html = render("<think>\r\n\r\n</think>");
+            assertTrue(html.contains("No reasoning returned"), html);
+        }
     }
 
     // ── Utility ─────────────────────────────────────────────────────────

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/HtmlToolRendererSupportTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/HtmlToolRendererSupportTest.java
@@ -1,0 +1,88 @@
+package com.github.catatafishen.agentbridge.ui.renderers;
+
+import org.junit.jupiter.api.Test;
+
+import javax.swing.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HtmlToolRendererSupportTest {
+
+    @Test
+    void markdownPaneReturnsNonEditableJEditorPane() {
+        JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane("Hello **world**");
+
+        assertNotNull(pane);
+        assertInstanceOf(JEditorPane.class, pane);
+        JEditorPane editorPane = (JEditorPane) pane;
+        assertFalse(editorPane.isEditable());
+        assertEquals("text/html", editorPane.getContentType());
+    }
+
+    @Test
+    void markdownPaneRendersBold() {
+        JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane("**bold**");
+
+        JEditorPane editorPane = (JEditorPane) pane;
+        String html = editorPane.getText();
+        assertTrue(html.contains("<b>bold</b>"), html);
+    }
+
+    @Test
+    void markdownPaneRendersParagraphText() {
+        JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane("plain text");
+
+        JEditorPane editorPane = (JEditorPane) pane;
+        String html = editorPane.getText();
+        // JEditorPane adds whitespace; just check the text content is present
+        assertTrue(html.contains("plain text"), html);
+    }
+
+    @Test
+    void markdownPaneRendersListItemContent() {
+        JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane("- item1\n- item2");
+
+        JEditorPane editorPane = (JEditorPane) pane;
+        String html = editorPane.getText();
+        assertTrue(html.contains("item1"), html);
+        assertTrue(html.contains("item2"), html);
+    }
+
+    @Test
+    void markdownPaneAppliesFontFamily() {
+        JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane("text");
+
+        JEditorPane editorPane = (JEditorPane) pane;
+        String html = editorPane.getText();
+        assertTrue(html.contains("font-family:"), html);
+    }
+
+    @Test
+    void markdownPaneIsEmptyForEmptyInput() {
+        JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane("");
+
+        assertNotNull(pane);
+    }
+
+    @Test
+    void markdownPaneRendersCode() {
+        JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane("Use `println()`");
+
+        JEditorPane editorPane = (JEditorPane) pane;
+        String html = editorPane.getText();
+        assertTrue(html.contains("<code>println()</code>"), html);
+    }
+
+    @Test
+    void markdownPaneRendersLinkHref() {
+        JComponent pane = HtmlToolRendererSupport.INSTANCE.markdownPane("[click](https://example.com)");
+
+        JEditorPane editorPane = (JEditorPane) pane;
+        String html = editorPane.getText();
+        assertTrue(html.contains("https://example.com"), html);
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/TaskToolRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/TaskToolRendererTest.java
@@ -11,6 +11,33 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class TaskToolRendererTest {
 
     @Test
+    void parseTaskOutputReturnsEmptyForEmptyInput() {
+        TaskToolRenderer.ParsedTaskResult parsed = TaskToolRenderer.INSTANCE.parseTaskOutput("");
+        assertNull(parsed.getTaskId());
+        assertEquals("", parsed.getContent());
+    }
+
+    @Test
+    void parseTaskOutputReturnsOriginalForContentWithOnlyWrapperLines() {
+        // If content becomes blank after stripping wrappers, falls back to original trimmed input
+        String raw = "<task_result>\n</task_result>";
+        TaskToolRenderer.ParsedTaskResult parsed = TaskToolRenderer.INSTANCE.parseTaskOutput(raw);
+        // Content is blank after stripping, so falls back
+        assertNotNull(parsed);
+    }
+
+    @Test
+    void parseTaskOutputStripsOnlyWrapperLinesNotInlineOccurrences() {
+        // Inline <task_result> that's NOT on its own line should be preserved
+        TaskToolRenderer.ParsedTaskResult parsed =
+            TaskToolRenderer.INSTANCE.parseTaskOutput("The tag <task_result> appears inline </task_result> in text");
+
+        assertNull(parsed.getTaskId());
+        assertTrue(parsed.getContent().contains("<task_result>"), parsed.getContent());
+        assertTrue(parsed.getContent().contains("</task_result>"), parsed.getContent());
+    }
+
+    @Test
     void parseTaskOutputExtractsTaskIdAndStripsWrapper() {
         String raw = """
             task_id: session-123 (for resuming to continue this task if needed)

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/TaskToolRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/TaskToolRendererTest.java
@@ -1,0 +1,46 @@
+package com.github.catatafishen.agentbridge.ui.renderers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TaskToolRendererTest {
+
+    @Test
+    void parseTaskOutputExtractsTaskIdAndStripsWrapper() {
+        String raw = """
+            task_id: session-123 (for resuming to continue this task if needed)
+
+            <task_result>
+            ## Result
+
+            - item
+            </task_result>
+            """;
+
+        TaskToolRenderer.ParsedTaskResult parsed = TaskToolRenderer.INSTANCE.parseTaskOutput(raw);
+
+        assertEquals("session-123", parsed.getTaskId());
+        assertTrue(parsed.getContent().contains("## Result"), parsed.getContent());
+        assertFalse(parsed.getContent().contains("<task_result>"), parsed.getContent());
+        assertFalse(parsed.getContent().contains("</task_result>"), parsed.getContent());
+    }
+
+    @Test
+    void parseTaskOutputKeepsPlainContent() {
+        TaskToolRenderer.ParsedTaskResult parsed =
+            TaskToolRenderer.INSTANCE.parseTaskOutput("plain subagent output");
+
+        assertNull(parsed.getTaskId());
+        assertEquals("plain subagent output", parsed.getContent());
+    }
+
+    @Test
+    void renderReturnsPanelForTaskOutput() {
+        assertNotNull(TaskToolRenderer.INSTANCE.render("<task_result>hello</task_result>"));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/TaskToolRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/TaskToolRendererTest.java
@@ -40,6 +40,15 @@ class TaskToolRendererTest {
     }
 
     @Test
+    void parseTaskOutputPreservesInlineTaskResultText() {
+        TaskToolRenderer.ParsedTaskResult parsed =
+            TaskToolRenderer.INSTANCE.parseTaskOutput("literal <task_result>text</task_result> body");
+
+        assertNull(parsed.getTaskId());
+        assertEquals("literal <task_result>text</task_result> body", parsed.getContent());
+    }
+
+    @Test
     void renderReturnsPanelForTaskOutput() {
         assertNotNull(TaskToolRenderer.INSTANCE.render("<task_result>hello</task_result>"));
     }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/ToolResultRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/ToolResultRendererTest.java
@@ -3,9 +3,11 @@ package com.github.catatafishen.agentbridge.ui.renderers;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.awt.Color;
+import java.awt.*;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for static/pure utility methods in {@link ToolRenderers}.
@@ -173,6 +175,41 @@ class ToolResultRendererTest {
         @Test
         void todoWriteCapitalizedHasRenderer() {
             assertTrue(ToolRenderers.INSTANCE.hasRenderer("TodoWrite", null));
+        }
+
+        @Test
+        void taskHasRenderer() {
+            assertTrue(ToolRenderers.INSTANCE.hasRenderer("task", null));
+        }
+
+        @Test
+        void bashHasRenderer() {
+            assertTrue(ToolRenderers.INSTANCE.hasRenderer("bash", null));
+        }
+
+        @Test
+        void listHasRenderer() {
+            assertTrue(ToolRenderers.INSTANCE.hasRenderer("list", null));
+        }
+
+        @Test
+        void lsHasRenderer() {
+            assertTrue(ToolRenderers.INSTANCE.hasRenderer("ls", null));
+        }
+
+        @Test
+        void patchHasRenderer() {
+            assertTrue(ToolRenderers.INSTANCE.hasRenderer("patch", null));
+        }
+
+        @Test
+        void webFetchHasRenderer() {
+            assertTrue(ToolRenderers.INSTANCE.hasRenderer("webfetch", null));
+        }
+
+        @Test
+        void webSearchHasRenderer() {
+            assertTrue(ToolRenderers.INSTANCE.hasRenderer("websearch", null));
         }
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/WebFetchRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/WebFetchRendererTest.java
@@ -1,0 +1,31 @@
+package com.github.catatafishen.agentbridge.ui.renderers;
+
+import org.junit.jupiter.api.Test;
+
+import javax.swing.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WebFetchRendererTest {
+
+    @Test
+    void renderOmitsHeaderLinesFromBodyWithoutBlankSeparator() {
+        JPanel panel = (JPanel) WebFetchRenderer.INSTANCE.render("""
+            URL: https://example.com
+            Status: 200 OK
+            # Body
+            """);
+
+        assertNotNull(panel);
+        assertEquals(3, panel.getComponentCount());
+
+        JEditorPane bodyPane = (JEditorPane) panel.getComponent(2);
+        String html = bodyPane.getText();
+        assertFalse(html.contains("URL:"), html);
+        assertFalse(html.contains("Status:"), html);
+        assertTrue(html.contains("Body"), html);
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/WebSearchRendererTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/renderers/WebSearchRendererTest.java
@@ -1,0 +1,32 @@
+package com.github.catatafishen.agentbridge.ui.renderers;
+
+import org.junit.jupiter.api.Test;
+
+import javax.swing.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class WebSearchRendererTest {
+
+    @Test
+    void renderNormalizesStructuredResults() throws Exception {
+        JPanel panel = (JPanel) WebSearchRenderer.INSTANCE.render(
+            "{\"query\":\"find things\",\"results\":[{\"title\":\"Title ] name\",\"url\":\"https://example.com/path(with)\",\"snippet\":\"Line 1\\nLine 2\"}]}"
+        );
+
+        assertNotNull(panel);
+        assertEquals(3, panel.getComponentCount());
+
+        JPanel section = (JPanel) panel.getComponent(2);
+        JPanel row = (JPanel) section.getComponent(0);
+        Object titleComponent = row.getComponent(0);
+        JLabel urlLabel = (JLabel) row.getComponent(1);
+        JLabel snippetLabel = (JLabel) section.getComponent(1);
+
+        assertEquals("HyperlinkLabel", titleComponent.getClass().getSimpleName());
+        assertEquals("Title ] name", titleComponent.getClass().getMethod("getText").invoke(titleComponent));
+        assertEquals("https://example.com/path(with)", urlLabel.getText());
+        assertEquals("Line 1 Line 2", snippetLabel.getText());
+    }
+}


### PR DESCRIPTION
Closing feature parity gap with opencode.


Introduce XML-style preprocessing for markdown to render <think>/<thinking> as <thinking-block> and strip standalone wrapper tags (chat-ui TS, MarkdownRenderer Kotlin), including unit tests. Extend OpenCode client with built-in agent modes, project agent directory scanning, and default_agent support in OPENCODE_CONFIG_CONTENT, and expand the native tools deny list. Add UI helpers and new tool renderers (HtmlToolRendererSupport, TaskToolRenderer, WebFetchRenderer, WebSearchRenderer), wire them into ToolRenderers and update ChatToolWindowContent to show labeled project agent/skill/command sections. Update and add tests to cover the new behaviors.