### PR TITLE
fix: address remaining PR #240 review comments

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
@@ -556,9 +556,16 @@ public final class AgentEditSession implements Disposable {
             () -> doc.setText(before));
         FileDocumentManager.getInstance().saveDocument(doc);
 
+        // Mirror acceptFile()/rejectFile(): clear highlights, refresh banner, and update review state
+        // so the file no longer shows up in the Review panel and any blocked git gate can proceed.
+        AgentEditHighlighter.getInstance(project).clearForFile(vf);
+        com.intellij.ui.EditorNotifications.getInstance(project).updateNotifications(vf);
+
         if (reason != null && !reason.isBlank()) {
             sendRevertNudge(vf, reason);
         }
+        fireReviewStateChanged();
+        completeReviewIfEmpty();
     }
 
     public synchronized void endSession() {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyQuickfixTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyQuickfixTool.java
@@ -129,18 +129,24 @@ public final class ApplyQuickfixTool extends QualityTool {
                     return;
                 }
 
-                // Write phase: only the actual fix application needs WriteAction
+                // Write phase: only the actual fix application needs WriteAction.
+                // notifyEditComplete() must run even if WriteAction.run itself throws before
+                // invoking the lambda, otherwise the ThreadLocal agent-edit marker leaks across
+                // tool calls. Wrap the whole WriteAction.run() in try/finally (matches the
+                // pattern used in ApplyActionTool / SuppressInspectionTool / WriteFileTool).
                 FileTool.notifyBeforeEdit(project, vf, document);
-                WriteAction.run(() -> {
-                    try {
-                        resultFuture.complete(applyAndReportFix(lineProblems, fixIndex, pathStr, targetLine));
-                    } catch (Exception e) {
-                        LOG.warn("Error applying quickfix", e);
-                        resultFuture.complete("Error applying quickfix: " + e.getMessage());
-                    } finally {
-                        FileTool.notifyEditComplete();
-                    }
-                });
+                try {
+                    WriteAction.run(() -> {
+                        try {
+                            resultFuture.complete(applyAndReportFix(lineProblems, fixIndex, pathStr, targetLine));
+                        } catch (Exception e) {
+                            LOG.warn("Error applying quickfix", e);
+                            resultFuture.complete("Error applying quickfix: " + e.getMessage());
+                        }
+                    });
+                } finally {
+                    FileTool.notifyEditComplete();
+                }
             } catch (Exception e) {
                 LOG.warn("Error in applyQuickfix", e);
                 resultFuture.complete(ToolUtils.ERROR_PREFIX + e.getMessage());

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -42,7 +42,12 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
     // ── Data model (same types as V1 for serialization compat) ─────
     private val entries = mutableListOf<EntryData>()
 
-    /** Snapshot of the current entries list — safe to read from any thread as a defensive copy. */
+    /**
+     * Snapshot of the current entries list. Returns a defensive copy, but the copy operation
+     * itself iterates the underlying mutable list, so this method is **EDT-only** — calling it
+     * off the EDT can race with mutations and throw `ConcurrentModificationException`.
+     * Off-EDT callers must hop via `ApplicationManager.getApplication().invokeLater { ... }`.
+     */
     fun entriesSnapshot(): List<EntryData> = ArrayList(entries)
     private var currentTextData: EntryData.Text? = null
     private var currentThinkingData: EntryData.Thinking? = null

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
@@ -1,5 +1,6 @@
 package com.github.catatafishen.agentbridge.ui.side;
 
+import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileTypes.FileTypeManager;
@@ -180,19 +181,55 @@ final class ProjectFilesPanel extends JPanel {
         File file = new File(fn.base, fn.relativePath);
         if (!file.exists()) {
             if (!fn.createIfMissing) return;
-            try {
-                File parent = file.getParentFile();
-                if (parent != null) Files.createDirectories(parent.toPath());
-                Files.writeString(file.toPath(), "");
-            } catch (IOException ex) {
-                return;
-            }
+            VirtualFile created = createEmptyFile(file);
+            if (created == null) return;
+            FileEditorManager.getInstance(project).openFile(created, true);
+            refresh();
+            return;
         }
         VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
         if (vf != null) {
             FileEditorManager.getInstance(project).openFile(vf, true);
         }
         refresh();
+    }
+
+    /**
+     * Creates an empty file via VFS inside a {@link com.intellij.openapi.application.WriteAction},
+     * so VFS events (and the file-type/index pipeline) stay consistent. Surfaces an error notification
+     * if creation fails — silently swallowing here would make the click appear to do nothing.
+     */
+    private @org.jetbrains.annotations.Nullable VirtualFile createEmptyFile(@NotNull File file) {
+        File parent = file.getParentFile();
+        try {
+            if (parent != null) Files.createDirectories(parent.toPath());
+        } catch (IOException ex) {
+            notifyCreateFailure(file, ex);
+            return null;
+        }
+        VirtualFile parentVf = parent == null ? null
+            : LocalFileSystem.getInstance().refreshAndFindFileByIoFile(parent);
+        if (parentVf == null) {
+            notifyCreateFailure(file, new IOException("parent directory not visible to VFS"));
+            return null;
+        }
+        return com.intellij.openapi.application.WriteAction.compute(() -> {
+            try {
+                return parentVf.createChildData(this, file.getName());
+            } catch (IOException ex) {
+                notifyCreateFailure(file, ex);
+                return null;
+            }
+        });
+    }
+
+    private void notifyCreateFailure(@NotNull File file, @NotNull Throwable cause) {
+        String detail = cause.getMessage() == null ? cause.toString() : cause.getMessage();
+        PlatformApiCompat.showNotification(
+            project,
+            "Could not create " + file.getName(),
+            detail,
+            com.intellij.notification.NotificationType.ERROR);
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/PromptsPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/PromptsPanel.kt
@@ -6,7 +6,6 @@ import com.github.catatafishen.agentbridge.ui.side.PromptsPanel.Companion.MAX_CH
 import com.github.catatafishen.agentbridge.ui.side.PromptsPanel.Companion.MAX_ROWS
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.project.Project
 import com.intellij.ui.DocumentAdapter
 import com.intellij.ui.SearchTextField
 import com.intellij.ui.components.JBList
@@ -25,7 +24,6 @@ import javax.swing.*
 import javax.swing.event.DocumentEvent
 
 internal class PromptsPanel(
-    @Suppress("UNUSED_PARAMETER") project: Project,
     private val chatConsole: ChatConsolePanel
 ) : JPanel(BorderLayout()), Disposable {
 
@@ -70,6 +68,10 @@ internal class PromptsPanel(
             override fun mouseClicked(e: MouseEvent) {
                 val idx = promptList.locationToIndex(e.point)
                 if (idx < 0) return
+                // locationToIndex returns the nearest index even when clicking empty space below
+                // the last row — guard against that by verifying the click is inside the cell.
+                val cellBounds = promptList.getCellBounds(idx, idx) ?: return
+                if (!cellBounds.contains(e.point)) return
                 val item = listModel.getElementAt(idx) ?: return
                 val entryId = promptEntryId(item.prompt)
                 if (entryId.isNotEmpty()) chatConsole.scrollToEntry(entryId)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SidePanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SidePanel.java
@@ -34,7 +34,7 @@ public final class SidePanel extends JPanel implements Disposable {
         Disposer.register(this, reviewPanel);
 
         ProjectFilesPanel projectFilesPanel = new ProjectFilesPanel(project);
-        PromptsPanel promptsPanel = new PromptsPanel(project, chatConsole);
+        PromptsPanel promptsPanel = new PromptsPanel(chatConsole);
         Disposer.register(this, promptsPanel);
 
         tabsPanel = PlatformApiCompat.createJBTabsPanel(project, this);


### PR DESCRIPTION
PR #240 was merged into master via the sidebar/UI-improvements PR chain (all 14 of its commits are now on master, rebased with new SHAs), but six inline comments from the Copilot PR reviewer were never addressed before that merge. Rather than rebase the conflict-laden #240 branch, this PR applies the remaining fixes on top of current master.

## Audit of PR #240's 11 review comments vs current master

### Already fixed in master (no action needed)
- **#1** ReviewChangesPanel CardLayout
- **#3** PromptsPanel HTML→JTextArea
- **#6** \`.idea/mcpServer.xml\` is gitignored (line 13)
- **#9** McpServerSettings — outdated comment marker
- **#10** INLINE-DIFF-REVIEW.md status section

### Fixed in this PR
- **#2** \`AgentEditSession.revertFile()\` now mirrors \`acceptFile()\`/\`rejectFile()\`: clears highlights, refreshes editor banners, fires \`ReviewSessionTopic\`, and calls \`completeReviewIfEmpty()\` so a blocked git gate can proceed after a revert.
- **#4** \`PromptsPanel\`: dropped the unused \`project\` constructor parameter (and its \`@Suppress(\"UNUSED_PARAMETER\")\`); updated \`SidePanel\` call site.
- **#5** \`PromptsPanel\` mouse handler: \`locationToIndex\` returns the nearest index even when clicking empty space below the last row — guarded with \`getCellBounds(idx).contains(point)\` to prevent ghost-clicks.
- **#7** \`ProjectFilesPanel.activate()\`: replaced \`Files.writeString\` on EDT with VFS \`createChildData\` inside \`WriteAction.compute\`, and surface an error notification (via \`PlatformApiCompat\`) instead of silently swallowing \`IOException\`.
- **#8** \`ApplyQuickfixTool\`: wrapped the entire \`WriteAction.run(...)\` in try/finally so \`notifyEditComplete()\` always runs even if \`WriteAction.run\` throws before invoking the lambda — matches the pattern used in \`ApplyActionTool\` / \`SuppressInspectionTool\` / \`WriteFileTool\`.
- **#11** \`ChatConsolePanel.entriesSnapshot()\`: corrected the misleading \"safe from any thread\" comment — the defensive copy iterates the underlying non-synchronized list, so callers must be on the EDT.

## Verification
- \`build_project\`: 0 errors, 0 warnings
- \`*Review*\` tests: 11/11 passed
- \`*Prompt*\` tests: 210/210 passed

Once this is merged, PR #240 can be closed (its commits are already in master and all remaining unresolved review threads have been addressed here).