### PR TITLE
fix: qualify Gradle --tests filter with wildcard package prefix

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -290,26 +290,45 @@ Fine-grained control over what the agent can do.
 
 ## Diff Review for Agent Edits
 
-Opt-in safety net that turns every agent-originated file edit into a reviewable change.
+Always-on safety net that turns every agent-originated file edit into a reviewable change.
 See the full reference in [docs/INLINE-DIFF-REVIEW.md](docs/INLINE-DIFF-REVIEW.md).
 
+- **Always-on tracking** — every agent edit shows up as a row, no setup required. There is
+  no master "off" switch anymore; you choose between **manual approval** and **Auto-Approve**
+- **Auto-Approve toggle** — when enabled, new edits land as **APPROVED** automatically and
+  any existing pending rows are swept to APPROVED. Toggle it off to review every change
 - **Persistent diff highlights** — green (added), amber (modified), red (deleted) bands
   appear in the gutter and editor, powered by the same `RangeHighlighter` layer used by VCS
-- **Review tab** — side-panel list of every file with pending changes; per-row Open / Accept
-  / Revert plus toolbar-level Accept All and Reject All (with optional reason nudge)
+- **Review tab** — side-panel list of every file with `+N / −N` line counts, status icon,
+  and last-edited timestamp. Per-row Open / Accept / Revert; approved rows stay listed
+  (visually muted) until cleaned. Press `Delete` on an approved row to remove it
+- **Re-edit flips back to PENDING** — when Auto-Approve is off and the agent edits a file
+  that was already approved, the row flips back to PENDING and only the *new* hunks
+  remain highlighted (the snapshot is rebased onto the previously-approved content)
+- **Cleanup paths** — per-row `Delete`, toolbar **Clean Approved**, post-`git_commit` prune
+  (only files actually in the commit), branch-switch / reset-hard wipe, and an optional
+  toolbar toggle **Auto-Clean on New Prompt**
 - **Editor banner** — shows `Review: File 3/7 · 5 changes` with Show-diff, Accept,
-  Previous, Next, and Revert… actions; navigation works across all tracked files
+  Previous, Next, and Revert… actions; navigation works across all pending files
+- **Structured revert nudges** — reverting a file (from panel or banner) sends the agent a
+  nudge containing the relative path, line ranges, optional reason, and a unified diff of
+  the reverted hunks. When a git gate is currently blocking, the revert dialog offers
+  **Continue reviewing** (queues the nudge, keeps gating) or **Send to agent now**
+  (short-circuits the gate immediately so the agent can re-plan)
 - **Git gating** — `git_commit`, `git_merge`, `git_rebase`, `git_pull`, `git_reset --hard`,
   `git_stash pop/apply`, `git_branch create/switch`, `git_cherry_pick`, and `git_revert`
-  block (up to 10 minutes) until review is resolved, so the agent can't commit or rebase
-  over unreviewed changes
+  block (up to 10 minutes) until **pending** items are resolved. Approved rows are no-ops
+  for the gate
 - **Agent-only tracking** — a thread-local marker ensures user typing, manual reformats,
   and external edits are *not* captured; only edits made from inside tool calls become
   review items
 - **Worktree-safe** — snapshots are invalidated automatically on branch switch,
   `reset --hard`, rebase, and similar operations so stale baselines never linger
-- **Off by default** — toggle via Review panel toolbar or `Settings → Tools → AgentBridge →
-  Review agent edits`
+- **Persistence** — the review list (snapshots, approval state, timestamps, line counts) is
+  stored in the workspace file and survives IDE restarts
+- **Unhandled-nudge handling** — `Settings → Tools → AgentBridge → Chat input` lets you
+  choose whether unhandled nudges are *Auto-sent as a new prompt* (default) or
+  *Restored into the chat input* (prepended to whatever you were typing)
 
 ---
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -280,10 +280,12 @@ Fine-grained control over what the agent can do.
 
 - **Per-tool permissions** — Allow, Ask, or Deny for each of the 92 tools
 - **Three-way prompts** — Deny / Allow / Allow for Session
-- **Path-based rules** — Different permissions for project files vs. files outside the project
 - **Built-in edit interception** — Agent CLI file edits are redirected through IntelliJ's document API so every change
   is undoable
-- **Sub-agent write blocking** — Built-in write tools automatically denied for sub-agents
+- **Diff Review for agent edits** — every file the agent writes shows up in the Review panel with persistent
+  green/amber/red highlights; you can require manual approval, gate destructive git operations on pending review, and
+  send structured revert nudges back to the agent. See the [Diff Review for Agent Edits](#diff-review-for-agent-edits)
+  section below
 - **Settings panel** — Enable/disable individual tools and configure permissions visually
 
 ---

--- a/README.md
+++ b/README.md
@@ -73,10 +73,12 @@ dialog interaction, build/run output reading, user prompts.
 **Editor** — Open files, show diffs, scratch files, conversation history search, theme
 management.
 
-**Diff Review** *(opt-in)* — Review every agent edit before it lands. Persistent
-green/amber/red diff highlights, a Review panel with Accept / Revert per file,
-cross-file change navigation, and automatic gating of destructive git operations
-(commit, merge, rebase, reset --hard, …) until review is resolved. See
+**Diff Review** — Always-on tracker for every agent edit. Persistent green/amber/red
+diff highlights, a Review panel listing each file with `+N / −N` line counts and
+last-edited timestamps, optional **Auto-Approve** toggle, structured revert nudges
+(with diff body) sent back to the agent, and automatic gating of destructive git
+operations (commit, merge, rebase, reset --hard, …) until pending changes are
+resolved. The list survives IDE restarts. See
 [docs/INLINE-DIFF-REVIEW.md](docs/INLINE-DIFF-REVIEW.md).
 
 **Nudge system** — Send mid-turn guidance while the agent is working (Enter), force-stop

--- a/docs/INLINE-DIFF-REVIEW.md
+++ b/docs/INLINE-DIFF-REVIEW.md
@@ -1,15 +1,17 @@
 # Diff Review for Agent Edits
 
 > **Tracking issue**: [#232](https://github.com/catatafishen/agentbridge/issues/232)
-> **Status**: Implemented
+> **Status**: Implemented (v2 — always-on tracking)
 
 When an AI agent edits files, it's easy to lose track of what actually changed. Diff Review
 turns every agent-originated edit into a reviewable change — with persistent diff highlights
-in the editor, a per-file Review panel, one-click Accept / Revert, and automatic gating of
-destructive git operations until review is complete.
+in the editor, a per-file Review panel, one-click Accept / Revert, structured revert nudges
+sent back to the agent, and automatic gating of destructive git operations until pending
+review is resolved.
 
-The feature is **off by default** and is opt-in through the **Diff Review** toggle in the
-Review tool window's toolbar (or via `Settings → Tools → AgentBridge → Review agent edits`).
+The feature is **always on**. There is no master "off" switch — instead, an
+**Auto-Approve** toggle controls whether new edits land as `PENDING` (you'll review them)
+or as `APPROVED` (the agent moves on but every change still shows up in the panel).
 
 ---
 
@@ -18,25 +20,31 @@ Review tool window's toolbar (or via `Settings → Tools → AgentBridge → Rev
 1. [At a glance](#at-a-glance)
 2. [UI surfaces](#ui-surfaces)
 3. [Session lifecycle](#session-lifecycle)
-4. [Accept / Revert semantics](#accept--revert-semantics)
-5. [Git gating](#git-gating)
-6. [Settings](#settings)
-7. [Architecture](#architecture)
-8. [Edge cases](#edge-cases)
+4. [Auto-Approve semantics](#auto-approve-semantics)
+5. [Cleanup rules](#cleanup-rules)
+6. [Revert-as-nudge protocol](#revert-as-nudge-protocol)
+7. [Git gating](#git-gating)
+8. [Persistence](#persistence)
+9. [Settings reference](#settings-reference)
+10. [Architecture](#architecture)
+11. [Edge cases](#edge-cases)
 
 ---
 
 ## At a glance
 
-| Capability                   | Behaviour                                                                                                                                                                                   |
-|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **What triggers a review**   | The first agent-originated edit after Diff Review is enabled.                                                                                                                               |
-| **What's tracked**           | File *modifications*, *additions*, and *deletions* by agent tools.                                                                                                                          |
-| **What's ignored**           | User typing, branch switches, reformats not triggered by the agent.                                                                                                                         |
-| **Where changes show up**    | The **Review** tab in the AgentBridge tool window, a banner at the top of each edited editor, and persistent diff highlights (green / yellow / red) in the gutter.                          |
-| **How you respond**          | **Accept** (keep change), **Revert** (restore pre-edit content + optional nudge), or navigate next / previous. Bulk *Accept All* / *Reject All* from the toolbar.                           |
-| **When it blocks the agent** | Destructive git operations (commit, merge, rebase, reset --hard, pull, stash pop/apply, branch switch/create, revert, cherry-pick) block until all items are resolved (or 10 minutes pass). |
-| **When it ends**             | You explicitly end the session, disable Diff Review, or the worktree changes underneath it (e.g. external branch switch).                                                                   |
+| Capability                   | Behaviour                                                                                                                                                                               |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **What triggers a review**   | The first agent-originated edit after the project opens. There is no manual start.                                                                                                      |
+| **What's tracked**           | File *modifications*, *additions*, and *deletions* by agent tools.                                                                                                                      |
+| **What's ignored**           | User typing, branch switches, reformats not triggered by the agent.                                                                                                                     |
+| **Where changes show up**    | The **Review** tab in the AgentBridge tool window, a banner at the top of each edited editor, and persistent diff highlights (green / yellow / red) in the gutter.                      |
+| **Default approval state**   | `PENDING` (Auto-Approve off). Every new edit needs your decision before destructive git operations may proceed.                                                                         |
+| **Auto-Approve mode**        | When enabled, new edits land as `APPROVED`; existing pending rows are swept to `APPROVED`. The list still grows so you can audit later.                                                 |
+| **How you respond**          | **Accept** keeps the change (row flips to `APPROVED`, stays listed). **Revert** restores pre-edit content and sends a nudge back to the agent.                                          |
+| **When it blocks the agent** | Destructive git operations (commit, merge, rebase, reset --hard, pull, stash pop/apply, branch switch/create, revert, cherry-pick) block until **pending** items are resolved (10 min). |
+| **When approved rows leave** | Per-row `Delete`, toolbar *Clean Approved*, post-`git_commit` prune, worktree-changing git operations, optional *Auto-Clean on New Prompt*.                                             |
+| **Persistence**              | The whole list (snapshots, approval state, timestamps, line counts) is stored in `<project>/.idea/workspace.xml` and survives IDE restarts.                                             |
 
 ---
 
@@ -44,30 +52,40 @@ Review tool window's toolbar (or via `Settings → Tools → AgentBridge → Rev
 
 ### 1. Review tab (side panel)
 
-The **Review** tab in the AgentBridge tool window is the primary surface.
-It lists every file with pending changes as a row with:
+The **Review** tab in the AgentBridge tool window is the primary surface. It lists every
+tracked file as a row showing:
 
 - A **status icon** (Added, Modified, or Deleted).
+- **`+N / −N` line counts** computed against the captured before-content.
 - The file name, with the full project-relative path as a tooltip.
+- The **last-edited timestamp** (Today HH:mm / Yesterday HH:mm / MMM d / MMM d yyyy —
+  same formatter the Prompts tab uses).
 - Per-row buttons: **Open**, **Accept**, **Revert** — always visible, no hover reveal.
-- Clicking a row **selects** it and opens the file in an editor; opening a tracked file
-  another way (project view, Go To File, etc.) reverse-selects its row.
+- Approved rows are visually muted to distinguish them from `PENDING` rows.
+- Press **`Delete`** on an approved row to remove it from the list (the file on disk is
+  not touched).
 
-The toolbar at the bottom of the panel exposes:
+Clicking a row selects it and opens the file; opening a tracked file another way (project
+view, Go To File, …) reverse-selects its row.
 
-- **Diff Review toggle** — the on/off switch for the whole feature. Turning it off while
-  a session is active prompts for confirmation and discards the current review.
-- **Accept All** / **Reject All** — bulk actions. *Reject All* asks for a single reason
-  that is forwarded to the agent as a nudge.
-- **Stop/Play toggle** — ends or restarts the review session without disabling the feature.
+The toolbar exposes:
 
-When the panel is empty, it says either *"No agent edits to review"* (Diff Review on,
-nothing pending) or *"Diff Review is off."* (feature disabled).
+| Action                       | Behaviour                                                                            |
+|------------------------------|--------------------------------------------------------------------------------------|
+| **Auto-Approve**             | Toggle. When ON, new edits land as `APPROVED` and existing `PENDING` rows are swept. |
+| **Auto-Clean on New Prompt** | Toggle. When ON, the next user prompt clears all approved rows before being sent.    |
+| **Clean Approved**           | One-shot button. Removes every `APPROVED` row from the list.                         |
+
+> The old **Diff Review on/off**, **Accept All**, and **Reject All** toolbar actions are
+> gone. Auto-Approve replaces "Accept All" semantically; *Revert* per file replaces
+> "Reject All" with structured nudges.
+
+When the panel is empty it says *"No agent edits to review."*
 
 ### 2. Editor notification banner
 
-Every file with a pending review gets a sticky banner at the top of its editor
-(`AgentEditNotificationProvider`). The banner reads, for example:
+Every file with a pending review still gets a sticky banner at the top of its editor
+(`AgentEditNotificationProvider`):
 
 ```
 Review: File 3/7 · 5 changes
@@ -76,11 +94,13 @@ Review: File 3/7 · 5 changes
 
 - **Show diff** opens IntelliJ's diff viewer with the captured before-content on the left
   and the current document on the right.
-- **Accept** removes this file from tracking and clears its highlights.
-- **Previous** / **Next** navigate across all changes in all tracked files
+- **Accept** flips the row to `APPROVED` and clears the highlights for this file.
+- **Previous** / **Next** navigate across all changes in all pending files
   (`ChangeNavigator`), jumping between files when you reach the end of one.
-- **Revert…** opens a dialog that asks for an optional reason. If supplied, the reason is
-  sent to the agent as a nudge so the next turn can try a different approach.
+- **Revert…** opens the structured-nudge dialog (see
+  [Revert-as-nudge protocol](#revert-as-nudge-protocol)).
+
+The banner is hidden for `APPROVED` rows.
 
 ### 3. Persistent diff highlights
 
@@ -93,22 +113,21 @@ current document and attaches `RangeHighlighter`s at `HighlighterLayer.SELECTION
 | **Modified** lines                           | Amber/yellow background |
 | **Deleted** lines (marker on following line) | Red background          |
 
-User selection still paints on top of the highlights. Highlights update automatically when
-the document changes and are cleared when the file is accepted, reverted, or the session
-ends.
+Highlights are cleared for files in the `APPROVED` state and re-applied if a re-edit flips
+the file back to `PENDING` (see below).
 
 ---
 
 ## Session lifecycle
 
-### Automatic start
+### Always-on, no manual start
 
-There is **no explicit "start" button**. The first agent tool call that writes or creates a
-file (e.g., `write_file`, `edit_text`, `replace_symbol_body`, `create_file`) calls
-`AgentEditSession.ensureStarted()`. If `Review agent edits` is enabled in settings, the
-session transitions to *active*; otherwise the call is a no-op.
+`AgentEditSession` is a project-level service annotated with `@State` so it loads on
+project open. The first agent tool call that writes or creates a file (e.g.,
+`write_file`, `edit_text`, `replace_symbol_body`, `create_file`) calls
+`AgentEditSession.ensureStarted()`, which is a no-op now that the session is always live.
 
-When the session becomes active, it installs:
+When the project opens, the session installs:
 
 - A project-wide `DocumentListener` that snapshots the before-content of any file the agent
   is about to modify (filtered using a `ThreadLocal` marker — see *What counts as an agent
@@ -128,57 +147,129 @@ so the following are **not** tracked:
 - Branch switches, `git pull`, or any other VCS-level content changes.
 - Edits made from a terminal running outside a tool call.
 
-### Active state
+### What ends a review row
 
-While active:
+A row leaves the list (or its file leaves the editor highlighter) when:
 
-- Each modified file has its before-content stored in a `ConcurrentHashMap<String, String>`
-  (path → content). Only the **first** capture per path is kept (`putIfAbsent`) — all later
-  edits accumulate against the original baseline.
-- Files larger than **5 MB** are skipped to avoid memory bloat. They're still edited, but
-  they won't appear in the Review panel.
-- Files outside the project scope are skipped (determined by `ProjectFileIndex`).
-- New files are recorded in a separate `newFiles` set; deletions go into a
-  `deletedFiles` map keyed by path → content (so revert can restore them).
+| Trigger                                                        | Effect                                                                |
+|----------------------------------------------------------------|-----------------------------------------------------------------------|
+| **Accept** (row or per-file)                                   | Status → `APPROVED`. Row stays. Highlights cleared.                   |
+| **Revert** (row or banner)                                     | File restored from snapshot. Row removed. Nudge sent to agent.        |
+| **Delete** key on an approved row                              | Row removed (file untouched).                                         |
+| **Clean Approved** toolbar button                              | Every `APPROVED` row removed.                                         |
+| **Successful `git_commit`**                                    | Approved rows whose path is in the commit are pruned.                 |
+| **Auto-Clean on New Prompt** (when enabled, on each user turn) | Every `APPROVED` row removed before the message is sent.              |
+| **Branch switch / `reset --hard` / rebase / pull / merge**     | All rows wiped (`invalidateOnWorktreeChange()`); snapshots are stale. |
 
-### End of session
+### Re-edit of an approved file flips it back to PENDING
 
-The session ends when any of these happen:
+When **Auto-Approve is OFF** and the agent edits a file that already has an `APPROVED`
+row:
 
-1. **Accept All** or **Reject All** (via panel or bulk action) resolves every tracked item.
-2. The user toggles **Diff Review** off (with a confirm dialog if there are pending items).
-3. The user clicks the Stop toggle in the Review toolbar.
-4. The working tree changes out from under us — a branch switch, `git reset --hard`, or
-   similar — detected via `invalidateOnWorktreeChange()`. Existing snapshots would
-   otherwise be invalid.
-5. The project is closed (session is a project service registered for `Disposer`).
+1. The row's `ApprovalState` flips back to `PENDING`.
+2. The captured snapshot is **rebased onto the previously-approved content** — it now
+   represents "the file at the moment the previous round of edits was approved".
+3. The editor highlighter is rebuilt from the rebased snapshot, so only the **new** hunks
+   are highlighted; the previously-approved hunks are no longer marked.
+4. `lastEditedMillis` and `linesAdded` / `linesRemoved` are recomputed against the
+   rebased snapshot.
 
-When a session ends, all highlights, banners, and tracked state are cleared.
+When **Auto-Approve is ON**, the row stays `APPROVED` and the snapshot is similarly
+rebased so the next time you toggle Auto-Approve off, the highlight diff will only show
+fresh changes.
+
+This keeps the panel honest: an approved row means "the agent's last batch was reviewed",
+not "we'll never look at this file again".
 
 ---
 
-## Accept / Revert semantics
+## Auto-Approve semantics
 
-| Status                          | **Accept**                                        | **Revert**                                                                                                                   |
-|---------------------------------|---------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
-| **MODIFIED** (snapshot exists)  | Drop the snapshot, keep the current file content. | Run `document.setText(snapshot)` inside a `WriteCommandAction` named *Reject Agent Edit* (undoable), save, clear highlights. |
-| **ADDED** (in `newFiles`)       | Remove from `newFiles`, keep the file.            | Delete the file via VFS inside *Delete Agent-Created File*. Parent directory is not touched.                                 |
-| **DELETED** (in `deletedFiles`) | Keep the deletion.                                | Recreate the file at its original path with the captured content.                                                            |
+Auto-Approve has three layers of behaviour:
 
-Each accept/reject clears the row, updates the editor banner for that file (if open), and
-fires `ReviewSessionTopic.reviewStateChanged` so the panel refreshes.
+1. **New edits land as `APPROVED`**, with the editor highlighter cleared immediately.
+2. **Toggle-on sweep** — flipping Auto-Approve from OFF → ON immediately marks every
+   existing `PENDING` row as `APPROVED`, clears highlights, and releases any blocked git
+   gate (since the gate only blocks on pending items).
+3. **Re-edit of an approved file** — see above. The snapshot is rebased; the row stays
+   `APPROVED`.
 
-**Reject reasons** are optional. If you supply one, it's forwarded to the agent as a
-nudge prefixed with `[User rejected agent edits]: …\nPlease try a different approach.`,
-giving the next turn context to change direction.
+Auto-Approve is **not** a master "off" switch. The session still tracks everything; you
+just consent in advance.
+
+---
+
+## Cleanup rules
+
+The review list is allowed to grow. The worst case is "every file in the project edited
+once" — one row per file. Cleanup is explicit and predictable:
+
+- **Per-row `Delete` key** removes a single approved row.
+- **Clean Approved** toolbar button is a one-shot purge of every approved row.
+- **Auto-Clean on New Prompt** is a per-project toolbar toggle (persisted in settings).
+  When ON, every approved row is removed before the next user message is sent, so each
+  prompt starts with a clean slate. Pending rows are never auto-cleaned.
+- **Successful `git_commit`** prunes approved rows whose path appears in the commit.
+  Pending rows are never pruned (and the gate would have prevented the commit anyway).
+  The commit-to-paths mapping uses `git show --name-only --format= HEAD`.
+- **Worktree-changing git operations** (branch switch, `reset --hard`, rebase, pull,
+  merge, stash pop/apply, revert, cherry-pick) call `invalidateOnWorktreeChange()` after
+  the gate has been resolved, wiping every row — pending or approved — because the
+  before-snapshots are stale.
+
+There is no automatic eviction by age or count. The only built-in cap is the per-file
+**5 MB snapshot limit** and a project-wide **50 MB total snapshot cap**: when the cap is
+exceeded, the oldest `APPROVED` rows are evicted first (sorted by `lastEditedAt`).
+`PENDING` rows are never evicted automatically — they wait for you.
+
+---
+
+## Revert-as-nudge protocol
+
+Reverting a file always restores its pre-edit content **and** sends the agent a nudge
+describing what happened. The nudge format is:
+
+```
+[User reverted <relative-path>:<line-ranges>] Reason: <reason or "(no reason given)">
+```
+
+followed by a fenced unified diff of the reverted hunks (`--- before` / `+++ after`).
+
+When multiple files are reverted in the same review pass, their nudges are merged via the
+existing `mergeNudges` path so the agent receives one combined message.
+
+### When a git gate is currently blocking
+
+If `awaitReviewCompletion` is currently waiting on the gate when you trigger a revert, the
+**Revert reason** dialog gains a third button:
+
+| Button                 | Behaviour                                                                                                                                                 |
+|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Continue reviewing** | Queues the nudge and **keeps the gate blocking** so you can revert / accept more files in the same pass. This is the default when the gate is active.     |
+| **Send to agent now**  | Short-circuits the gate immediately. The blocked tool returns an error whose body is the merged nudge for every file rejected so far; the agent re-plans. |
+| **Cancel**             | Closes the dialog. No revert happens.                                                                                                                     |
+
+When the gate is **not** active, the dialog hides "Continue reviewing"; the nudge goes
+through the normal pending-nudge path and is delivered with the next agent message.
+
+### Unhandled-nudge handling
+
+If a turn ends while a nudge is still pending, **`ChatInputSettings.unhandledNudgeMode`**
+controls what happens:
+
+| Mode                  | Behaviour                                                                                                                   |
+|-----------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| `AUTO_SEND` (default) | The nudge is sent on its own as a new prompt as soon as the turn ends. (Original behaviour.)                                |
+| `RESTORE_INTO_INPUT`  | The nudge text is **prepended to the chat input**, the input is focused, and nothing is auto-sent. You decide when to send. |
+
+Configure this in `Settings → Tools → AgentBridge → Chat input → Unhandled nudges`.
 
 ---
 
 ## Git gating
 
-Destructive git operations are **blocked** until the review is complete. This prevents
-common foot-guns like the agent committing edits you haven't reviewed, or rebasing while
-half the working tree is under review.
+Destructive git operations are **blocked** until pending review is complete. Approved rows
+are no-ops for the gate.
 
 Each gated tool calls:
 
@@ -211,36 +302,52 @@ tracked working-tree content.
 1. On the first gated call with pending review, `awaitReviewCompletion`:
     - Fires a balloon notification + an OS-level notification naming the blocked operation.
     - Expands the Review panel so the user sees exactly what's pending.
-2. The tool thread then waits on a `CompletableFuture` that completes when
-   `hasChanges()` goes to false (via accept/reject) or the session ends.
-3. The timeout is **10 minutes**. On timeout, the tool returns an actionable error:
+2. The tool thread waits on a `CompletableFuture` that completes when
+   `hasPendingChanges()` goes to false. Approved rows do **not** keep the gate blocked.
+3. The wait can be **short-circuited** by selecting *Send to agent now* in any revert
+   dialog issued during the gate — the gated tool immediately returns the merged
+   revert nudge as an error so the agent can re-plan.
+4. The timeout is **10 minutes**. On timeout, the tool returns an actionable error:
    > Error: Timed out after 10 minutes waiting for the user to review N file(s) before
    > `<operation>`. Accept or revert the pending changes in the Review panel and retry.
 
 ### Why the wait yields locks
 
-The wait releases two locks held by `PsiBridgeService.callTool`:
-
-- The **global write-tool semaphore** (otherwise all other tool calls starve).
-- The **per-tool sync lock** (otherwise a second call to the same tool from another
-  mcp-http thread deadlocks — it would acquire the semaphore but block on the sync lock
-  this thread still holds while waiting on the future).
-
-Both are re-acquired in the original order (semaphore → sync lock) before the tool
-finishes. `writeSemaphore.acquireUninterruptibly()` is intentional so the `callTool`
-finally block doesn't over-release if the thread is interrupted during the wait.
+Same as the v1 behaviour: the wait releases the global write-tool semaphore and the
+per-tool sync lock so other tool calls can proceed while review is in progress, and
+re-acquires them in the original order before the tool finishes.
 
 ---
 
-## Settings
+## Persistence
 
-| Setting                                    | Default | Effect                                                                         |
-|--------------------------------------------|---------|--------------------------------------------------------------------------------|
-| `Tools → AgentBridge → Review agent edits` | **off** | Master switch. When off, no snapshots are captured and all gating is bypassed. |
+`AgentEditSession` is a `PersistentStateComponent` with
+`@Storage(StoragePathMacros.WORKSPACE_FILE)` — the review list is stored in
+`<project>/.idea/workspace.xml`, **not** in version control. The persisted state contains:
 
-The toggle is also exposed in the Review panel's toolbar for quick access. Disabling it
-while a session is active shows a confirm dialog (*"You have N unreviewed file(s).
-Disabling Diff Review will discard the review session."*) before discarding state.
+- The map of `path → before-content` snapshot.
+- The set of files added and the map of files deleted by the agent.
+- Per-path `ApprovalState`, `lastEditedMillis`, `linesAdded`, `linesRemoved`.
+
+On project re-open the session restores everything and re-applies highlights to any open
+editors. Approved and pending rows alike survive an IDE restart, an IDE crash, and a
+project re-open. Worktree-changing git operations still wipe the list as they did before.
+
+The persisted state is intentionally not committed: snapshots may contain unsaved work
+and aren't meaningful to other developers.
+
+---
+
+## Settings reference
+
+| Setting                                                              | Default     | Effect                                                                                                                                                                        |
+|----------------------------------------------------------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Auto-Approve agent edits** (toolbar toggle, persisted per-project) | OFF         | When ON, new edits land as `APPROVED` and existing pending rows are swept. Toggle-on releases any blocked git gate.                                                           |
+| **Auto-Clean on New Prompt** (toolbar toggle, persisted per-project) | OFF         | When ON, every approved row is removed before the next user prompt is sent. Pending rows are never auto-cleaned.                                                              |
+| **Unhandled nudges** (`Settings → Tools → AgentBridge → Chat input`) | `AUTO_SEND` | `AUTO_SEND`: pending nudges are sent on their own as a new prompt at end-of-turn. `RESTORE_INTO_INPUT`: pending nudges are prepended to the chat input and focus moves to it. |
+
+The legacy *"Review agent edits"* master switch is gone; the persisted field stays on
+`McpServerSettings` for back-compat (read once for migration, then ignored).
 
 ---
 
@@ -249,22 +356,22 @@ Disabling Diff Review will discard the review session."*) before discarding stat
 Package: `com.github.catatafishen.agentbridge.psi.review` (non-UI) and
 `com.github.catatafishen.agentbridge.ui.review` (UI).
 
-| Class                                                         | Responsibility                                                                                                                                                                             |
-|---------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `AgentEditSession`                                            | Project service. Owns snapshots / newFiles / deletedFiles. Exposes `ensureStarted`, `captureBeforeContent`, `acceptFile`, `rejectFile`, `acceptAll`, `rejectAll`, `awaitReviewCompletion`. |
-| `AgentEditHighlighter`                                        | Project service. Attaches/updates range highlighters on any open editor for tracked files.                                                                                                 |
-| `AgentEditNotificationProvider`                               | `EditorNotificationProvider` that injects the per-editor banner.                                                                                                                           |
-| `ReviewItem`                                                  | Immutable record of `(path, relativePath, status, beforeContent)`.                                                                                                                         |
-| `ReviewSessionTopic`                                          | Message-bus topic fired when any review state changes. Subscribed by the Review panel and editor notifications.                                                                            |
-| `ReviewChangesPanel`                                          | Swing panel that renders the table, buttons, and toolbar. Lives in the side-panel Review tab.                                                                                              |
-| `ReviewPanelController`                                       | Project service that brokers "expand the Review panel" requests from non-UI code (the UI component registers its expand callback once built).                                              |
-| `RevertReasonDialog`                                          | Modal dialog that collects an optional reason before reverting a file.                                                                                                                     |
-| `NextAgentEditChangeAction` / `PreviousAgentEditChangeAction` | Editor actions for cross-file change navigation.                                                                                                                                           |
-| `RevertAgentEditsAction`                                      | Editor action that reverts the current file.                                                                                                                                               |
-| `ChangeNavigator`                                             | Pure helper that computes the ordered next/previous change across files.                                                                                                                   |
-| `ChangeRange`                                                 | Record of `(afterLine, afterLineEnd, type, beforeLine, beforeCount)`.                                                                                                                      |
+| Class                           | Responsibility                                                                                                                                                                                                                                                           |
+|---------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `AgentEditSession`              | Project `@Service` + `@State` `PersistentStateComponent`. Owns snapshots / newFiles / deletedFiles plus per-path approval state. Always-on; exposes `acceptFile`, `revertFile`, `removeApproved*`, `awaitReviewCompletion`, `setAutoApprove`, `removeApprovedForCommit`. |
+| `ApprovalState`                 | Enum `{ PENDING, APPROVED }`.                                                                                                                                                                                                                                            |
+| `ReviewItem`                    | Immutable record `(path, relativePath, status, beforeContent, approvalState, lastEditedMillis, linesAdded, linesRemoved)`. `approved()` convenience.                                                                                                                     |
+| `AgentEditHighlighter`          | Project service. Attaches/updates range highlighters on any open editor for tracked files. Skips `APPROVED` files unless re-edited.                                                                                                                                      |
+| `AgentEditNotificationProvider` | `EditorNotificationProvider` that injects the per-editor banner. Calls the gate-aware `revertFile`.                                                                                                                                                                      |
+| `RevertReasonDialog`            | Modal dialog that collects an optional reason. `Result` enum with `CONTINUE_REVIEWING` / `SEND_NOW` / `DEFAULT` / `CANCEL`; only shows the third button when a gate is active.                                                                                           |
+| `ReviewSessionTopic`            | Message-bus topic fired when any review state changes. Subscribed by the Review panel and editor notifications.                                                                                                                                                          |
+| `ReviewChangesPanel`            | Swing panel. Renders the table (`+N / −N`, timestamp, muted-when-approved), `Delete`-key handler, toolbar with **Auto-Approve**, **Auto-Clean on New Prompt**, **Clean Approved**.                                                                                       |
+| `ReviewPanelController`         | Project service that brokers "expand the Review panel" requests from non-UI code.                                                                                                                                                                                        |
+| `ChangeNavigator`               | Pure helper that computes the ordered next/previous change across pending files.                                                                                                                                                                                         |
+| `ChangeRange`                   | Record `(startLine, endLine, type, deletedFromLine, deletedCount)`.                                                                                                                                                                                                      |
+| `TimestampDisplayFormatter`     | Shared Today / Yesterday / MMM d / MMM d yyyy formatter (also used by the Prompts tab).                                                                                                                                                                                  |
 
-File-edit tool hooks:
+File-edit tool hooks (unchanged from v1):
 
 - `FileTool.writeFile` (all variants), `FileTool.createFile`, `FileTool.deleteFile` call
   `AgentEditSession.ensureStarted()` and `captureBeforeContent` / `registerNewFile` /
@@ -272,9 +379,22 @@ File-edit tool hooks:
 - These hooks run *inside* `markAgentEditStart/End` so the document listener knows the
   edit is agent-originated.
 
+New hooks (v2):
+
+- `ChatToolWindowContent.onSendStopClicked` calls `AgentEditSession.removeApprovedAll()`
+  on the first message of a fresh user turn when *Auto-Clean on New Prompt* is enabled.
+- `ChatToolWindowContent.setSendingState(false)` branches on
+  `ChatInputSettings.unhandledNudgeMode` to either auto-send pending nudges or prepend
+  them to the chat input.
+- `GitCommitTool.execute` parses `git show --name-only --format= HEAD` after a successful
+  commit and calls `AgentEditSession.removeApprovedForCommit(paths)`.
+
 Unit coverage:
 
-- `ReviewPendingMessageTest` — verifies the timeout error wording.
+- `ReviewItemDerivationTest` — derivation of the row list from session maps.
+- `ReviewItemV2FieldsTest` — `ApprovalState`, `approved()`, `linesAdded` / `linesRemoved`,
+  `lastEditedMillis`, enum-name round-trip used by the persistence path.
+- `ReviewPendingMessageTest` — timeout error wording.
 - `ChangeNavigatorTest` — cross-file navigation.
 - `AgentEditSessionRangesTest` — `computeRanges(String, String)` pure helper.
 
@@ -282,40 +402,43 @@ Unit coverage:
 
 ## Edge cases
 
+- **Re-edit of an approved file** — when Auto-Approve is OFF, the row flips back to
+  `PENDING` and the snapshot is rebased onto the previously-approved content so only the
+  fresh hunks are highlighted. When Auto-Approve is ON, the row stays `APPROVED` and the
+  snapshot is rebased silently.
+- **Multi-file revert during a blocked gate** — pick **Continue reviewing** for every file
+  except the last; the nudges are merged via `mergeNudges` and the agent receives a single
+  combined message when you finally hit **Send to agent now**.
+- **Auto-Approve toggle while a gate is blocking** — turning Auto-Approve ON sweeps every
+  pending row to `APPROVED` and immediately releases the gate. The blocked tool resumes
+  normally.
 - **Large files (> 5 MB)** — skipped entirely. Edits still happen, but the file won't
-  appear in the Review panel. This is a deliberate memory-bloat guard.
-- **Binary files** — treated like any other file via VFS; diff is computed on the raw
-  text. The diff engine may bail with `FilesTooBigForDiffException`, in which case the
-  file appears in the panel but `computeRanges` returns empty (no line highlights).
-- **Same file edited multiple times** — only the first snapshot is kept. The diff you see
-  is always "original → current", not "previous edit → current".
+  appear in the Review panel.
+- **Total snapshot cap (50 MB project-wide)** — when exceeded, the oldest `APPROVED` rows
+  are evicted first (sorted by `lastEditedMillis`). `PENDING` rows are never evicted
+  automatically.
+- **Binary files** — treated like any other file via VFS. The diff engine may bail with
+  `FilesTooBigForDiffException`, in which case the file appears in the panel but
+  `computeRanges` returns empty (no line highlights).
 - **File modified outside agent control** — the document listener only snapshots when the
   agent-edit ThreadLocal is set, so IDE reformats, your own edits, and branch switches do
-  **not** create review items. If you edit a file that the agent has already modified,
-  your edits become part of the "current" side of the diff. Reverting in that case will
-  also revert your manual edits — this is intentional: you're restoring to the
-  pre-session baseline.
-- **Renames** — tracked via `VFilePropertyChangeEvent.PROP_NAME` with an
-  `OLD_PATH_KEY` marker; snapshots are re-keyed to the new path.
-- **Worktree-changing git operations** — any `git_branch switch`, `git_reset --hard`,
-  `git_rebase`, `git_merge`, `git_pull`, `git_stash pop/apply`, `git_revert`, or
-  `git_cherry_pick` that is *executed* (after review gating has been resolved) calls
-  `invalidateOnWorktreeChange` afterward. Snapshots taken against the old working-tree
-  content would be stale, so the session is ended cleanly rather than allowing half-valid
-  reverts.
-- **New file then deleted in the same session** — appears once in the panel as
-  DELETED (since we reconcile newFiles and deletedFiles when building `getReviewItems`).
-  Revert re-creates it with the originally captured content if any; otherwise it stays
-  deleted.
+  **not** create review items. If you edit a file the agent has already modified, your
+  edits become part of the "current" side of the diff. Reverting will restore the
+  pre-session baseline (including discarding your manual edits) — this is intentional.
+- **Renames** — tracked via `VFilePropertyChangeEvent.PROP_NAME` with an `OLD_PATH_KEY`
+  marker; snapshots are re-keyed to the new path, with approval state preserved.
+- **Worktree-changing git operations** — `git_branch switch`, `git_reset --hard`,
+  `git_rebase`, `git_merge`, `git_pull`, `git_stash pop/apply`, `git_revert`, and
+  `git_cherry_pick` all call `invalidateOnWorktreeChange` after the gate resolves,
+  wiping every row.
+- **New file then deleted in the same session** — appears once in the panel as `DELETED`.
+  Revert re-creates it with the originally captured content if any.
 - **Deleted file with no prior snapshot** — content captured at deletion time is used as
-  the "original" for restore. This covers files that existed before the session but were
-  never modified before deletion.
-- **Session ending with unresolved items** — disabling Diff Review or clicking Stop
-  discards all tracked state after confirmation. The files on disk are not touched — only
-  the review overlays disappear.
-- **Second gated tool call during review** — multiple gated operations may be waiting on
-  the same future. All are released together when `hasChanges()` becomes false. If new
-  edits arrive *while* the wait is active (agent keeps working), a fresh future is created
-  and the wait restarts, giving the user another 10 minutes to review the fresh batch.
-- **Closing the project mid-review** — the session is a `Disposable` registered with the
-  project; pending futures complete exceptionally as the project disposes.
+  the "original" for restore.
+- **Project closed mid-review** — the session is a `Disposable` registered with the
+  project; pending futures complete exceptionally as the project disposes. The persisted
+  list is restored on next open.
+- **Multiple gated tool calls concurrently** — all of them wait on the same future and
+  release together when `hasPendingChanges()` becomes false (or a *Send to agent now*
+  short-circuit fires). If new pending edits arrive *while* the wait is active (the agent
+  keeps working), a fresh future is created and the wait restarts.

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
@@ -102,6 +102,11 @@ public abstract class AcpClient extends AbstractAgentClient {
     private @Nullable Process agentProcess;
     private @Nullable InitializeResponse capabilities;
     private @Nullable String currentSessionId;
+
+    protected @Nullable String getCurrentSessionId() {
+        return currentSessionId;
+    }
+
     private @Nullable String launchCwd;
     /**
      * Tracks the resume session ID requested in the current launch cycle.

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
@@ -219,6 +219,14 @@ public final class CopilotClient extends AcpClient {
                 + "The --resume CLI flag is passed at launch but is currently ignored.");
     }
 
+    @Override
+    public @Nullable Path getSessionDirectory() {
+        String sid = getCurrentSessionId();
+        if (sid == null) return null;
+        Path dir = copilotHome().resolve(SESSION_STATE_DIR).resolve(sid);
+        return java.nio.file.Files.isDirectory(dir) ? dir : null;
+    }
+
     /**
      * Returns the standard Copilot CLI home directory ({@code ~/.copilot/}).
      * No environment overrides — the CLI uses the real user home for config, auth, and sessions.

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/AbstractAgentClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/AbstractAgentClient.java
@@ -64,6 +64,17 @@ public abstract class AbstractAgentClient {
     }
 
     /**
+     * Returns the filesystem path to the current session's working directory,
+     * or {@code null} if no session is active or the client doesn't expose one.
+     * <p>
+     * Used by the Files tab in the side panel to list session artifacts
+     * (plans, events, checkpoints, research files, etc.).
+     */
+    public @Nullable java.nio.file.Path getSessionDirectory() {
+        return null;
+    }
+
+    /**
      * Close/stop the agent. Alias for {@link #stop()}.
      */
     public void close() {
@@ -111,7 +122,8 @@ public abstract class AbstractAgentClient {
      * should override this method.
      * </p>
      */
-    public void dropCurrentSession() {}
+    public void dropCurrentSession() {
+    }
 
     // ─── Prompts ─────────────────────────────────────
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
@@ -1289,6 +1289,16 @@ public final class PlatformApiCompat {
         }
 
         /**
+         * Updates the visible title of the tab at {@code index}.
+         * Used for badge overlays like {@code "Todos (3/7)"}.
+         */
+        public void setTabTitle(int index, @NotNull String title) {
+            if (index >= 0 && index < tabInfos.size()) {
+                tabInfos.get(index).setText(title);
+            }
+        }
+
+        /**
          * Registers a tab-selection listener. {@code onTabSelected} receives the zero-based
          * index of the newly selected tab whenever the selection changes.
          */

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProvider.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProvider.java
@@ -63,11 +63,16 @@ public final class AgentEditNotificationProvider implements EditorNotificationPr
 
         panel.createActionLabel("Revert…", () -> {
             String relativePath = toRelativePath(project, file);
-            RevertReasonDialog dialog = new RevertReasonDialog(project, file, relativePath);
-            if (dialog.showAndGet()) {
-                AgentEditSession.getInstance(project).revertFile(file, dialog.getReason());
-                EditorNotifications.getInstance(project).updateNotifications(file);
-            }
+            AgentEditSession s = AgentEditSession.getInstance(project);
+            RevertReasonDialog dialog = new RevertReasonDialog(project, file, relativePath, s.isGateActive());
+            if (!dialog.showAndGet()) return;
+            AgentEditSession.RevertGateAction gateAction = switch (dialog.getResult()) {
+                case CONTINUE_REVIEWING -> AgentEditSession.RevertGateAction.CONTINUE_REVIEWING;
+                case SEND_NOW -> AgentEditSession.RevertGateAction.SEND_NOW;
+                default -> AgentEditSession.RevertGateAction.DEFAULT;
+            };
+            s.revertFile(file.getPath(), dialog.getReason(), gateAction);
+            EditorNotifications.getInstance(project).updateNotifications(file);
         });
 
         return panel;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
@@ -855,8 +855,8 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
     }
 
     public synchronized void endSession() {
-        if (!active) return;
-        active = false;
+        if (!started) return;
+        started = false;
 
         AgentEditHighlighter.getInstance(project).clearAll();
 
@@ -880,7 +880,6 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
         fireReviewStateChanged();
 
         LOG.info("Agent edit review session ended");
-    }
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
@@ -2,9 +2,15 @@ package com.github.catatafishen.agentbridge.psi.review;
 
 import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
 import com.github.catatafishen.agentbridge.services.ChatWebServer;
+import com.github.catatafishen.agentbridge.settings.McpServerSettings;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.components.StoragePathMacros;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.EditorFactory;
@@ -36,39 +42,61 @@ import org.jetbrains.annotations.Nullable;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Tracks file state before agent edits during a review session.
- * <p>
- * <b>Lifecycle:</b> auto-starts on first agent file edit (when enabled) and continues
- * until the user explicitly ends the session. Captures a "before" snapshot of each file
- * on first modification; supports per-file revert with optional reason nudge.
- * <p>
- * <b>Snapshot strategy:</b> lazy — only files that are actually modified get captured.
- * The before-content is stored with {@code putIfAbsent} so only the very first capture
- * (the pre-session state) is kept, regardless of how many subsequent edits occur.
+ * Always-on tracker for agent-originated file edits. The session itself never turns off;
+ * it persists across IDE restarts via {@link PersistentStateComponent}. What does change
+ * is the per-row {@link ApprovalState}: rows are PENDING by default and APPROVED either
+ * automatically (when {@link McpServerSettings#isAutoApproveAgentEdits()} is on) or via
+ * explicit user action. Approved rows stay visible until pruned (DEL key, "Clean
+ * Approved" toolbar action, post-commit prune, worktree-changing git operation, or
+ * optional auto-clean on a new prompt).
+ *
+ * <p><b>Gating:</b> {@link #awaitReviewCompletion} blocks only on PENDING rows. While a
+ * gate is active, {@link #revertFile} can short-circuit it via the
+ * {@link RevertGateAction#SEND_NOW} option, returning the merged revert nudges as the
+ * gated tool's error response so the agent can re-plan.
+ *
+ * <p><b>Re-edit of an approved file:</b> when a file with an APPROVED row is edited
+ * again by the agent, the snapshot is rebased to the just-approved content (the diff in
+ * the panel shows only the <i>new</i> changes, not the cumulative ones since the session
+ * began). When auto-approve is OFF, the row also flips back to PENDING; with auto-approve
+ * ON it stays APPROVED.
+ *
+ * <p>Storage is workspace-only (not committed to VCS).
  */
-public final class AgentEditSession implements Disposable {
+@Service(Service.Level.PROJECT)
+@State(
+    name = "AgentEditReview",
+    storages = @Storage(StoragePathMacros.WORKSPACE_FILE)
+)
+public final class AgentEditSession implements Disposable, PersistentStateComponent<AgentEditSession.PersistedState> {
 
     private static final Logger LOG = Logger.getInstance(AgentEditSession.class);
 
-    /**
-     * Skip snapshotting files larger than 5 MB to avoid memory bloat.
-     */
+    /** Skip snapshotting files larger than 5 MB to avoid memory bloat. */
     private static final long MAX_SNAPSHOT_BYTES = 5L * 1024 * 1024;
 
     /**
-     * UserData key for tracking old path during rename/move events.
+     * Project-wide cap on the total size of all snapshots + deletedFiles content. When
+     * exceeded, the oldest APPROVED rows are evicted first; if still over cap nothing
+     * else is dropped (the new edit is accepted but the user is not blocked).
      */
-    private static final Key<String> OLD_PATH_KEY = Key.create("AgentEditSession.oldPath");
+    private static final long MAX_TOTAL_SNAPSHOT_BYTES = 50L * 1024 * 1024;
 
-    private final Project project;
-    private volatile boolean active;
+    private static final long REVIEW_WAIT_TIMEOUT_MINUTES = 10;
+
+    /** UserData key for tracking old path during rename/move events. */
+    private static final Key<String> OLD_PATH_KEY = Key.create("AgentEditSession.oldPath");
 
     /**
      * Thread-local marker set during agent-originated tool edits.
@@ -77,17 +105,10 @@ public final class AgentEditSession implements Disposable {
      */
     private static final ThreadLocal<Boolean> agentEditActive = ThreadLocal.withInitial(() -> false);
 
-    /**
-     * Marks the current thread as executing an agent-originated edit.
-     * Must be paired with {@link #markAgentEditEnd()} in a finally block.
-     */
     public static void markAgentEditStart() {
         agentEditActive.set(true);
     }
 
-    /**
-     * Clears the agent-edit marker for the current thread.
-     */
     public static void markAgentEditEnd() {
         agentEditActive.remove();
     }
@@ -96,59 +117,59 @@ public final class AgentEditSession implements Disposable {
         return agentEditActive.get();
     }
 
-    /**
-     * Before-content snapshots keyed by canonical VFS path.
-     */
+    private final Project project;
+
+    /** Before-content snapshots keyed by canonical VFS path. */
     private final Map<String, String> snapshots = new ConcurrentHashMap<>();
-
-    /**
-     * Content of files deleted during the session, keyed by path.
-     */
+    /** Content of files deleted during the session, keyed by path. */
     private final Map<String, String> deletedFiles = new ConcurrentHashMap<>();
-
-    /**
-     * Paths of files created during the session.
-     */
+    /** Paths of files created during the session. */
     private final Set<String> newFiles = ConcurrentHashMap.newKeySet();
+    /** User approval state per path. */
+    private final Map<String, ApprovalState> approvals = new ConcurrentHashMap<>();
+    /** Epoch millis of the most recent agent edit per path. */
+    private final Map<String, Long> lastEditedAt = new ConcurrentHashMap<>();
+    /** Inserted line count vs. the snapshot baseline. */
+    private final Map<String, Integer> linesAdded = new ConcurrentHashMap<>();
+    /** Deleted line count vs. the snapshot baseline. */
+    private final Map<String, Integer> linesRemoved = new ConcurrentHashMap<>();
 
-    /**
-     * Disposable for session-scoped listeners; null when inactive.
-     */
     private Disposable sessionDisposable;
+    private volatile boolean started;
 
-    /**
-     * Tracks whether the user has been notified about the currently-pending review state.
-     * Reset when review items are resolved. Prevents notification spam on agent retries
-     * of gated git operations.
-     */
     private volatile boolean reviewNotificationFired;
+    private java.util.concurrent.CompletableFuture<Void> reviewCompletionFuture;
 
     /**
-     * Completes when the current review batch has been fully resolved (accept or reject)
-     * or the session has ended. Lazily (re-)created by {@link #awaitReviewCompletion}
-     * when a blocking gate starts; completed by {@link #completeReviewIfEmpty} /
-     * {@link #endSession}. Null when no gate is currently in flight.
+     * Buffer of revert nudges accumulated during the current gate. Flushed on either
+     * {@link RevertGateAction#SEND_NOW} (returned as the tool error) or on natural gate
+     * resolution (forwarded into {@link PsiBridgeService#setPendingNudge}).
      */
-    private java.util.concurrent.CompletableFuture<Void> reviewCompletionFuture;
+    private final List<String> gateRevertBuffer = Collections.synchronizedList(new ArrayList<>());
+
+    /**
+     * Set when the current gate is short-circuited via "Send to agent now". Cleared
+     * after the gated tool consumes it and reports the error to the agent.
+     */
+    private volatile String pendingGateCancelMessage;
 
     public AgentEditSession(@NotNull Project project) {
         this.project = project;
+        ensureStarted();
     }
 
     public static AgentEditSession getInstance(@NotNull Project project) {
         return project.getService(AgentEditSession.class);
     }
 
-    public boolean isActive() {
-        return active;
-    }
-
+    /**
+     * Always-on session bootstrap: installs the document and VFS listeners exactly once
+     * per project lifetime. Kept public for back-compat with the older opt-in API — most
+     * callers can drop the call entirely.
+     */
     public synchronized void ensureStarted() {
-        if (active) return;
-        if (!com.github.catatafishen.agentbridge.settings.McpServerSettings.getInstance(project).isReviewAgentEdits()) {
-            return;
-        }
-        active = true;
+        if (started || project.isDisposed()) return;
+        started = true;
 
         sessionDisposable = Disposer.newDisposable("AgentEditSession");
         Disposer.register(this, sessionDisposable);
@@ -160,32 +181,35 @@ public final class AgentEditSession implements Disposable {
         project.getMessageBus().connect(sessionDisposable)
             .subscribe(VirtualFileManager.VFS_CHANGES, new SessionVfsListener());
 
-        LOG.info("Agent edit review session started");
-        fireReviewStateChanged();
+        LOG.info("Agent edit review session started (always-on)");
     }
 
     /**
-     * Ends the session if active. Called from git tools that change the working tree
-     * (branch switch, reset --hard, rebase, stash pop, merge, pull, cherry-pick, revert).
-     * After a worktree change, existing snapshots are invalid since files may have
-     * reverted to different content.
+     * Always-on session is always "active". Kept for API back-compat (old call sites
+     * that used to short-circuit on inactive sessions).
      */
-    public void invalidateOnWorktreeChange(@NotNull String operation) {
-        if (!active) return;
-        LOG.info("Invalidating review session due to: " + operation);
-        endSession();
+    public boolean isActive() {
+        return started;
     }
 
+    /**
+     * Wipes all tracked state and ends any in-flight gate. Called on worktree changes
+     * (branch switch, reset --hard, rebase, stash pop, merge, pull, cherry-pick, revert)
+     * — existing snapshots would otherwise be stale.
+     */
+    public void invalidateOnWorktreeChange(@NotNull String operation) {
+        if (snapshots.isEmpty() && deletedFiles.isEmpty() && newFiles.isEmpty()) return;
+        LOG.info("Invalidating review session due to: " + operation);
+        wipeAllTrackedState();
+        completeGate();
+    }
+
+    // ── Capture / register ──────────────────────────────────────────────────
+
     public void captureBeforeContent(@NotNull VirtualFile vf, @NotNull String content) {
-        if (!active) return;
-        if (content.length() > MAX_SNAPSHOT_BYTES) return;
         if (!isProjectFile(vf)) return;
-        String prev = snapshots.putIfAbsent(vf.getPath(), content);
-        if (prev == null) {
-            LOG.info("Captured before-snapshot for: " + getRelativePath(vf));
-            com.intellij.ui.EditorNotifications.getInstance(project).updateNotifications(vf);
-            fireReviewStateChanged();
-        }
+        captureBeforeContent(vf.getPath(), content);
+        com.intellij.ui.EditorNotifications.getInstance(project).updateNotifications(vf);
     }
 
     /**
@@ -193,33 +217,42 @@ public final class AgentEditSession implements Disposable {
      * Used when a VirtualFile is not available (e.g., files that don't exist yet on VFS).
      */
     public void captureBeforeContent(@NotNull String path, @NotNull String content) {
-        if (!active) return;
         if (content.length() > MAX_SNAPSHOT_BYTES) return;
         snapshots.putIfAbsent(path, content);
+        lastEditedAt.put(path, System.currentTimeMillis());
+        applyDefaultApproval(path);
+        recomputeLineCounts(path);
+        enforceTotalSnapshotCap();
+        fireReviewStateChanged();
     }
 
-    /**
-     * Registers a file as newly created during this session.
-     */
     public void registerNewFile(@NotNull String path) {
-        if (!active) return;
         newFiles.add(path);
+        lastEditedAt.put(path, System.currentTimeMillis());
+        applyDefaultApproval(path);
+        fireReviewStateChanged();
     }
 
-    /**
-     * Registers a file as deleted during this session, capturing its content for restore.
-     */
     public void registerDeletedFile(@NotNull String path, @NotNull String content) {
-        if (!active) return;
         if (content.length() > MAX_SNAPSHOT_BYTES) return;
         deletedFiles.put(path, content);
+        lastEditedAt.put(path, System.currentTimeMillis());
+        applyDefaultApproval(path);
+        enforceTotalSnapshotCap();
+        fireReviewStateChanged();
     }
 
-    /**
-     * Computes change ranges between the before-snapshot and the current document content.
-     *
-     * @return list of change ranges, or empty if no snapshot exists or content is unchanged
-     */
+    private void applyDefaultApproval(@NotNull String path) {
+        ApprovalState defaultState = isAutoApproveOn() ? ApprovalState.APPROVED : ApprovalState.PENDING;
+        approvals.put(path, defaultState);
+    }
+
+    private boolean isAutoApproveOn() {
+        return McpServerSettings.getInstance(project).isAutoApproveAgentEdits();
+    }
+
+    // ── Range / snapshot accessors (unchanged surface) ──────────────────────
+
     public @NotNull List<ChangeRange> computeRanges(@NotNull VirtualFile vf) {
         String before = snapshots.get(vf.getPath());
         if (before == null) return Collections.emptyList();
@@ -234,12 +267,7 @@ public final class AgentEditSession implements Disposable {
         return computeRanges(before, after);
     }
 
-    /**
-     * Computes line-level change ranges between two strings.
-     * Package-visible for testing.
-     */
     @SuppressWarnings("RedundantThrows")
-    // Diff.buildChanges throws checked exception in some SDK versions but not others
     static @NotNull List<ChangeRange> computeRanges(@NotNull String before, @NotNull String after) {
         String[] beforeLines = Diff.splitLines(before);
         String[] afterLines = Diff.splitLines(after);
@@ -275,16 +303,10 @@ public final class AgentEditSession implements Disposable {
         }
     }
 
-    /**
-     * Returns the before-content snapshot for a file, or null if not captured.
-     */
     public @Nullable String getSnapshot(@NotNull VirtualFile vf) {
         return snapshots.get(vf.getPath());
     }
 
-    /**
-     * Returns all paths that have been modified during this session (not including new or deleted).
-     */
     public @NotNull Set<String> getModifiedFilePaths() {
         return Collections.unmodifiableSet(snapshots.keySet());
     }
@@ -297,181 +319,404 @@ public final class AgentEditSession implements Disposable {
         return Collections.unmodifiableSet(newFiles);
     }
 
+    // ── Aggregate state ─────────────────────────────────────────────────────
+
     /**
-     * Checks whether any changes have been captured in this session.
+     * Any tracked items at all (pending or approved). Used by UI emptiness checks.
      */
     public boolean hasChanges() {
         return !snapshots.isEmpty() || !deletedFiles.isEmpty() || !newFiles.isEmpty();
     }
 
     /**
-     * Builds a unified list of review items from the session's tracked state.
-     * Each file appears exactly once: as ADDED, MODIFIED, or DELETED.
+     * Any PENDING items remaining. Gate-blocking check.
      */
+    public boolean hasPendingChanges() {
+        for (Map.Entry<String, ApprovalState> e : approvals.entrySet()) {
+            if (e.getValue() == ApprovalState.PENDING && pathIsTracked(e.getKey())) return true;
+        }
+        return false;
+    }
+
+    /** True while {@link #awaitReviewCompletion} is blocking on a future. */
+    public boolean isGateActive() {
+        java.util.concurrent.CompletableFuture<Void> f = reviewCompletionFuture;
+        return f != null && !f.isDone();
+    }
+
+    private boolean pathIsTracked(@NotNull String path) {
+        return snapshots.containsKey(path) || newFiles.contains(path) || deletedFiles.containsKey(path);
+    }
+
     public @NotNull List<ReviewItem> getReviewItems() {
-        if (!active) return Collections.emptyList();
         String basePath = project.getBasePath();
         List<ReviewItem> items = new ArrayList<>();
 
         for (Map.Entry<String, String> entry : snapshots.entrySet()) {
             String path = entry.getKey();
-            // Skip files that were subsequently deleted — they'll appear as DELETED
             if (deletedFiles.containsKey(path)) continue;
-            items.add(new ReviewItem(path, relativize(path, basePath),
-                ReviewItem.Status.MODIFIED, entry.getValue()));
+            items.add(buildItem(path, basePath, ReviewItem.Status.MODIFIED, entry.getValue()));
         }
         for (String path : newFiles) {
-            items.add(new ReviewItem(path, relativize(path, basePath),
-                ReviewItem.Status.ADDED, null));
+            items.add(buildItem(path, basePath, ReviewItem.Status.ADDED, null));
         }
         for (Map.Entry<String, String> entry : deletedFiles.entrySet()) {
             String path = entry.getKey();
-            // For deleted files, beforeContent is the original snapshot if available,
-            // otherwise the content captured at deletion time
             String beforeContent = snapshots.getOrDefault(path, entry.getValue());
-            items.add(new ReviewItem(path, relativize(path, basePath),
-                ReviewItem.Status.DELETED, beforeContent));
+            items.add(buildItem(path, basePath, ReviewItem.Status.DELETED, beforeContent));
         }
 
         items.sort((a, b) -> a.relativePath().compareToIgnoreCase(b.relativePath()));
         return items;
     }
 
-    /**
-     * Accepts a file's changes — removes it from review tracking.
-     * For MODIFIED: clears the snapshot (keeps current content).
-     * For ADDED: removes from newFiles set (keeps the file).
-     * For DELETED: removes from deletedFiles map (keeps it deleted).
-     */
-    public void acceptFile(@NotNull String path) {
-        if (!active) return;
-        snapshots.remove(path);
-        newFiles.remove(path);
-        deletedFiles.remove(path);
+    private @NotNull ReviewItem buildItem(@NotNull String path, @Nullable String basePath,
+                                          @NotNull ReviewItem.Status status,
+                                          @Nullable String beforeContent) {
+        ApprovalState state = approvals.getOrDefault(path, ApprovalState.PENDING);
+        long ts = lastEditedAt.getOrDefault(path, 0L);
+        int added = linesAdded.getOrDefault(path, 0);
+        int removed = linesRemoved.getOrDefault(path, 0);
+        return new ReviewItem(path, relativize(path, basePath), status, beforeContent,
+            state, ts, added, removed);
+    }
 
+    // ── Approval mutations ──────────────────────────────────────────────────
+
+    /** Flips a single row to APPROVED. Keeps the row visible. */
+    public void acceptFile(@NotNull String path) {
+        if (!pathIsTracked(path)) return;
+        approvals.put(path, ApprovalState.APPROVED);
+        VirtualFile vf = LocalFileSystem.getInstance().findFileByPath(path);
+        if (vf != null) {
+            com.intellij.ui.EditorNotifications.getInstance(project).updateNotifications(vf);
+        }
+        fireReviewStateChanged();
+        completeGateIfNoPending();
+    }
+
+    /** Flips every PENDING row to APPROVED. Used by the "Auto-Approve ON" sweep. */
+    public void acceptAll() {
+        boolean changed = false;
+        for (String path : collectAllPaths()) {
+            if (approvals.put(path, ApprovalState.APPROVED) != ApprovalState.APPROVED) {
+                changed = true;
+            }
+        }
+        if (changed) {
+            com.intellij.ui.EditorNotifications.getInstance(project).updateAllNotifications();
+            fireReviewStateChanged();
+            completeGateIfNoPending();
+        }
+    }
+
+    /**
+     * Removes a single row from tracking and clears its highlights. Caller is responsible
+     * for ensuring the row is APPROVED — pending rows should be reverted, not removed.
+     */
+    public void removeApproved(@NotNull String path) {
+        if (approvals.get(path) != ApprovalState.APPROVED) return;
+        clearTrackedPath(path);
+        fireReviewStateChanged();
+    }
+
+    /** Removes every APPROVED row. */
+    public void removeAllApproved() {
+        List<String> approved = new ArrayList<>();
+        for (Map.Entry<String, ApprovalState> e : approvals.entrySet()) {
+            if (e.getValue() == ApprovalState.APPROVED) approved.add(e.getKey());
+        }
+        if (approved.isEmpty()) return;
+        for (String path : approved) clearTrackedPath(path);
+        com.intellij.ui.EditorNotifications.getInstance(project).updateAllNotifications();
+        fireReviewStateChanged();
+    }
+
+    /**
+     * Post-commit prune: removes APPROVED rows whose paths were committed. Pending rows
+     * are intentionally left in place — they didn't make it into the commit anyway.
+     */
+    public void removeApprovedForCommit(@NotNull Collection<String> committedPaths) {
+        if (committedPaths.isEmpty()) return;
+        boolean changed = false;
+        for (String path : committedPaths) {
+            if (approvals.get(path) == ApprovalState.APPROVED && pathIsTracked(path)) {
+                clearTrackedPath(path);
+                changed = true;
+            }
+        }
+        if (changed) {
+            com.intellij.ui.EditorNotifications.getInstance(project).updateAllNotifications();
+            fireReviewStateChanged();
+        }
+    }
+
+    private void clearTrackedPath(@NotNull String path) {
+        snapshots.remove(path);
+        deletedFiles.remove(path);
+        newFiles.remove(path);
+        approvals.remove(path);
+        lastEditedAt.remove(path);
+        linesAdded.remove(path);
+        linesRemoved.remove(path);
         VirtualFile vf = LocalFileSystem.getInstance().findFileByPath(path);
         if (vf != null) {
             AgentEditHighlighter.getInstance(project).clearForFile(vf);
             com.intellij.ui.EditorNotifications.getInstance(project).updateNotifications(vf);
         }
-        fireReviewStateChanged();
-        completeReviewIfEmpty();
     }
 
     /**
-     * Accepts all files — clears all review tracking.
+     * Called from settings on Auto-Approve toggle ON. Sweeps all current PENDING rows
+     * to APPROVED and fires a single state change.
      */
-    public void acceptAll() {
-        if (!active) return;
-        // Collect paths that need highlight clearing before we wipe the maps
-        Set<String> allPaths = new java.util.HashSet<>(snapshots.keySet());
-        allPaths.addAll(newFiles);
-        // deletedFiles have no open editors to clear
+    public void onAutoApproveTurnedOn() {
+        acceptAll();
+    }
 
-        snapshots.clear();
-        newFiles.clear();
-        deletedFiles.clear();
+    // ── Revert (always sends a structured nudge) ────────────────────────────
 
-        AgentEditHighlighter highlighter = AgentEditHighlighter.getInstance(project);
-        for (String path : allPaths) {
-            VirtualFile vf = LocalFileSystem.getInstance().findFileByPath(path);
-            if (vf != null) {
-                highlighter.clearForFile(vf);
+    /** What to do with the in-flight gate when reverting during a blocked git op. */
+    public enum RevertGateAction {
+        /** Queue the nudge into pendingNudge; keep the gate blocking so the user can
+         * reject more files. Subsequent reverts during the same gate default here. */
+        CONTINUE_REVIEWING,
+        /** Short-circuit the gate immediately — the gated tool returns the merged
+         * revert nudges as its error response so the agent can re-plan. */
+        SEND_NOW,
+        /** Plain revert with no gate special-casing (used when no gate is active). */
+        DEFAULT
+    }
+
+    /**
+     * Reverts a tracked file and emits a structured nudge to the agent.
+     *
+     * <p>The nudge always has the form:
+     * <pre>
+     * [User reverted &lt;rel-path&gt;:&lt;line-ranges&gt;] Reason: &lt;reason&gt;
+     * &lt;unified diff body&gt;
+     * Please try a different approach for this file.
+     * </pre>
+     *
+     * @param path       absolute VFS path of the tracked file
+     * @param reason     user-supplied reason; may be blank
+     * @param gateAction what to do with any in-flight gate; pass {@link
+     *                   RevertGateAction#DEFAULT} when called outside a gate
+     */
+    public void revertFile(@NotNull String path, @Nullable String reason,
+                           @NotNull RevertGateAction gateAction) {
+        if (!pathIsTracked(path)) return;
+
+        ReviewItem item = findItem(path);
+        if (item == null) return;
+
+        String nudge = buildRevertNudge(item, reason);
+        applyRevert(item);
+
+        boolean gateActive = isGateActive();
+        switch (gateAction) {
+            case SEND_NOW -> {
+                synchronized (gateRevertBuffer) {
+                    gateRevertBuffer.add(nudge);
+                    pendingGateCancelMessage = String.join("\n\n", gateRevertBuffer);
+                    gateRevertBuffer.clear();
+                }
+                completeGate();
+            }
+            case CONTINUE_REVIEWING -> {
+                synchronized (gateRevertBuffer) {
+                    gateRevertBuffer.add(nudge);
+                }
+            }
+            case DEFAULT -> {
+                if (gateActive) {
+                    synchronized (gateRevertBuffer) {
+                        gateRevertBuffer.add(nudge);
+                    }
+                } else {
+                    PsiBridgeService.getInstance(project).setPendingNudge(nudge);
+                }
             }
         }
-        com.intellij.ui.EditorNotifications.getInstance(project).updateAllNotifications();
+
+        clearTrackedPath(path);
         fireReviewStateChanged();
-        completeReviewIfEmpty();
+        completeGateIfNoPending();
+    }
+
+    /** Convenience overload for callers that have a {@link VirtualFile}. */
+    public void revertFile(@NotNull VirtualFile vf, @Nullable String reason) {
+        revertFile(vf.getPath(), reason, RevertGateAction.DEFAULT);
+    }
+
+    private @Nullable ReviewItem findItem(@NotNull String path) {
+        for (ReviewItem item : getReviewItems()) {
+            if (item.path().equals(path)) return item;
+        }
+        return null;
+    }
+
+    private void applyRevert(@NotNull ReviewItem item) {
+        switch (item.status()) {
+            case MODIFIED -> restoreModifiedFile(item);
+            case ADDED -> deleteAddedFile(item);
+            case DELETED -> restoreDeletedFile(item);
+        }
+    }
+
+    private void restoreModifiedFile(@NotNull ReviewItem item) {
+        String snapshot = snapshots.get(item.path());
+        if (snapshot == null) return;
+        VirtualFile vf = LocalFileSystem.getInstance().findFileByPath(item.path());
+        if (vf == null) return;
+        Document doc = FileDocumentManager.getInstance().getDocument(vf);
+        if (doc != null) {
+            WriteCommandAction.runWriteCommandAction(project, "Revert Agent Edit", null,
+                () -> doc.setText(snapshot));
+            FileDocumentManager.getInstance().saveDocument(doc);
+        }
+    }
+
+    private void deleteAddedFile(@NotNull ReviewItem item) {
+        VirtualFile vf = LocalFileSystem.getInstance().findFileByPath(item.path());
+        if (vf == null) return;
+        WriteCommandAction.runWriteCommandAction(project, "Delete Agent-Created File", null, () -> {
+            try {
+                vf.delete(this);
+            } catch (Exception e) {
+                LOG.warn("Failed to delete agent-created file: " + item.path(), e);
+            }
+        });
+    }
+
+    private void restoreDeletedFile(@NotNull ReviewItem item) {
+        String content = item.beforeContent();
+        if (content == null) return;
+        WriteCommandAction.runWriteCommandAction(project, "Restore Deleted File", null, () -> {
+            try {
+                java.io.File ioFile = new java.io.File(item.path());
+                java.io.File parent = ioFile.getParentFile();
+                if (parent != null) {
+                    VirtualFile parentVf = LocalFileSystem.getInstance()
+                        .refreshAndFindFileByIoFile(parent);
+                    if (parentVf != null) {
+                        VirtualFile created = parentVf.createChildData(this, ioFile.getName());
+                        created.setBinaryContent(content.getBytes(StandardCharsets.UTF_8));
+                    }
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to restore deleted file: " + item.path(), e);
+            }
+        });
     }
 
     /**
-     * Rejects a single file — restores it to pre-session state.
-     * For MODIFIED: restores snapshot content.
-     * For ADDED: deletes the file.
-     * For DELETED: recreates the file with its original content.
-     *
-     * @param path   file path
-     * @param reason optional reason (sent as nudge to agent)
+     * Builds the structured revert nudge: {@code [User reverted file:ranges] Reason:...}
+     * followed by a unified-diff body, followed by a re-plan nudge.
      */
-    public void rejectFile(@NotNull String path, @Nullable String reason) {
-        if (!active) return;
-
-        String basePath = project.getBasePath();
-        if (snapshots.containsKey(path) && !deletedFiles.containsKey(path)) {
-            rejectModifiedFile(new ReviewItem(path, relativize(path, basePath), ReviewItem.Status.MODIFIED, null));
-        } else if (newFiles.contains(path)) {
-            rejectAddedFile(new ReviewItem(path, relativize(path, basePath), ReviewItem.Status.ADDED, null));
-        } else if (deletedFiles.containsKey(path)) {
-            rejectDeletedFile(new ReviewItem(path, relativize(path, basePath), ReviewItem.Status.DELETED, null));
-        }
-
-        if (reason != null && !reason.isBlank()) {
-            VirtualFile vf = LocalFileSystem.getInstance().findFileByPath(path);
-            if (vf != null) {
-                sendRevertNudge(vf, reason);
+    private @NotNull String buildRevertNudge(@NotNull ReviewItem item, @Nullable String reason) {
+        String header;
+        String body;
+        switch (item.status()) {
+            case MODIFIED -> {
+                String before = snapshots.get(item.path());
+                String after = readCurrentContent(item.path());
+                List<ChangeRange> ranges = (before != null && after != null)
+                    ? computeRanges(before, after) : Collections.emptyList();
+                header = "[User reverted " + item.relativePath() + formatRanges(ranges) + "]";
+                body = (before != null && after != null) ? buildUnifiedDiff(before, after) : "";
+            }
+            case ADDED -> {
+                header = "[User reverted creation of " + item.relativePath() + "]";
+                body = "";
+            }
+            case DELETED -> {
+                header = "[User reverted deletion of " + item.relativePath() + "]";
+                body = "";
+            }
+            default -> {
+                header = "[User reverted " + item.relativePath() + "]";
+                body = "";
             }
         }
-        fireReviewStateChanged();
-        completeReviewIfEmpty();
-    }
 
-    /**
-     * Rejects all files — restores all to pre-session state.
-     *
-     * @param reason optional reason (sent as nudge to agent)
-     */
-    public void rejectAll(@Nullable String reason) {
-        if (!active) return;
-        List<ReviewItem> items = getReviewItems();
-        for (ReviewItem item : items) {
-            // Call individual reject but suppress intermediate topic events
-            rejectFileSilent(item);
-        }
+        StringBuilder sb = new StringBuilder(header);
         if (reason != null && !reason.isBlank()) {
-            String nudge = "[User rejected all agent edits]: " + reason
-                + "\nPlease try a different approach.";
-            PsiBridgeService.getInstance(project).setPendingNudge(nudge);
+            sb.append(" Reason: ").append(reason.trim());
         }
-        fireReviewStateChanged();
-        completeReviewIfEmpty();
+        if (!body.isEmpty()) {
+            sb.append('\n').append(body);
+        }
+        sb.append("\nPlease try a different approach for this file.");
+        return sb.toString();
     }
 
-    /**
-     * Blocks until all pending review items have been accepted/rejected, the session ends,
-     * or the timeout expires. Called by git tools before destructive operations.
-     *
-     * <p>On the first call, fires a balloon notification + system notification
-     * and expands the Review panel. Subsequent calls only expand the panel.</p>
-     *
-     * <p><b>Lock yield:</b> this method is called from inside a tool's {@code execute()},
-     * which holds two locks: the global write-tool semaphore and the per-tool sync lock
-     * (both managed by {@link PsiBridgeService#callTool}). Without yielding both, a second
-     * call to the same tool from another mcp-http thread deadlocks: the second thread acquires
-     * the semaphore (released here) but then waits for the syncLock, while this thread still
-     * holds the syncLock and waits to re-acquire the semaphore. We release both before blocking
-     * and re-acquire both afterward (semaphore first, then syncLock — matching callTool's
-     * acquisition order) to break the circular dependency.</p>
-     *
-     * @param operation description of the git operation (for the notification + error)
-     * @return null if review completed in time; otherwise a timeout error message
-     */
-    // S2222: syncLock.lock() in this finally block intentionally re-acquires a lock that was
-    // originally acquired by callTool(). Sonar cannot trace cross-method lock ownership.
-    // The lock is released by callTool's own finally block, maintaining correct lock ordering.
+    private static @NotNull String formatRanges(@NotNull List<ChangeRange> ranges) {
+        if (ranges.isEmpty()) return "";
+        StringBuilder sb = new StringBuilder(":");
+        boolean first = true;
+        for (ChangeRange r : ranges) {
+            if (!first) sb.append(',');
+            first = false;
+            int start = r.startLine() + 1;
+            int end = Math.max(start, r.endLine());
+            if (start == end) sb.append(start);
+            else sb.append(start).append('-').append(end);
+        }
+        return sb.toString();
+    }
+
+    private @Nullable String readCurrentContent(@NotNull String path) {
+        VirtualFile vf = LocalFileSystem.getInstance().findFileByPath(path);
+        if (vf == null) return null;
+        Document doc = FileDocumentManager.getInstance().getDocument(vf);
+        if (doc == null) return null;
+        return ApplicationManager.getApplication().runReadAction((Computable<String>) doc::getText);
+    }
+
+    private static @NotNull String buildUnifiedDiff(@NotNull String before, @NotNull String after) {
+        String[] beforeLines = Diff.splitLines(before);
+        String[] afterLines = Diff.splitLines(after);
+        try {
+            Diff.Change change = Diff.buildChanges(beforeLines, afterLines);
+            StringBuilder sb = new StringBuilder();
+            sb.append("```diff\n");
+            while (change != null) {
+                sb.append("@@ -").append(change.line0 + 1).append(',').append(change.deleted)
+                    .append(" +").append(change.line1 + 1).append(',').append(change.inserted)
+                    .append(" @@\n");
+                for (int i = 0; i < change.deleted && (change.line0 + i) < beforeLines.length; i++) {
+                    sb.append('-').append(beforeLines[change.line0 + i]);
+                    if (!sb.toString().endsWith("\n")) sb.append('\n');
+                }
+                for (int i = 0; i < change.inserted && (change.line1 + i) < afterLines.length; i++) {
+                    sb.append('+').append(afterLines[change.line1 + i]);
+                    if (!sb.toString().endsWith("\n")) sb.append('\n');
+                }
+                change = change.link;
+            }
+            sb.append("```");
+            return sb.toString();
+        } catch (FilesTooBigForDiffException e) {
+            return "```\n(diff too large to render)\n```";
+        }
+    }
+
+    // ── Gating ──────────────────────────────────────────────────────────────
+
     @SuppressWarnings("java:S2222")
     public @Nullable String awaitReviewCompletion(@NotNull String operation) {
-        if (!active || !hasChanges()) {
+        if (!hasPendingChanges()) {
             reviewNotificationFired = false;
             return null;
         }
 
-        int fileCount = getReviewItems().size();
+        int fileCount = countPending();
 
         if (!reviewNotificationFired) {
             reviewNotificationFired = true;
             notifyReviewRequired(operation);
         }
-        // Always expand the review panel so the user sees what's blocked.
         ApplicationManager.getApplication().invokeLater(() -> {
             if (project.isDisposed()) return;
             com.github.catatafishen.agentbridge.ui.review.ReviewPanelController
@@ -480,24 +725,22 @@ public final class AgentEditSession implements Disposable {
 
         PsiBridgeService psi = PsiBridgeService.getInstance(project);
         java.util.concurrent.Semaphore writeSemaphore = psi.getWriteToolSemaphore();
-        // Read the syncLock BEFORE releasing anything — it is a ThreadLocal on this thread.
         java.util.concurrent.locks.ReentrantLock syncLock = psi.getCurrentSyncLock();
 
-        // Release the syncLock first (if any), then the semaphore.
-        // Reversed acquisition order breaks the circular-wait condition.
         if (syncLock != null) syncLock.unlock();
         writeSemaphore.release();
         try {
-            // Re-check after releasing locks: the EDT can call completeReviewIfEmpty() at
-            // any time, including in the window between the checks above and getOrCreate().
-            // If it ran with a null future (no changes left), we must not hang on get().
-            while (active && hasChanges()) {
+            while (hasPendingChanges() && pendingGateCancelMessage == null) {
                 java.util.concurrent.CompletableFuture<Void> future = getOrCreateReviewCompletionFuture();
-                // Guard: if the EDT cleared all changes between creating the future and now
-                // (and therefore completed or never completed it), avoid waiting.
-                if (!active || !hasChanges()) break;
+                if (!hasPendingChanges() || pendingGateCancelMessage != null) break;
                 future.get(REVIEW_WAIT_TIMEOUT_MINUTES, java.util.concurrent.TimeUnit.MINUTES);
             }
+            String cancelMessage = pendingGateCancelMessage;
+            if (cancelMessage != null) {
+                pendingGateCancelMessage = null;
+                return "Error: " + operation + " cancelled by user revert.\n" + cancelMessage;
+            }
+            flushBufferedRevertsToPendingNudge();
             return null;
         } catch (java.util.concurrent.TimeoutException e) {
             return formatReviewTimeoutError(operation, fileCount);
@@ -507,12 +750,17 @@ public final class AgentEditSession implements Disposable {
         } catch (java.util.concurrent.ExecutionException e) {
             return "Error: Review wait failed: " + e.getCause();
         } finally {
-            // Re-acquire in the same order as callTool: semaphore first, then syncLock.
-            // acquireUninterruptibly: we must re-acquire even if the thread was interrupted,
-            // otherwise callTool's finally block would over-release the semaphore.
             writeSemaphore.acquireUninterruptibly();
             if (syncLock != null) syncLock.lock();
         }
+    }
+
+    private int countPending() {
+        int n = 0;
+        for (Map.Entry<String, ApprovalState> e : approvals.entrySet()) {
+            if (e.getValue() == ApprovalState.PENDING && pathIsTracked(e.getKey())) n++;
+        }
+        return n;
     }
 
     private synchronized java.util.concurrent.CompletableFuture<Void> getOrCreateReviewCompletionFuture() {
@@ -524,48 +772,36 @@ public final class AgentEditSession implements Disposable {
         return f;
     }
 
-    /**
-     * Package-private pure formatter — extracted so unit tests can verify the wording
-     * without needing a {@link Project} or the message bus.
-     */
+    private void completeGate() {
+        java.util.concurrent.CompletableFuture<Void> f = reviewCompletionFuture;
+        if (f != null && !f.isDone()) {
+            f.complete(null);
+        }
+    }
+
+    private void completeGateIfNoPending() {
+        if (hasPendingChanges()) return;
+        reviewNotificationFired = false;
+        completeGate();
+    }
+
+    private void flushBufferedRevertsToPendingNudge() {
+        String merged;
+        synchronized (gateRevertBuffer) {
+            if (gateRevertBuffer.isEmpty()) return;
+            merged = String.join("\n\n", gateRevertBuffer);
+            gateRevertBuffer.clear();
+        }
+        PsiBridgeService.getInstance(project).setPendingNudge(merged);
+    }
+
     static @NotNull String formatReviewTimeoutError(@NotNull String operation, int fileCount) {
         return "Error: Timed out after " + REVIEW_WAIT_TIMEOUT_MINUTES
             + " minutes waiting for the user to review " + fileCount
             + (fileCount == 1 ? " agent-edited file" : " agent-edited files")
             + " before '" + operation
-            + "' could run. Ask the user to accept/reject the pending edits in the"
-            + " Review panel (left of chat), or end the review session, then retry.";
-    }
-
-    private static final long REVIEW_WAIT_TIMEOUT_MINUTES = 10;
-
-    /**
-     * Reverts a file to its pre-session state.
-     *
-     * @param vf     the file to revert
-     * @param reason optional reason for the revert (sent as nudge to agent)
-     */
-    public void revertFile(@NotNull VirtualFile vf, @Nullable String reason) {
-        String before = snapshots.remove(vf.getPath());
-        if (before == null) return;
-
-        Document doc = FileDocumentManager.getInstance().getDocument(vf);
-        if (doc == null) return;
-
-        WriteCommandAction.runWriteCommandAction(project, "Revert Agent Edit", null,
-            () -> doc.setText(before));
-        FileDocumentManager.getInstance().saveDocument(doc);
-
-        // Mirror acceptFile()/rejectFile(): clear highlights, refresh banner, and update review state
-        // so the file no longer shows up in the Review panel and any blocked git gate can proceed.
-        AgentEditHighlighter.getInstance(project).clearForFile(vf);
-        com.intellij.ui.EditorNotifications.getInstance(project).updateNotifications(vf);
-
-        if (reason != null && !reason.isBlank()) {
-            sendRevertNudge(vf, reason);
-        }
-        fireReviewStateChanged();
-        completeReviewIfEmpty();
+            + "' could run. Ask the user to accept or revert the pending edits in the"
+            + " Review panel (left of chat), then retry.";
     }
 
     public synchronized void endSession() {
@@ -595,23 +831,42 @@ public final class AgentEditSession implements Disposable {
 
         LOG.info("Agent edit review session ended");
     }
+    }
 
     @Override
     public void dispose() {
-        endSession();
+        wipeAllTrackedState();
+        completeGate();
+        if (sessionDisposable != null) {
+            Disposer.dispose(sessionDisposable);
+            sessionDisposable = null;
+        }
     }
+
+    private void wipeAllTrackedState() {
+        AgentEditHighlighter.getInstance(project).clearAll();
+        snapshots.clear();
+        deletedFiles.clear();
+        newFiles.clear();
+        approvals.clear();
+        lastEditedAt.clear();
+        linesAdded.clear();
+        linesRemoved.clear();
+        synchronized (gateRevertBuffer) {
+            gateRevertBuffer.clear();
+        }
+        pendingGateCancelMessage = null;
+        reviewNotificationFired = false;
+        com.intellij.ui.EditorNotifications.getInstance(project).updateAllNotifications();
+        fireReviewStateChanged();
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
 
     private boolean isProjectFile(@NotNull VirtualFile vf) {
         if (!vf.isValid() || vf.isDirectory()) return false;
         return ApplicationManager.getApplication().runReadAction(
             (Computable<Boolean>) () -> ProjectFileIndex.getInstance(project).isInContent(vf));
-    }
-
-    private void sendRevertNudge(@NotNull VirtualFile vf, @NotNull String reason) {
-        String relativePath = getRelativePath(vf);
-        String nudge = "[User reverted " + relativePath + "]: " + reason
-            + "\nPlease try a different approach for this file.";
-        PsiBridgeService.getInstance(project).setPendingNudge(nudge);
     }
 
     private @NotNull String getRelativePath(@NotNull VirtualFile vf) {
@@ -630,102 +885,63 @@ public final class AgentEditSession implements Disposable {
         return new java.io.File(path).getName();
     }
 
-    /**
-     * Rejects a single review item without firing topic events (used in bulk reject).
-     */
-    private void rejectFileSilent(@NotNull ReviewItem item) {
-        switch (item.status()) {
-            case MODIFIED -> rejectModifiedFile(item);
-            case ADDED -> rejectAddedFile(item);
-            case DELETED -> rejectDeletedFile(item);
-        }
+    private @NotNull Set<String> collectAllPaths() {
+        Set<String> paths = new HashSet<>();
+        paths.addAll(snapshots.keySet());
+        paths.addAll(newFiles);
+        paths.addAll(deletedFiles.keySet());
+        return paths;
     }
 
-    /**
-     * Restores a MODIFIED file to its snapshot content and clears editor decorations.
-     */
-    private void rejectModifiedFile(@NotNull ReviewItem item) {
-        String path = item.path();
-        String snapshot = snapshots.remove(path);
-        if (snapshot == null) return;
+    private void recomputeLineCounts(@NotNull String path) {
         VirtualFile vf = LocalFileSystem.getInstance().findFileByPath(path);
-        if (vf == null) return;
+        String before = snapshots.get(path);
+        if (vf == null || before == null) return;
         Document doc = FileDocumentManager.getInstance().getDocument(vf);
-        if (doc != null) {
-            WriteCommandAction.runWriteCommandAction(project, "Reject Agent Edit", null,
-                () -> doc.setText(snapshot));
-            FileDocumentManager.getInstance().saveDocument(doc);
+        if (doc == null) return;
+        String after = ApplicationManager.getApplication().runReadAction(
+            (Computable<String>) doc::getText);
+        int added = 0;
+        int removed = 0;
+        for (ChangeRange r : computeRanges(before, after)) {
+            added += r.insertedCount();
+            removed += r.deletedCount();
         }
-        AgentEditHighlighter.getInstance(project).clearForFile(vf);
-        com.intellij.ui.EditorNotifications.getInstance(project).updateNotifications(vf);
+        linesAdded.put(path, added);
+        linesRemoved.put(path, removed);
     }
 
     /**
-     * Deletes an ADDED (agent-created) file and clears editor decorations.
+     * Drops oldest APPROVED rows until total snapshot bytes are under the project-wide
+     * cap. Pending rows are never auto-evicted — the user controls them.
      */
-    private void rejectAddedFile(@NotNull ReviewItem item) {
-        String path = item.path();
-        newFiles.remove(path);
-        VirtualFile vf = LocalFileSystem.getInstance().findFileByPath(path);
-        if (vf == null) return;
-        AgentEditHighlighter.getInstance(project).clearForFile(vf);
-        WriteCommandAction.runWriteCommandAction(project, "Delete Agent-Created File", null, () -> {
-            try {
-                vf.delete(this);
-            } catch (Exception e) {
-                LOG.warn("Failed to delete agent-created file: " + path, e);
-            }
-        });
+    private void enforceTotalSnapshotCap() {
+        long total = totalSnapshotBytes();
+        if (total <= MAX_TOTAL_SNAPSHOT_BYTES) return;
+
+        List<Map.Entry<String, Long>> approved = new ArrayList<>();
+        for (Map.Entry<String, Long> e : lastEditedAt.entrySet()) {
+            if (approvals.get(e.getKey()) == ApprovalState.APPROVED) approved.add(e);
+        }
+        approved.sort(Map.Entry.comparingByValue());
+        for (Map.Entry<String, Long> e : approved) {
+            if (totalSnapshotBytes() <= MAX_TOTAL_SNAPSHOT_BYTES) return;
+            clearTrackedPath(e.getKey());
+        }
     }
 
-    /**
-     * Recreates a DELETED file from its original content (prefers snapshot over deletion-time capture).
-     */
-    private void rejectDeletedFile(@NotNull ReviewItem item) {
-        String path = item.path();
-        String content = deletedFiles.remove(path);
-        String snapshotContent = snapshots.remove(path);
-        String restore = snapshotContent != null ? snapshotContent : content;
-        if (restore == null) return;
-        WriteCommandAction.runWriteCommandAction(project, "Restore Deleted File", null, () -> {
-            try {
-                java.io.File ioFile = new java.io.File(path);
-                java.io.File parent = ioFile.getParentFile();
-                if (parent != null) {
-                    VirtualFile parentVf = LocalFileSystem.getInstance()
-                        .refreshAndFindFileByIoFile(parent);
-                    if (parentVf != null) {
-                        VirtualFile created = parentVf.createChildData(this, ioFile.getName());
-                        created.setBinaryContent(restore.getBytes(StandardCharsets.UTF_8));
-                    }
-                }
-            } catch (Exception e) {
-                LOG.warn("Failed to restore deleted file: " + path, e);
-            }
-        });
+    private long totalSnapshotBytes() {
+        long total = 0;
+        for (String s : snapshots.values()) total += s.length();
+        for (String s : deletedFiles.values()) total += s.length();
+        return total;
     }
 
     private void fireReviewStateChanged() {
+        if (project.isDisposed()) return;
         project.getMessageBus().syncPublisher(ReviewSessionTopic.TOPIC).reviewStateChanged();
     }
 
-    /**
-     * Resets the notification flag when the review batch is fully resolved so a future
-     * agent edit cycle will re-notify when gating fires again.
-     */
-    private void completeReviewIfEmpty() {
-        if (hasChanges()) return;
-        reviewNotificationFired = false;
-        java.util.concurrent.CompletableFuture<Void> f = reviewCompletionFuture;
-        if (f != null && !f.isDone()) {
-            f.complete(null);
-        }
-    }
-
-    /**
-     * Sends notifications (IntelliJ balloon + system + web push) when a git operation
-     * is blocked waiting for review completion.
-     */
     private void notifyReviewRequired(@NotNull String operation) {
         String title = "Review Required";
         String body = "'" + operation + "' is waiting for you to review agent edits.";
@@ -735,7 +951,6 @@ public final class AgentEditSession implements Disposable {
                 "AgentBridge", MessageType.WARNING,
                 "<b>" + title + "</b><br>" + body
             );
-            // Expand the inline Review panel and activate the tool window
             com.github.catatafishen.agentbridge.ui.review.ReviewPanelController
                 .getInstance(project).expandReviewPanel();
         });
@@ -749,47 +964,57 @@ public final class AgentEditSession implements Disposable {
         }
     }
 
+    // ── Listeners ───────────────────────────────────────────────────────────
+
     private class SessionDocumentListener implements DocumentListener {
 
         @Override
         public void beforeDocumentChange(@NotNull DocumentEvent event) {
-            if (!active) return;
-            // Only capture snapshots during agent-originated tool edits.
-            // Non-agent changes (branch switches, IDE reformats, user typing)
-            // would pollute the session with incorrect "before" content.
             if (!isAgentEditActive()) return;
 
             Document doc = event.getDocument();
             VirtualFile vf = FileDocumentManager.getInstance().getFile(doc);
             if (vf == null || !vf.isValid()) return;
 
+            String path = vf.getPath();
+            // Re-edit of an APPROVED row: rebase the snapshot to the just-approved state
+            // (so the diff shows only the *new* hunks, not the cumulative ones).
+            if (approvals.get(path) == ApprovalState.APPROVED && snapshots.containsKey(path)) {
+                String currentText = doc.getText();
+                snapshots.put(path, currentText);
+                if (!isAutoApproveOn()) {
+                    approvals.put(path, ApprovalState.PENDING);
+                }
+                lastEditedAt.put(path, System.currentTimeMillis());
+                AgentEditHighlighter.getInstance(project).clearForFile(vf);
+                fireReviewStateChanged();
+                return;
+            }
+
             captureBeforeContent(vf, doc.getText());
         }
 
         @Override
         public void documentChanged(@NotNull DocumentEvent event) {
-            if (!active) return;
-
             Document doc = event.getDocument();
             VirtualFile vf = FileDocumentManager.getInstance().getFile(doc);
             if (vf == null || !vf.isValid()) return;
 
             if (snapshots.containsKey(vf.getPath())) {
                 AgentEditHighlighter.getInstance(project).refreshHighlights(vf);
+                if (isAgentEditActive()) {
+                    recomputeLineCounts(vf.getPath());
+                    lastEditedAt.put(vf.getPath(), System.currentTimeMillis());
+                    fireReviewStateChanged();
+                }
             }
         }
     }
 
-    /**
-     * Safety-net VFS listener: captures file lifecycle events (create, delete, rename, move)
-     * that the DocumentListener cannot detect.
-     */
     private class SessionVfsListener implements BulkFileListener {
 
         @Override
         public void before(@NotNull List<? extends VFileEvent> events) {
-            if (!active) return;
-
             for (VFileEvent event : events) {
                 if (event instanceof VFileDeleteEvent deleteEvent) {
                     handleBeforeDelete(deleteEvent);
@@ -804,12 +1029,10 @@ public final class AgentEditSession implements Disposable {
 
         @Override
         public void after(@NotNull List<? extends VFileEvent> events) {
-            if (!active) return;
-
             for (VFileEvent event : events) {
                 if (event instanceof VFileCreateEvent) {
                     VirtualFile vf = event.getFile();
-                    if (vf != null && !vf.isDirectory() && isProjectFile(vf)) {
+                    if (vf != null && !vf.isDirectory() && isProjectFile(vf) && isAgentEditActive()) {
                         registerNewFile(vf.getPath());
                     }
                 } else if (event instanceof VFileMoveEvent moveEvent) {
@@ -824,10 +1047,7 @@ public final class AgentEditSession implements Disposable {
         private void handleBeforeDelete(@NotNull VFileDeleteEvent event) {
             VirtualFile vf = event.getFile();
             if (vf.isDirectory() || !isProjectFile(vf)) return;
-            // Only capture agent-initiated deletes (same guard as beforeDocumentChange).
-            // User-initiated deletes must not be registered as agent edits.
             if (!isAgentEditActive()) return;
-
             if (newFiles.remove(vf.getPath())) return;
 
             try {
@@ -841,10 +1061,6 @@ public final class AgentEditSession implements Disposable {
             }
         }
 
-        /**
-         * Tags a file with its current path before rename/move so we can update
-         * path-based tracking after the event completes.
-         */
         private void tagOldPath(@NotNull VirtualFile vf) {
             if (vf.isDirectory()) return;
             String path = vf.getPath();
@@ -853,10 +1069,6 @@ public final class AgentEditSession implements Disposable {
             }
         }
 
-        /**
-         * Updates path-based tracking maps when a file is renamed or moved.
-         * Transfers snapshot and newFiles entries from the old path to the new path.
-         */
         private void transferPathTracking(@NotNull VirtualFile vf) {
             String oldPath = vf.getUserData(OLD_PATH_KEY);
             if (oldPath == null) return;
@@ -869,6 +1081,110 @@ public final class AgentEditSession implements Disposable {
             if (newFiles.remove(oldPath)) {
                 newFiles.add(vf.getPath());
             }
+            ApprovalState st = approvals.remove(oldPath);
+            if (st != null) approvals.put(vf.getPath(), st);
+            Long ts = lastEditedAt.remove(oldPath);
+            if (ts != null) lastEditedAt.put(vf.getPath(), ts);
+            Integer la = linesAdded.remove(oldPath);
+            if (la != null) linesAdded.put(vf.getPath(), la);
+            Integer lr = linesRemoved.remove(oldPath);
+            if (lr != null) linesRemoved.put(vf.getPath(), lr);
         }
+    }
+
+    // ── PersistentStateComponent ────────────────────────────────────────────
+
+    @Override
+    public @Nullable PersistedState getState() {
+        PersistedState state = new PersistedState();
+        state.snapshots = new LinkedHashMap<>(snapshots);
+        state.deletedFiles = new LinkedHashMap<>(deletedFiles);
+        state.newFiles = new ArrayList<>(newFiles);
+        Map<String, String> approvalsAsString = new LinkedHashMap<>();
+        for (Map.Entry<String, ApprovalState> e : approvals.entrySet()) {
+            approvalsAsString.put(e.getKey(), e.getValue().name());
+        }
+        state.approvals = approvalsAsString;
+        Map<String, String> tsAsString = new LinkedHashMap<>();
+        for (Map.Entry<String, Long> e : lastEditedAt.entrySet()) {
+            tsAsString.put(e.getKey(), Long.toString(e.getValue()));
+        }
+        state.lastEditedAt = tsAsString;
+        Map<String, String> addedAsString = new LinkedHashMap<>();
+        for (Map.Entry<String, Integer> e : linesAdded.entrySet()) {
+            addedAsString.put(e.getKey(), Integer.toString(e.getValue()));
+        }
+        state.linesAdded = addedAsString;
+        Map<String, String> removedAsString = new LinkedHashMap<>();
+        for (Map.Entry<String, Integer> e : linesRemoved.entrySet()) {
+            removedAsString.put(e.getKey(), Integer.toString(e.getValue()));
+        }
+        state.linesRemoved = removedAsString;
+        return state;
+    }
+
+    @Override
+    public void loadState(@NotNull PersistedState state) {
+        snapshots.clear();
+        if (state.snapshots != null) snapshots.putAll(state.snapshots);
+        deletedFiles.clear();
+        if (state.deletedFiles != null) deletedFiles.putAll(state.deletedFiles);
+        newFiles.clear();
+        if (state.newFiles != null) newFiles.addAll(state.newFiles);
+
+        approvals.clear();
+        if (state.approvals != null) {
+            for (Map.Entry<String, String> e : state.approvals.entrySet()) {
+                try {
+                    approvals.put(e.getKey(), ApprovalState.valueOf(e.getValue()));
+                } catch (IllegalArgumentException ignored) {
+                    approvals.put(e.getKey(), ApprovalState.PENDING);
+                }
+            }
+        }
+        lastEditedAt.clear();
+        if (state.lastEditedAt != null) {
+            for (Map.Entry<String, String> e : state.lastEditedAt.entrySet()) {
+                try {
+                    lastEditedAt.put(e.getKey(), Long.parseLong(e.getValue()));
+                } catch (NumberFormatException ignored) {
+                    // skip malformed entries
+                }
+            }
+        }
+        linesAdded.clear();
+        if (state.linesAdded != null) {
+            for (Map.Entry<String, String> e : state.linesAdded.entrySet()) {
+                try {
+                    linesAdded.put(e.getKey(), Integer.parseInt(e.getValue()));
+                } catch (NumberFormatException ignored) {
+                    // skip malformed entries
+                }
+            }
+        }
+        linesRemoved.clear();
+        if (state.linesRemoved != null) {
+            for (Map.Entry<String, String> e : state.linesRemoved.entrySet()) {
+                try {
+                    linesRemoved.put(e.getKey(), Integer.parseInt(e.getValue()));
+                } catch (NumberFormatException ignored) {
+                    // skip malformed entries
+                }
+            }
+        }
+    }
+
+    /**
+     * Serialized review state. All maps use {@code String} values so IntelliJ's
+     * {@code XmlSerializer} can round-trip them without custom converters.
+     */
+    public static final class PersistedState {
+        public Map<String, String> snapshots = new HashMap<>();
+        public Map<String, String> deletedFiles = new HashMap<>();
+        public List<String> newFiles = new ArrayList<>();
+        public Map<String, String> approvals = new HashMap<>();
+        public Map<String, String> lastEditedAt = new HashMap<>();
+        public Map<String, String> linesAdded = new HashMap<>();
+        public Map<String, String> linesRemoved = new HashMap<>();
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
@@ -83,7 +83,9 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
 
     private static final Logger LOG = Logger.getInstance(AgentEditSession.class);
 
-    /** Skip snapshotting files larger than 5 MB to avoid memory bloat. */
+    /**
+     * Skip snapshotting files larger than 5 MB to avoid memory bloat.
+     */
     private static final long MAX_SNAPSHOT_BYTES = 5L * 1024 * 1024;
 
     /**
@@ -95,7 +97,9 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
 
     private static final long REVIEW_WAIT_TIMEOUT_MINUTES = 10;
 
-    /** UserData key for tracking old path during rename/move events. */
+    /**
+     * UserData key for tracking old path during rename/move events.
+     */
     private static final Key<String> OLD_PATH_KEY = Key.create("AgentEditSession.oldPath");
 
     /**
@@ -119,19 +123,33 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
 
     private final Project project;
 
-    /** Before-content snapshots keyed by canonical VFS path. */
+    /**
+     * Before-content snapshots keyed by canonical VFS path.
+     */
     private final Map<String, String> snapshots = new ConcurrentHashMap<>();
-    /** Content of files deleted during the session, keyed by path. */
+    /**
+     * Content of files deleted during the session, keyed by path.
+     */
     private final Map<String, String> deletedFiles = new ConcurrentHashMap<>();
-    /** Paths of files created during the session. */
+    /**
+     * Paths of files created during the session.
+     */
     private final Set<String> newFiles = ConcurrentHashMap.newKeySet();
-    /** User approval state per path. */
+    /**
+     * User approval state per path.
+     */
     private final Map<String, ApprovalState> approvals = new ConcurrentHashMap<>();
-    /** Epoch millis of the most recent agent edit per path. */
+    /**
+     * Epoch millis of the most recent agent edit per path.
+     */
     private final Map<String, Long> lastEditedAt = new ConcurrentHashMap<>();
-    /** Inserted line count vs. the snapshot baseline. */
+    /**
+     * Inserted line count vs. the snapshot baseline.
+     */
     private final Map<String, Integer> linesAdded = new ConcurrentHashMap<>();
-    /** Deleted line count vs. the snapshot baseline. */
+    /**
+     * Deleted line count vs. the snapshot baseline.
+     */
     private final Map<String, Integer> linesRemoved = new ConcurrentHashMap<>();
 
     private Disposable sessionDisposable;
@@ -338,7 +356,9 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
         return false;
     }
 
-    /** True while {@link #awaitReviewCompletion} is blocking on a future. */
+    /**
+     * True while {@link #awaitReviewCompletion} is blocking on a future.
+     */
     public boolean isGateActive() {
         java.util.concurrent.CompletableFuture<Void> f = reviewCompletionFuture;
         return f != null && !f.isDone();
@@ -383,7 +403,9 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
 
     // ── Approval mutations ──────────────────────────────────────────────────
 
-    /** Flips a single row to APPROVED. Keeps the row visible. */
+    /**
+     * Flips a single row to APPROVED. Keeps the row visible.
+     */
     public void acceptFile(@NotNull String path) {
         if (!pathIsTracked(path)) return;
         approvals.put(path, ApprovalState.APPROVED);
@@ -395,7 +417,23 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
         completeGateIfNoPending();
     }
 
-    /** Flips every PENDING row to APPROVED. Used by the "Auto-Approve ON" sweep. */
+    /**
+     * Flips a single row back to PENDING.
+     */
+    public void unapproveFile(@NotNull String path) {
+        if (!pathIsTracked(path)) return;
+        if (approvals.get(path) != ApprovalState.APPROVED) return;
+        approvals.put(path, ApprovalState.PENDING);
+        VirtualFile vf = LocalFileSystem.getInstance().findFileByPath(path);
+        if (vf != null) {
+            com.intellij.ui.EditorNotifications.getInstance(project).updateNotifications(vf);
+        }
+        fireReviewStateChanged();
+    }
+
+    /**
+     * Flips every PENDING row to APPROVED. Used by the "Auto-Approve ON" sweep.
+     */
     public void acceptAll() {
         boolean changed = false;
         for (String path : collectAllPaths()) {
@@ -420,7 +458,9 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
         fireReviewStateChanged();
     }
 
-    /** Removes every APPROVED row. */
+    /**
+     * Removes every APPROVED row.
+     */
     public void removeAllApproved() {
         List<String> approved = new ArrayList<>();
         for (Map.Entry<String, ApprovalState> e : approvals.entrySet()) {
@@ -476,15 +516,23 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
 
     // ── Revert (always sends a structured nudge) ────────────────────────────
 
-    /** What to do with the in-flight gate when reverting during a blocked git op. */
+    /**
+     * What to do with the in-flight gate when reverting during a blocked git op.
+     */
     public enum RevertGateAction {
-        /** Queue the nudge into pendingNudge; keep the gate blocking so the user can
-         * reject more files. Subsequent reverts during the same gate default here. */
+        /**
+         * Queue the nudge into pendingNudge; keep the gate blocking so the user can
+         * reject more files. Subsequent reverts during the same gate default here.
+         */
         CONTINUE_REVIEWING,
-        /** Short-circuit the gate immediately — the gated tool returns the merged
-         * revert nudges as its error response so the agent can re-plan. */
+        /**
+         * Short-circuit the gate immediately — the gated tool returns the merged
+         * revert nudges as its error response so the agent can re-plan.
+         */
         SEND_NOW,
-        /** Plain revert with no gate special-casing (used when no gate is active). */
+        /**
+         * Plain revert with no gate special-casing (used when no gate is active).
+         */
         DEFAULT
     }
 
@@ -544,7 +592,9 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
         completeGateIfNoPending();
     }
 
-    /** Convenience overload for callers that have a {@link VirtualFile}. */
+    /**
+     * Convenience overload for callers that have a {@link VirtualFile}.
+     */
     public void revertFile(@NotNull VirtualFile vf, @Nullable String reason) {
         revertFile(vf.getPath(), reason, RevertGateAction.DEFAULT);
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/ApprovalState.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/ApprovalState.java
@@ -1,0 +1,23 @@
+package com.github.catatafishen.agentbridge.psi.review;
+
+/**
+ * The user-controlled review state of a tracked file.
+ *
+ * <p>This is orthogonal to {@link ReviewItem.Status}: a row's {@code Status} describes the
+ * <i>kind</i> of change the agent made (added / modified / deleted), while
+ * {@code ApprovalState} describes whether the user has signed off on it. A file always has
+ * exactly one {@code Status} <i>and</i> exactly one {@code ApprovalState}.
+ *
+ * <p>New rows always start as {@link #PENDING}; toggling Auto-Approve on flips every
+ * pending row to {@link #APPROVED} immediately. The git-gate only blocks on pending rows.
+ */
+public enum ApprovalState {
+    /** The user has not yet acknowledged the change. Blocks git gates. */
+    PENDING,
+    /**
+     * The user has approved the change. The row stays visible in the panel until it is
+     * cleaned up (DEL key, "Clean Approved" toolbar action, post-commit prune, or
+     * worktree-changing git op). Approved rows do not block git gates.
+     */
+    APPROVED
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/RevertAgentEditsAction.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/RevertAgentEditsAction.java
@@ -41,12 +41,16 @@ public final class RevertAgentEditsAction extends AnAction {
         if (!session.isActive() || session.getSnapshot(vf) == null) return;
 
         String relativePath = toRelativePath(project, vf);
-        RevertReasonDialog dialog = new RevertReasonDialog(project, vf, relativePath);
+        RevertReasonDialog dialog = new RevertReasonDialog(project, vf, relativePath, session.isGateActive());
         if (!dialog.showAndGet()) {
             return;
         }
-
-        session.revertFile(vf, dialog.getReason());
+        AgentEditSession.RevertGateAction gateAction = switch (dialog.getResult()) {
+            case CONTINUE_REVIEWING -> AgentEditSession.RevertGateAction.CONTINUE_REVIEWING;
+            case SEND_NOW -> AgentEditSession.RevertGateAction.SEND_NOW;
+            default -> AgentEditSession.RevertGateAction.DEFAULT;
+        };
+        session.revertFile(vf.getPath(), dialog.getReason(), gateAction);
     }
 
     private static @NotNull String toRelativePath(@NotNull Project project,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/RevertReasonDialog.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/RevertReasonDialog.java
@@ -9,6 +9,8 @@ import com.intellij.util.ui.JBUI;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.swing.AbstractAction;
+import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -17,26 +19,61 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.event.ActionEvent;
 
 /**
  * Modal dialog asking the user to confirm a revert and (optionally) provide a reason
- * that will be forwarded to the agent as a nudge. The reason is free-form text; an
- * empty value skips the nudge and performs a silent revert.
+ * that becomes part of the structured nudge sent to the agent.
+ *
+ * <p>When called while a review gate is active (a git tool blocked on
+ * {@link AgentEditSession#awaitReviewCompletion}), the dialog exposes a third action —
+ * <b>Continue reviewing</b> — so the user can reject several files in the same review
+ * pass without the gated tool short-circuiting on the first rejection. The default
+ * action in that mode becomes <b>Continue reviewing</b>; <b>Send to agent now</b>
+ * remains available as the explicit "I'm done, abort the gate" choice.</p>
+ *
+ * <p>Outside a gate the dialog has only <b>Revert</b> (which fires the nudge into the
+ * normal pendingNudge path) and <b>Cancel</b>.</p>
  */
 public final class RevertReasonDialog extends DialogWrapper {
 
+    /** What the user chose to do with the revert. */
+    public enum Result {
+        /** Cancel — no revert happens. */
+        CANCEL,
+        /** Revert and send the nudge into the normal pending-nudge channel. */
+        REVERT,
+        /** Revert, queue the nudge, but keep the gate blocking. */
+        CONTINUE_REVIEWING,
+        /** Revert and short-circuit the gate immediately. */
+        SEND_NOW
+    }
+
     private final VirtualFile file;
     private final String relativePath;
+    private final boolean gateActive;
     private JBTextArea reasonArea;
+    private Result result = Result.CANCEL;
 
     public RevertReasonDialog(@NotNull Project project,
                               @NotNull VirtualFile file,
                               @NotNull String relativePath) {
+        this(project, file, relativePath, false);
+    }
+
+    /**
+     * @param gateActive when {@code true}, exposes the "Continue reviewing" option and
+     *                   makes it the default action.
+     */
+    public RevertReasonDialog(@NotNull Project project,
+                              @NotNull VirtualFile file,
+                              @NotNull String relativePath,
+                              boolean gateActive) {
         super(project, false);
         this.file = file;
         this.relativePath = relativePath;
+        this.gateActive = gateActive;
         setTitle("Revert Agent Edit");
-        setOKButtonText("Revert");
         init();
     }
 
@@ -47,12 +84,16 @@ public final class RevertReasonDialog extends DialogWrapper {
         panel.setBorder(JBUI.Borders.empty(8));
 
         JBLabel header = new JBLabel(
-            "<html>Revert <b>" + escapeHtml(relativePath) + "</b> to its pre-session state?</html>");
+            "<html>Revert <b>" + escapeHtml(relativePath) + "</b> to its pre-edit state?</html>");
         panel.add(header);
         panel.add(Box.createVerticalStrut(8));
 
-        JBLabel hint = new JBLabel(
-            "<html><i>Optional: explain why. This is sent to the agent as a nudge so it can try a different approach.</i></html>");
+        String hintHtml = gateActive
+            ? "<html><i>A git operation is currently waiting for review.<br>"
+                + "<b>Continue reviewing</b> queues this revert and keeps the gate blocking so you can reject more files.<br>"
+                + "<b>Send to agent now</b> aborts the gate immediately with all queued reverts.</i></html>"
+            : "<html><i>Optional: explain why. The reason and a unified diff are sent to the agent as a nudge so it can try a different approach.</i></html>";
+        JBLabel hint = new JBLabel(hintHtml);
         panel.add(hint);
         panel.add(Box.createVerticalStrut(4));
 
@@ -71,8 +112,26 @@ public final class RevertReasonDialog extends DialogWrapper {
     }
 
     @Override
+    protected Action @NotNull [] createActions() {
+        if (gateActive) {
+            Action continueAction = new RevertAction("Continue reviewing", Result.CONTINUE_REVIEWING);
+            continueAction.putValue(DEFAULT_ACTION, Boolean.TRUE);
+            Action sendNowAction = new RevertAction("Send to agent now", Result.SEND_NOW);
+            return new Action[] { continueAction, sendNowAction, getCancelAction() };
+        }
+        Action revertAction = new RevertAction("Revert", Result.REVERT);
+        revertAction.putValue(DEFAULT_ACTION, Boolean.TRUE);
+        return new Action[] { revertAction, getCancelAction() };
+    }
+
+    @Override
     public @Nullable JComponent getPreferredFocusedComponent() {
         return reasonArea;
+    }
+
+    /** What the user chose. */
+    public @NotNull Result getResult() {
+        return result;
     }
 
     /** Trimmed reason text, or {@code null} if the user left it empty. */
@@ -86,6 +145,21 @@ public final class RevertReasonDialog extends DialogWrapper {
 
     public @NotNull VirtualFile getFile() {
         return file;
+    }
+
+    private final class RevertAction extends AbstractAction {
+        private final Result chosen;
+
+        RevertAction(@NotNull String name, @NotNull Result chosen) {
+            super(name);
+            this.chosen = chosen;
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            result = chosen;
+            close(OK_EXIT_CODE);
+        }
     }
 
     private static @NotNull String escapeHtml(@NotNull String s) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/ReviewItem.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/ReviewItem.java
@@ -5,26 +5,47 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * A unified view of a single file's review state within an {@link AgentEditSession}.
- * Derived from the session's snapshots, newFiles, and deletedFiles maps.
+ * Derived from the session's tracked maps.
  *
- * @param path           absolute VFS path
- * @param relativePath   project-relative path for display
- * @param status         the file's review status
- * @param beforeContent  the original content (null for ADDED files)
+ * @param path             absolute VFS path
+ * @param relativePath     project-relative path for display
+ * @param status           the kind of change the agent made
+ * @param beforeContent    the original content (null for ADDED files)
+ * @param approvalState    the user's review decision
+ * @param lastEditedMillis epoch millis of the most recent agent edit
+ * @param linesAdded       inserted line count (vs. the snapshot baseline)
+ * @param linesRemoved     deleted line count (vs. the snapshot baseline)
  */
 public record ReviewItem(
     @NotNull String path,
     @NotNull String relativePath,
     @NotNull Status status,
-    @Nullable String beforeContent
+    @Nullable String beforeContent,
+    @NotNull ApprovalState approvalState,
+    long lastEditedMillis,
+    int linesAdded,
+    int linesRemoved
 ) {
 
+    /**
+     * Convenience: is this row currently approved?
+     */
+    public boolean approved() {
+        return approvalState == ApprovalState.APPROVED;
+    }
+
     public enum Status {
-        /** File was created by the agent during this session. */
+        /**
+         * File was created by the agent during this session.
+         */
         ADDED,
-        /** File existed before and was modified by the agent. */
+        /**
+         * File existed before and was modified by the agent.
+         */
         MODIFIED,
-        /** File was deleted by the agent during this session. */
+        /**
+         * File was deleted by the agent during this session.
+         */
         DELETED
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
@@ -128,6 +128,26 @@ public final class GitCommitTool extends GitTool {
 
         if (result.startsWith("Error")) return result;
 
+        // Prune approved review rows for files that are now part of this commit.
+        // Run on EDT-safe pool: AgentEditSession mutations + listeners are EDT-safe.
+        try {
+            String committedNames = runGitQuiet("show", "--name-only", "--format=", "HEAD");
+            if (committedNames != null && !committedNames.isBlank()) {
+                java.util.List<String> paths = new java.util.ArrayList<>();
+                for (String line : committedNames.split("\\r?\\n")) {
+                    String trimmed = line.trim();
+                    if (!trimmed.isEmpty()) paths.add(trimmed);
+                }
+                if (!paths.isEmpty()) {
+                    var session = com.github.catatafishen.agentbridge.psi.PlatformApiCompat
+                        .getService(project, com.github.catatafishen.agentbridge.psi.review.AgentEditSession.class);
+                    if (session != null) session.removeApprovedForCommit(paths);
+                }
+            }
+        } catch (Throwable ignored) {
+            // Best-effort: failure to prune the review list must not affect the commit result.
+        }
+
         // Append committed file list so agent can verify what was included
         String fileStats = runGitQuiet("show", "--stat", "--format=", "HEAD");
         if (fileStats != null && !fileStats.isBlank()) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsTool.java
@@ -509,7 +509,7 @@ public final class RunTestsTool extends TestingTool {
             setTaskNames.invoke(gradleSettings, List.of(taskPrefix + "test"));
 
             var setScriptParameters = gradleSettings.getClass().getMethod("setScriptParameters", String.class);
-            setScriptParameters.invoke(gradleSettings, "--tests " + target);
+            setScriptParameters.invoke(gradleSettings, "--tests " + buildGradleTestFilter(target));
 
             String basePath = project.getBasePath();
             if (basePath != null) {
@@ -873,6 +873,35 @@ public final class RunTestsTool extends TestingTool {
      */
     static String buildGradleTaskPrefix(@NotNull String module) {
         return module.isEmpty() ? "" : ":" + module + ":";
+    }
+
+    /**
+     * Normalises a Gradle {@code --tests} filter argument so it always includes a package qualifier.
+     * <p>
+     * Gradle's {@code --tests} filter requires a pattern in the form
+     * {@code [package.]ClassName[.methodName]}.  A bare simple name such as {@code FormattingTest}
+     * or a wildcard like {@code *Test} is silently rejected with
+     * {@code "No tests found for given includes"} because Gradle interprets it as a root-package
+     * class pattern, not an any-package wildcard.
+     * <p>
+     * Rules applied:
+     * <ul>
+     *   <li>No dot in target (e.g. {@code FormattingTest}, {@code *Test}) → prepend {@code *.}</li>
+     *   <li>Has a dot but first segment starts with an uppercase letter
+     *       (e.g. {@code FormattingTest.testFoo}) → prepend {@code *.}</li>
+     *   <li>Otherwise (e.g. {@code com.example.Foo}, {@code *.*Test}) → return unchanged</li>
+     * </ul>
+     * Pure function — no IDE dependency.
+     */
+    static String buildGradleTestFilter(@NotNull String target) {
+        if (!target.contains(".")) {
+            return "*." + target;
+        }
+        char first = target.charAt(0);
+        if (Character.isUpperCase(first)) {
+            return "*." + target;
+        }
+        return target;
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ChatInputConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ChatInputConfigurable.java
@@ -32,6 +32,10 @@ public final class ChatInputConfigurable implements Configurable {
     private JSpinner scratchRetentionSpinner;
     private JCheckBox autoCloseTabsCheckbox;
     private JCheckBox closeRunningTerminalsCheckbox;
+    private JComboBox<String> unhandledNudgeModeCombo;
+
+    private static final String NUDGE_MODE_AUTO_SEND_LABEL = "Auto-send as a new prompt";
+    private static final String NUDGE_MODE_RESTORE_LABEL = "Restore into chat input";
 
     public ChatInputConfigurable(@NotNull Project project) {
         this.project = project;
@@ -87,6 +91,10 @@ public final class ChatInputConfigurable implements Configurable {
             cleanupSettings.isAutoCloseRunningTerminals());
         closeRunningTerminalsCheckbox.setEnabled(cleanupSettings.isAutoCloseAgentTabs());
 
+        unhandledNudgeModeCombo = new JComboBox<>(new String[]{
+            NUDGE_MODE_AUTO_SEND_LABEL, NUDGE_MODE_RESTORE_LABEL
+        });
+
         autoCloseTabsCheckbox.addChangeListener(e ->
             closeRunningTerminalsCheckbox.setEnabled(autoCloseTabsCheckbox.isSelected()));
 
@@ -131,6 +139,10 @@ public final class ChatInputConfigurable implements Configurable {
             .addLabeledComponent("Scratch file retention (hours, 0 = forever):", scratchRetentionSpinner)
             .addComponent(autoCloseTabsCheckbox)
             .addComponent(closeRunningTerminalsCheckbox)
+            .addVerticalGap(4)
+            .addSeparator(8)
+            .addLabeledComponent("When the agent finishes before you act on a nudge:", unhandledNudgeModeCombo)
+            .addTooltip("\"Restore into chat input\" prepends the unsent nudge to the input area instead of firing it.")
             .addComponentFillVertically(new JPanel(), 0)
             .getPanel();
         panel.setBorder(JBUI.Borders.empty(8));
@@ -182,7 +194,8 @@ public final class ChatInputConfigurable implements Configurable {
         CleanupSettings cleanupSettings = CleanupSettings.getInstance(project);
         if ((int) scratchRetentionSpinner.getValue() != cleanupSettings.getScratchRetentionHours()) return true;
         if (autoCloseTabsCheckbox.isSelected() != cleanupSettings.isAutoCloseAgentTabs()) return true;
-        return closeRunningTerminalsCheckbox.isSelected() != cleanupSettings.isAutoCloseRunningTerminals();
+        if (closeRunningTerminalsCheckbox.isSelected() != cleanupSettings.isAutoCloseRunningTerminals()) return true;
+        return selectedNudgeMode() != s.getUnhandledNudgeMode();
     }
 
     @Override
@@ -215,6 +228,8 @@ public final class ChatInputConfigurable implements Configurable {
         cleanupSettings.setScratchRetentionHours((int) scratchRetentionSpinner.getValue());
         cleanupSettings.setAutoCloseAgentTabs(autoCloseTabsCheckbox.isSelected());
         cleanupSettings.setAutoCloseRunningTerminals(closeRunningTerminalsCheckbox.isSelected());
+
+        s.setUnhandledNudgeMode(selectedNudgeMode());
     }
 
     @Override
@@ -238,6 +253,11 @@ public final class ChatInputConfigurable implements Configurable {
         autoCloseTabsCheckbox.setSelected(cleanupSettings.isAutoCloseAgentTabs());
         closeRunningTerminalsCheckbox.setSelected(cleanupSettings.isAutoCloseRunningTerminals());
         closeRunningTerminalsCheckbox.setEnabled(cleanupSettings.isAutoCloseAgentTabs());
+
+        unhandledNudgeModeCombo.setSelectedItem(switch (s.getUnhandledNudgeMode()) {
+            case RESTORE_INTO_INPUT -> NUDGE_MODE_RESTORE_LABEL;
+            case AUTO_SEND -> NUDGE_MODE_AUTO_SEND_LABEL;
+        });
     }
 
     @Override
@@ -254,6 +274,14 @@ public final class ChatInputConfigurable implements Configurable {
         scratchRetentionSpinner = null;
         autoCloseTabsCheckbox = null;
         closeRunningTerminalsCheckbox = null;
+        unhandledNudgeModeCombo = null;
+    }
+
+    private ChatInputSettings.UnhandledNudgeMode selectedNudgeMode() {
+        if (unhandledNudgeModeCombo == null) return ChatInputSettings.UnhandledNudgeMode.AUTO_SEND;
+        return NUDGE_MODE_RESTORE_LABEL.equals(unhandledNudgeModeCombo.getSelectedItem())
+            ? ChatInputSettings.UnhandledNudgeMode.RESTORE_INTO_INPUT
+            : ChatInputSettings.UnhandledNudgeMode.AUTO_SEND;
     }
 
     private String selectedTriggerChar() {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ChatInputSettings.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/ChatInputSettings.java
@@ -82,6 +82,31 @@ public final class ChatInputSettings implements PersistentStateComponent<ChatInp
         myState.fileSearchTrigger = trigger;
     }
 
+    // ── Unhandled nudge mode ────────────────────────────────────────────────
+
+    /**
+     * What happens to a queued nudge when the agent finishes its turn before the user
+     * acted on it.
+     *
+     * <p>{@link #AUTO_SEND} (default) — fire the nudge as a brand-new prompt
+     * automatically, preserving the historical behaviour. <br>
+     * {@link #RESTORE_INTO_INPUT} — prepend the nudge text into the chat input area so
+     * the user can edit it (and any text they were already typing stays appended).
+     */
+    public enum UnhandledNudgeMode {
+        AUTO_SEND,
+        RESTORE_INTO_INPUT
+    }
+
+    @NotNull
+    public UnhandledNudgeMode getUnhandledNudgeMode() {
+        return myState.unhandledNudgeMode == null ? UnhandledNudgeMode.AUTO_SEND : myState.unhandledNudgeMode;
+    }
+
+    public void setUnhandledNudgeMode(@NotNull UnhandledNudgeMode mode) {
+        myState.unhandledNudgeMode = mode;
+    }
+
     // ── PersistentStateComponent ────────────────────────────────────────────
 
     @Override
@@ -102,5 +127,7 @@ public final class ChatInputSettings implements PersistentStateComponent<ChatInp
         public int smartPasteMinChars = DEFAULT_SMART_PASTE_MIN_CHARS;
         @NotNull
         public String fileSearchTrigger = "#";
+        @NotNull
+        public UnhandledNudgeMode unhandledNudgeMode = UnhandledNudgeMode.AUTO_SEND;
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/McpServerSettings.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/McpServerSettings.java
@@ -127,14 +127,47 @@ public final class McpServerSettings implements PersistentStateComponent<McpServ
     }
 
     /**
-     * When true, the plugin runs an agent-edit review session that captures before-snapshots
-     * of files on first modification and renders persistent diff highlights in the editor
-     * until the user ends the session. See {@link com.github.catatafishen.agentbridge.psi.review.AgentEditSession}.
+     * When true, agent edits are auto-approved as soon as they land. Disabling makes new
+     * rows appear as PENDING — they accumulate in the Review panel and the user must
+     * accept (or revert) them. Toggling this on also sweeps any existing PENDING rows
+     * to APPROVED. The Diff Review session itself is always on; this flag only controls
+     * the default approval state of new rows.
+     *
+     * <p>See {@link com.github.catatafishen.agentbridge.psi.review.AgentEditSession}.
      */
+    public boolean isAutoApproveAgentEdits() {
+        return myState.autoApproveAgentEdits;
+    }
+
+    public void setAutoApproveAgentEdits(boolean enabled) {
+        myState.autoApproveAgentEdits = enabled;
+    }
+
+    /**
+     * When true, the Review panel automatically removes all approved rows when the user
+     * starts a fresh prompt (not nudges or follow-ups within the same turn). The list
+     * still grows during a single agent turn so the user can audit a full batch of edits
+     * after it completes.
+     */
+    public boolean isAutoCleanReviewOnNewPrompt() {
+        return myState.autoCleanReviewOnNewPrompt;
+    }
+
+    public void setAutoCleanReviewOnNewPrompt(boolean enabled) {
+        myState.autoCleanReviewOnNewPrompt = enabled;
+    }
+
+    /**
+     * @deprecated The Diff Review session is now always-on. The on/off toggle has been
+     * replaced by the Auto-Approve toggle ({@link #isAutoApproveAgentEdits()}). This
+     * accessor is kept only to read legacy persisted state during migration.
+     */
+    @Deprecated(forRemoval = true)
     public boolean isReviewAgentEdits() {
         return myState.reviewAgentEdits;
     }
 
+    @Deprecated(forRemoval = true)
     public void setReviewAgentEdits(boolean enabled) {
         myState.reviewAgentEdits = enabled;
     }
@@ -171,6 +204,8 @@ public final class McpServerSettings implements PersistentStateComponent<McpServ
         private boolean smoothScrollEnabled = false;
         private boolean showTurnStats = true;
         private boolean reviewAgentEdits = false;
+        private boolean autoApproveAgentEdits = false;
+        private boolean autoCleanReviewOnNewPrompt = false;
         private String kindReadColorKey = null;
         private String kindEditColorKey = null;
         private String kindExecuteColorKey = null;
@@ -246,6 +281,22 @@ public final class McpServerSettings implements PersistentStateComponent<McpServ
 
         public void setReviewAgentEdits(boolean reviewAgentEdits) {
             this.reviewAgentEdits = reviewAgentEdits;
+        }
+
+        public boolean isAutoApproveAgentEdits() {
+            return autoApproveAgentEdits;
+        }
+
+        public void setAutoApproveAgentEdits(boolean autoApproveAgentEdits) {
+            this.autoApproveAgentEdits = autoApproveAgentEdits;
+        }
+
+        public boolean isAutoCleanReviewOnNewPrompt() {
+            return autoCleanReviewOnNewPrompt;
+        }
+
+        public void setAutoCleanReviewOnNewPrompt(boolean autoCleanReviewOnNewPrompt) {
+            this.autoCleanReviewOnNewPrompt = autoCleanReviewOnNewPrompt;
         }
 
         public @org.jetbrains.annotations.Nullable String getKindReadColorKey() {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -60,6 +60,9 @@ class ChatToolWindowContent(
     ).also {
         it.secondComponent = mainPanel
         it.setHonorComponentsMinimumSize(false)
+        // When the tool window is resized (by dragging its border), keep the chat pane
+        // at its current width and let the sidebar absorb the size change.
+        it.dividerPositionStrategy = com.intellij.openapi.ui.Splitter.DividerPositionStrategy.KEEP_SECOND_SIZE
         it.border = com.intellij.ui.SideBorder(JBColor.border(), com.intellij.ui.SideBorder.TOP)
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -839,6 +839,12 @@ class ChatToolWindowContent(
         if (rawText.isEmpty()) return
         consolePanel.disableQuickReplies()
         statusBanner?.dismissCurrent()
+        // Auto-clean approved review rows when a brand-new user turn starts (not nudge / queued follow-up).
+        if (com.github.catatafishen.agentbridge.settings.McpServerSettings.getInstance(project).isAutoCleanReviewOnNewPrompt) {
+            try {
+                project.getService(com.github.catatafishen.agentbridge.psi.review.AgentEditSession::class.java)?.removeAllApproved()
+            } catch (_: Throwable) { /* defensive: review session is best-effort */ }
+        }
         setSendingState(true)
 
         val contextItems = contextManager.collectInlineContextItems()
@@ -963,8 +969,17 @@ class ChatToolWindowContent(
                 ApplicationManager.getApplication().invokeLater {
                     consolePanel.removeNudgeBubble(nudgeId)
                     if (nudgeText != null) {
-                        promptTextArea.text = nudgeText
-                        onSendStopClicked()
+                        val mode = com.github.catatafishen.agentbridge.settings.ChatInputSettings.getInstance().unhandledNudgeMode
+                        if (mode == com.github.catatafishen.agentbridge.settings.ChatInputSettings.UnhandledNudgeMode.RESTORE_INTO_INPUT) {
+                            // Prepend the unhandled nudge to whatever the user is currently typing — do not auto-send.
+                            val current = promptTextArea.text
+                            promptTextArea.text = if (current.isNullOrEmpty()) nudgeText else nudgeText + "\n\n" + current
+                            promptTextArea.requestFocusInWindow()
+                        } else {
+                            // Default: auto-send the nudge as a fresh prompt.
+                            promptTextArea.text = nudgeText
+                            onSendStopClicked()
+                        }
                     }
                 }
             }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/MarkdownRenderer.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/MarkdownRenderer.kt
@@ -35,6 +35,7 @@ object MarkdownRenderer {
         var inImplicitCode: Boolean = false
     )
 
+    @JvmOverloads
     fun markdownToHtml(
         text: String,
         resolveFileReference: (String) -> Pair<String, Int?>? = { null },

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
@@ -1,9 +1,12 @@
 package com.github.catatafishen.agentbridge.ui.review;
 
 import com.github.catatafishen.agentbridge.psi.review.AgentEditSession;
+import com.github.catatafishen.agentbridge.psi.review.ApprovalState;
 import com.github.catatafishen.agentbridge.psi.review.ReviewItem;
 import com.github.catatafishen.agentbridge.psi.review.ReviewSessionTopic;
+import com.github.catatafishen.agentbridge.psi.review.RevertReasonDialog;
 import com.github.catatafishen.agentbridge.settings.McpServerSettings;
+import com.github.catatafishen.agentbridge.ui.util.TimestampDisplayFormatter;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.ActionManager;
@@ -16,7 +19,6 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.JBColor;
@@ -25,33 +27,68 @@ import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.table.JBTable;
 import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
 import org.jetbrains.annotations.NotNull;
 
-import javax.swing.*;
+import javax.swing.AbstractAction;
+import javax.swing.ActionMap;
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.Icon;
+import javax.swing.InputMap;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTable;
+import javax.swing.KeyStroke;
+import javax.swing.SwingConstants;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.CardLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.GridBagLayout;
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Panel displaying review items from the current {@link AgentEditSession}.
- * Shows a table of files with status, and per-file accept/reject actions.
- * Toolbar provides a stop/play toggle to enable/disable diff review, plus bulk accept-all/reject-all actions.
- * <p>
- * Action buttons (view, accept, reject) are always visible in the right side of the file cell.
- * Click handling uses coordinate math in a {@link java.awt.event.MouseListener} since renderer
- * components are paint-only in JTable (not interactive).
+ * Side panel listing every file the agent has touched in the current
+ * {@link AgentEditSession}. The session is always running; entries appear here as soon
+ * as the agent edits a file and stay visible (visually muted) after the user accepts
+ * them, until they are removed via:
+ * <ul>
+ *   <li>the per-row <kbd>Delete</kbd> shortcut (approved rows only),</li>
+ *   <li>the toolbar <b>Clean Approved</b> button,</li>
+ *   <li>the post-commit prune in {@code git_commit},</li>
+ *   <li>the optional <b>Auto-clean on new prompt</b> toggle, or</li>
+ *   <li>a worktree-changing git operation that wipes the whole session.</li>
+ * </ul>
+ *
+ * <p>The toolbar exposes <b>Auto-Approve</b> (new edits and existing pending rows are
+ * approved on toggle-on) and <b>Auto-Clean on new prompt</b> (sweep approved rows when
+ * the next user message starts a fresh turn). There is no longer an on/off master
+ * switch — diff review is always on.</p>
  */
 public final class ReviewChangesPanel extends JPanel implements Disposable {
 
     private static final String CARD_TABLE = "table";
     private static final String CARD_EMPTY = "empty";
 
+    /** Local action key for the DEL/Backspace shortcut binding. */
+    private static final String ACTION_REMOVE_APPROVED = "removeApprovedRow";
+
     private static final int BUTTON_AREA_WIDTH = 82;
+    private static final int META_AREA_WIDTH = 130;
 
     private final transient Project project;
     private final ReviewTableModel tableModel;
@@ -118,18 +155,14 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
 
     public void refresh() {
         AgentEditSession session = AgentEditSession.getInstance(project);
-        List<ReviewItem> items = session.isActive() ? session.getReviewItems() : List.of();
+        List<ReviewItem> items = session.getReviewItems();
         tableModel.setItems(items);
 
         if (!items.isEmpty()) {
             cardLayout.show(cardPanel, CARD_TABLE);
         } else {
-            boolean reviewEnabled = McpServerSettings.getInstance(project).isReviewAgentEdits();
-            if (reviewEnabled) {
-                emptyLabel.setText("No agent edits to review");
-            } else {
-                emptyLabel.setText("<html><center>Diff Review is off.<br>Agent edits are applied directly without review.</center></html>");
-            }
+            emptyLabel.setText("<html><center>No agent edits to review.<br>"
+                + "Edits will appear here as soon as the agent touches a file.</center></html>");
             cardLayout.show(cardPanel, CARD_EMPTY);
         }
         revalidate();
@@ -150,7 +183,7 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         statusCol.setCellRenderer(new StatusCellRenderer());
 
         TableColumn fileCol = table.getColumnModel().getColumn(ReviewTableModel.COL_FILE);
-        fileCol.setPreferredWidth(JBUI.scale(200));
+        fileCol.setPreferredWidth(JBUI.scale(280));
         fileCol.setCellRenderer(new FileCellRenderer());
 
         table.addMouseListener(new MouseAdapter() {
@@ -162,12 +195,29 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
 
                 ReviewItem item = tableModel.getItem(row);
                 if (col == ReviewTableModel.COL_FILE) {
-                    Rectangle cellRect = table.getCellRect(row, ReviewTableModel.COL_FILE, true);
+                    java.awt.Rectangle cellRect = table.getCellRect(row, ReviewTableModel.COL_FILE, true);
                     int relX = e.getX() - cellRect.x;
                     int buttonStart = cellRect.width - JBUI.scale(BUTTON_AREA_WIDTH);
                     if (relX >= buttonStart) {
                         handleFileActionClick(item, relX - buttonStart);
                     }
+                }
+            }
+        });
+
+        // DEL removes the focused row when it's APPROVED.
+        InputMap im = table.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
+        ActionMap am = table.getActionMap();
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0), ACTION_REMOVE_APPROVED);
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0), ACTION_REMOVE_APPROVED);
+        am.put(ACTION_REMOVE_APPROVED, new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                int row = table.getSelectedRow();
+                if (row < 0 || row >= tableModel.getRowCount()) return;
+                ReviewItem item = tableModel.getItem(row);
+                if (item.approvalState() == ApprovalState.APPROVED) {
+                    AgentEditSession.getInstance(project).removeApproved(item.path());
                 }
             }
         });
@@ -182,7 +232,7 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         } else if (relXInButtonArea < JBUI.scale(4) + 2 * btnW + 2 * gap) {
             AgentEditSession.getInstance(project).acceptFile(item.path());
         } else {
-            showRejectDialog(item);
+            showRevertDialog(item);
         }
     }
 
@@ -194,64 +244,116 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         }
     }
 
-    private void showRejectDialog(@NotNull ReviewItem item) {
-        String reason = Messages.showInputDialog(
-            project,
-            "Reason for rejecting changes to " + item.relativePath() + " (optional):",
-            "Reject Agent Edit",
-            Messages.getQuestionIcon(),
-            null, null
-        );
-        if (reason == null) return;
-        AgentEditSession.getInstance(project).rejectFile(item.path(), reason.isBlank() ? null : reason);
+    private void showRevertDialog(@NotNull ReviewItem item) {
+        VirtualFile vf = LocalFileSystem.getInstance().findFileByPath(item.path());
+        if (vf == null) return;
+        AgentEditSession session = AgentEditSession.getInstance(project);
+        RevertReasonDialog dialog = new RevertReasonDialog(project, vf, item.relativePath(), session.isGateActive());
+        if (!dialog.showAndGet()) return;
+        AgentEditSession.RevertGateAction gateAction = switch (dialog.getResult()) {
+            case CONTINUE_REVIEWING -> AgentEditSession.RevertGateAction.CONTINUE_REVIEWING;
+            case SEND_NOW -> AgentEditSession.RevertGateAction.SEND_NOW;
+            default -> AgentEditSession.RevertGateAction.DEFAULT;
+        };
+        session.revertFile(item.path(), dialog.getReason(), gateAction);
     }
 
     private @NotNull ActionToolbar createToolbar() {
         DefaultActionGroup group = new DefaultActionGroup();
 
-        group.add(new DiffReviewToggleAction(project));
+        group.add(new AutoApproveToggleAction(project));
+        group.add(new AutoCleanOnNewPromptToggleAction(project));
 
         group.addSeparator();
 
-        group.add(new DumbAwareAction("Accept All", "Accept all agent edits", AllIcons.Actions.Checked) {
+        group.add(new DumbAwareAction("Clean Approved",
+            "Remove all approved rows from the list", AllIcons.Actions.GC) {
+            @Override
+            public @NotNull ActionUpdateThread getActionUpdateThread() {
+                return ActionUpdateThread.BGT;
+            }
+
             @Override
             public void actionPerformed(@NotNull AnActionEvent e) {
-                AgentEditSession.getInstance(project).acceptAll();
+                AgentEditSession.getInstance(project).removeAllApproved();
             }
 
             @Override
             public void update(@NotNull AnActionEvent e) {
-                e.getPresentation().setEnabled(
-                    AgentEditSession.getInstance(project).isActive()
-                        && AgentEditSession.getInstance(project).hasChanges()
-                );
-            }
-        });
-
-        group.add(new DumbAwareAction("Reject All", "Reject all agent edits and revert", AllIcons.Actions.Rollback) {
-            @Override
-            public void actionPerformed(@NotNull AnActionEvent e) {
-                String reason = Messages.showInputDialog(
-                    project,
-                    "Reason for rejecting all changes (optional):",
-                    "Reject All Agent Edits",
-                    Messages.getWarningIcon(),
-                    null, null
-                );
-                if (reason == null) return;
-                AgentEditSession.getInstance(project).rejectAll(reason.isBlank() ? null : reason);
-            }
-
-            @Override
-            public void update(@NotNull AnActionEvent e) {
-                e.getPresentation().setEnabled(
-                    AgentEditSession.getInstance(project).isActive()
-                        && AgentEditSession.getInstance(project).hasChanges()
-                );
+                boolean anyApproved = false;
+                for (ReviewItem it : AgentEditSession.getInstance(project).getReviewItems()) {
+                    if (it.approvalState() == ApprovalState.APPROVED) { anyApproved = true; break; }
+                }
+                e.getPresentation().setEnabled(anyApproved);
             }
         });
 
         return ActionManager.getInstance().createActionToolbar("ReviewChangesToolbar", group, true);
+    }
+
+    // ── Toolbar actions ───────────────────────────────────────────────────────
+
+    /**
+     * Toggles auto-approve. When turned on, also sweeps every existing PENDING row to
+     * APPROVED via {@link AgentEditSession#onAutoApproveTurnedOn()} so the user doesn't
+     * have to click Accept on backlog items.
+     */
+    private static final class AutoApproveToggleAction extends ToggleAction {
+        private final Project project;
+
+        AutoApproveToggleAction(@NotNull Project project) {
+            super("Auto-Approve", "Apply agent edits without per-file approval", AllIcons.Actions.Lightning);
+            this.project = project;
+        }
+
+        @Override
+        public @NotNull ActionUpdateThread getActionUpdateThread() {
+            return ActionUpdateThread.BGT;
+        }
+
+        @Override
+        public boolean isSelected(@NotNull AnActionEvent e) {
+            return McpServerSettings.getInstance(project).isAutoApproveAgentEdits();
+        }
+
+        @Override
+        public void setSelected(@NotNull AnActionEvent e, boolean state) {
+            McpServerSettings.getInstance(project).setAutoApproveAgentEdits(state);
+            if (state) {
+                AgentEditSession.getInstance(project).onAutoApproveTurnedOn();
+            }
+            project.getMessageBus().syncPublisher(ReviewSessionTopic.TOPIC).reviewStateChanged();
+        }
+    }
+
+    /**
+     * Toggles "Auto-clean approved on new prompt": when ON, every fresh user turn sweeps
+     * approved rows out of the list before the message is sent.
+     */
+    private static final class AutoCleanOnNewPromptToggleAction extends ToggleAction {
+        private final Project project;
+
+        AutoCleanOnNewPromptToggleAction(@NotNull Project project) {
+            super("Auto-Clean on New Prompt",
+                "Remove approved rows automatically when starting a new prompt",
+                AllIcons.Actions.ClearCash);
+            this.project = project;
+        }
+
+        @Override
+        public @NotNull ActionUpdateThread getActionUpdateThread() {
+            return ActionUpdateThread.BGT;
+        }
+
+        @Override
+        public boolean isSelected(@NotNull AnActionEvent e) {
+            return McpServerSettings.getInstance(project).isAutoCleanReviewOnNewPrompt();
+        }
+
+        @Override
+        public void setSelected(@NotNull AnActionEvent e, boolean state) {
+            McpServerSettings.getInstance(project).setAutoCleanReviewOnNewPrompt(state);
+        }
     }
 
     // ── Table model ───────────────────────────────────────────────────────────
@@ -292,8 +394,7 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         public Object getValueAt(int rowIndex, int columnIndex) {
             ReviewItem item = items.get(rowIndex);
             return switch (columnIndex) {
-                case COL_STATUS -> item.status().name();
-                case COL_FILE -> item.relativePath();
+                case COL_STATUS, COL_FILE -> item;
                 default -> null;
             };
         }
@@ -306,147 +407,79 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         public Component getTableCellRendererComponent(JTable table, Object value,
                                                        boolean isSelected, boolean hasFocus,
                                                        int row, int column) {
-            Component c = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-            if (value instanceof String status && c instanceof JLabel label) {
+            Component c = super.getTableCellRendererComponent(table, "", isSelected, hasFocus, row, column);
+            if (value instanceof ReviewItem item && c instanceof JLabel label) {
                 label.setText("");
                 label.setHorizontalAlignment(CENTER);
-                switch (status) {
-                    case "ADDED" -> {
-                        label.setForeground(isSelected ? table.getSelectionForeground()
-                            : new JBColor(new Color(0, 128, 0), new Color(80, 200, 80)));
-                        label.setIcon(AllIcons.General.Add);
-                        label.setToolTipText("Added");
-                    }
-                    case "MODIFIED" -> {
-                        label.setForeground(isSelected ? table.getSelectionForeground()
-                            : new JBColor(new Color(0, 100, 200), new Color(80, 160, 255)));
-                        label.setIcon(AllIcons.Actions.Edit);
-                        label.setToolTipText("Modified");
-                    }
-                    case "DELETED" -> {
-                        label.setForeground(isSelected ? table.getSelectionForeground()
-                            : new JBColor(new Color(200, 0, 0), new Color(255, 80, 80)));
-                        label.setIcon(AllIcons.General.Remove);
-                        label.setToolTipText("Deleted");
-                    }
-                    default -> {
-                        label.setIcon(null);
-                        label.setToolTipText(null);
-                    }
-                }
+                applyStatusIcon(item, table, isSelected, label);
             }
             return c;
         }
-    }
 
-    // ── Toolbar actions ───────────────────────────────────────────────────────
-
-    /**
-     * Named inner class extracted from the anonymous {@link ToggleAction} in
-     * {@link #createToolbar()} to reduce cognitive complexity (SonarQube S3776).
-     * Enables or disables diff review for agent edits, with a confirmation
-     * dialog when disabling while a review session with unreviewed changes is active.
-     */
-    private static final class DiffReviewToggleAction extends ToggleAction {
-
-        private final Project project;
-
-        DiffReviewToggleAction(@NotNull Project project) {
-            super("Diff Review", "Toggle diff review for agent edits", AllIcons.Actions.Diff);
-            this.project = project;
-        }
-
-        @Override
-        public @NotNull ActionUpdateThread getActionUpdateThread() {
-            return ActionUpdateThread.BGT;
-        }
-
-        @Override
-        public boolean isSelected(@NotNull AnActionEvent e) {
-            return McpServerSettings.getInstance(project).isReviewAgentEdits();
-        }
-
-        @Override
-        public void setSelected(@NotNull AnActionEvent e, boolean state) {
-            if (state) {
-                enableDiffReview();
-            } else {
-                disableDiffReview();
+        private static void applyStatusIcon(@NotNull ReviewItem item, @NotNull JTable table,
+                                            boolean isSelected, @NotNull JLabel label) {
+            switch (item.status()) {
+                case ADDED -> {
+                    label.setForeground(isSelected ? table.getSelectionForeground()
+                        : new JBColor(new Color(0, 128, 0), new Color(80, 200, 80)));
+                    label.setIcon(AllIcons.General.Add);
+                    label.setToolTipText(approvedTip("Added", item));
+                }
+                case MODIFIED -> {
+                    label.setForeground(isSelected ? table.getSelectionForeground()
+                        : new JBColor(new Color(0, 100, 200), new Color(80, 160, 255)));
+                    label.setIcon(AllIcons.Actions.Edit);
+                    label.setToolTipText(approvedTip("Modified", item));
+                }
+                case DELETED -> {
+                    label.setForeground(isSelected ? table.getSelectionForeground()
+                        : new JBColor(new Color(200, 0, 0), new Color(255, 80, 80)));
+                    label.setIcon(AllIcons.General.Remove);
+                    label.setToolTipText(approvedTip("Deleted", item));
+                }
             }
         }
 
-        private void enableDiffReview() {
-            McpServerSettings.getInstance(project).setReviewAgentEdits(true);
-            project.getMessageBus().syncPublisher(ReviewSessionTopic.TOPIC).reviewStateChanged();
-        }
-
-        private void disableDiffReview() {
-            AgentEditSession session = AgentEditSession.getInstance(project);
-            if (session.isActive() && session.hasChanges() && !confirmDiscard(session)) {
-                return;
-            }
-            boolean wasActive = session.isActive();
-            McpServerSettings.getInstance(project).setReviewAgentEdits(false);
-            session.endSession();
-            if (!wasActive) {
-                project.getMessageBus().syncPublisher(ReviewSessionTopic.TOPIC).reviewStateChanged();
-            }
-        }
-
-        private boolean confirmDiscard(@NotNull AgentEditSession session) {
-            int result = Messages.showOkCancelDialog(
-                project,
-                "You have " + session.getReviewItems().size()
-                    + " unreviewed file(s). Disabling Diff Review will discard the review session.",
-                "Discard Review Session?",
-                "Discard",
-                "Cancel",
-                Messages.getWarningIcon()
-            );
-            return result == Messages.OK;
-        }
-
-        @Override
-        public void update(@NotNull AnActionEvent e) {
-            super.update(e);
-            boolean enabled = McpServerSettings.getInstance(project).isReviewAgentEdits();
-            if (enabled) {
-                e.getPresentation().setIcon(AllIcons.Actions.Suspend);
-                e.getPresentation().setText("Disable Diff Review");
-                e.getPresentation().setDescription("Disable diff review and stop tracking agent edits");
-            } else {
-                e.getPresentation().setIcon(AllIcons.Actions.Execute);
-                e.getPresentation().setText("Enable Diff Review");
-                e.getPresentation().setDescription("Enable diff review to track and review agent edits");
-            }
+        private static @NotNull String approvedTip(@NotNull String base, @NotNull ReviewItem item) {
+            return item.approvalState() == ApprovalState.APPROVED ? base + " · Approved" : base + " · Pending";
         }
     }
 
     /**
-     * Renders the file name with always-visible action buttons on the right side of the cell.
-     * Buttons are pre-created once to avoid allocation and layout jitter on every repaint.
-     * Click dispatch is handled by the table's {@link MouseAdapter} using coordinate math.
+     * Renders a row as: [filename · meta(+N −N · 5m ago)] [view | accept | revert].
+     * Approved rows render with muted foreground/background. Pending rows look normal.
      */
     private static final class FileCellRenderer extends DefaultTableCellRenderer {
         private final JPanel cellPanel = new JPanel(new BorderLayout(JBUI.scale(4), 0));
         private final JLabel nameLabel = new JLabel();
+        private final JLabel metaLabel = new JLabel();
+        private final JPanel centerPanel = new JPanel(new BorderLayout(JBUI.scale(6), 0));
         private final JPanel buttonsPanel = new JPanel(new GridLayout(1, 3, JBUI.scale(2), 0));
 
         FileCellRenderer() {
             cellPanel.setOpaque(true);
             nameLabel.setOpaque(false);
+            metaLabel.setOpaque(false);
+            metaLabel.setFont(UIUtil.getLabelFont().deriveFont(UIUtil.getLabelFont().getSize() - 1f));
+            metaLabel.setForeground(JBColor.GRAY);
+            metaLabel.setHorizontalAlignment(SwingConstants.RIGHT);
+            metaLabel.setPreferredSize(new Dimension(JBUI.scale(META_AREA_WIDTH), 0));
 
             JButton viewBtn = createButton(AllIcons.General.InspectionsEye, "View file");
-            JButton acceptBtn = createButton(AllIcons.Actions.Checked, "Accept");
-            JButton rejectBtn = createButton(AllIcons.Actions.Rollback, "Reject");
+            JButton acceptBtn = createButton(AllIcons.Actions.Checked, "Approve");
+            JButton revertBtn = createButton(AllIcons.Actions.Rollback, "Revert…");
             buttonsPanel.add(viewBtn);
             buttonsPanel.add(acceptBtn);
-            buttonsPanel.add(rejectBtn);
+            buttonsPanel.add(revertBtn);
             buttonsPanel.setOpaque(false);
             buttonsPanel.setPreferredSize(new Dimension(JBUI.scale(BUTTON_AREA_WIDTH), 0));
 
+            centerPanel.setOpaque(false);
+            centerPanel.add(nameLabel, BorderLayout.CENTER);
+            centerPanel.add(metaLabel, BorderLayout.EAST);
+
             cellPanel.setBorder(BorderFactory.createEmptyBorder(2, 4, 2, 4));
-            cellPanel.add(nameLabel, BorderLayout.CENTER);
+            cellPanel.add(centerPanel, BorderLayout.CENTER);
             cellPanel.add(buttonsPanel, BorderLayout.EAST);
         }
 
@@ -466,18 +499,55 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         public Component getTableCellRendererComponent(JTable table, Object value,
                                                        boolean isSelected, boolean hasFocus,
                                                        int row, int column) {
-            String path = value instanceof String s ? s : "";
+            ReviewItem item = value instanceof ReviewItem ri ? ri : null;
+            String path = item != null ? item.path() : "";
+            String relativePath = item != null ? item.relativePath() : path;
             java.nio.file.Path p = java.nio.file.Path.of(path);
-            nameLabel.setText(p.getFileName() != null ? p.getFileName().toString() : path);
-            nameLabel.setToolTipText(path);
+            String fileName = p.getFileName() != null ? p.getFileName().toString() : path;
+
+            boolean approved = item != null && item.approvalState() == ApprovalState.APPROVED;
+            String prefix = approved ? "✓ " : "";
+            nameLabel.setText(prefix + fileName);
+            nameLabel.setToolTipText(relativePath
+                + (approved ? " · Approved (DEL to remove)" : " · Pending review"));
+
+            metaLabel.setText(item != null ? buildMeta(item) : "");
+            metaLabel.setToolTipText(item != null && item.lastEditedMillis() > 0
+                ? "Last edited " + TimestampDisplayFormatter.formatEpochMillis(item.lastEditedMillis())
+                : null);
 
             Color bg = isSelected ? table.getSelectionBackground() : table.getBackground();
             Color fg = isSelected ? table.getSelectionForeground() : table.getForeground();
+            if (approved && !isSelected) {
+                bg = mute(bg);
+                fg = JBColor.GRAY;
+            }
             cellPanel.setBackground(bg);
             buttonsPanel.setBackground(bg);
+            centerPanel.setBackground(bg);
             nameLabel.setForeground(fg);
 
             return cellPanel;
+        }
+
+        private static @NotNull Color mute(@NotNull Color base) {
+            // Slight tint towards the panel background to visually de-emphasise approved rows.
+            int r = (base.getRed() + UIUtil.getPanelBackground().getRed()) / 2;
+            int g = (base.getGreen() + UIUtil.getPanelBackground().getGreen()) / 2;
+            int b = (base.getBlue() + UIUtil.getPanelBackground().getBlue()) / 2;
+            return new Color(r, g, b);
+        }
+
+        private static @NotNull String buildMeta(@NotNull ReviewItem item) {
+            StringBuilder sb = new StringBuilder();
+            if (item.linesAdded() > 0 || item.linesRemoved() > 0) {
+                sb.append("+").append(item.linesAdded()).append(" −").append(item.linesRemoved());
+            }
+            if (item.lastEditedMillis() > 0) {
+                if (!sb.isEmpty()) sb.append(" · ");
+                sb.append(TimestampDisplayFormatter.formatEpochMillis(item.lastEditedMillis()));
+            }
+            return sb.toString();
         }
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
@@ -1,10 +1,9 @@
 package com.github.catatafishen.agentbridge.ui.review;
 
 import com.github.catatafishen.agentbridge.psi.review.AgentEditSession;
-import com.github.catatafishen.agentbridge.psi.review.ApprovalState;
+import com.github.catatafishen.agentbridge.psi.review.RevertReasonDialog;
 import com.github.catatafishen.agentbridge.psi.review.ReviewItem;
 import com.github.catatafishen.agentbridge.psi.review.ReviewSessionTopic;
-import com.github.catatafishen.agentbridge.psi.review.RevertReasonDialog;
 import com.github.catatafishen.agentbridge.settings.McpServerSettings;
 import com.github.catatafishen.agentbridge.ui.util.TimestampDisplayFormatter;
 import com.intellij.icons.AllIcons;
@@ -30,30 +29,11 @@ import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 import org.jetbrains.annotations.NotNull;
 
-import javax.swing.AbstractAction;
-import javax.swing.ActionMap;
-import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
-import javax.swing.Icon;
-import javax.swing.InputMap;
-import javax.swing.JButton;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JTable;
-import javax.swing.KeyStroke;
-import javax.swing.SwingConstants;
+import javax.swing.*;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
-import java.awt.BorderLayout;
-import java.awt.CardLayout;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Cursor;
-import java.awt.Dimension;
-import java.awt.GridBagLayout;
-import java.awt.GridLayout;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
@@ -63,32 +43,23 @@ import java.util.List;
 
 /**
  * Side panel listing every file the agent has touched in the current
- * {@link AgentEditSession}. The session is always running; entries appear here as soon
- * as the agent edits a file and stay visible (visually muted) after the user accepts
- * them, until they are removed via:
- * <ul>
- *   <li>the per-row <kbd>Delete</kbd> shortcut (approved rows only),</li>
- *   <li>the toolbar <b>Clean Approved</b> button,</li>
- *   <li>the post-commit prune in {@code git_commit},</li>
- *   <li>the optional <b>Auto-clean on new prompt</b> toggle, or</li>
- *   <li>a worktree-changing git operation that wipes the whole session.</li>
- * </ul>
- *
- * <p>The toolbar exposes <b>Auto-Approve</b> (new edits and existing pending rows are
- * approved on toggle-on) and <b>Auto-Clean on new prompt</b> (sweep approved rows when
- * the next user message starts a fresh turn). There is no longer an on/off master
- * switch — diff review is always on.</p>
+ * {@link AgentEditSession}.
+ * <p>
+ * Columns: [status icon] [file name + meta] [approve checkbox] [remove X].
+ * Clicking a row opens the file. The approve checkbox toggles between PENDING and
+ * APPROVED (green check when approved). The X button removes approved rows.
  */
 public final class ReviewChangesPanel extends JPanel implements Disposable {
 
     private static final String CARD_TABLE = "table";
     private static final String CARD_EMPTY = "empty";
-
-    /** Local action key for the DEL/Backspace shortcut binding. */
     private static final String ACTION_REMOVE_APPROVED = "removeApprovedRow";
 
-    private static final int BUTTON_AREA_WIDTH = 82;
-    private static final int META_AREA_WIDTH = 130;
+    /**
+     * Standard diff colors for added/removed line counts.
+     */
+    private static final JBColor DIFF_GREEN = new JBColor(new Color(0, 128, 0), new Color(80, 200, 80));
+    private static final JBColor DIFF_RED = new JBColor(new Color(200, 0, 0), new Color(255, 80, 80));
 
     private final transient Project project;
     private final ReviewTableModel tableModel;
@@ -150,7 +121,6 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
 
     @Override
     public void dispose() {
-        // Message-bus connection auto-disposes via the Disposer parent link above.
     }
 
     public void refresh() {
@@ -177,31 +147,60 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         table.setTableHeader(null);
         table.setExpandableItemsEnabled(false);
 
+        // COL_STATUS — small icon column
         TableColumn statusCol = table.getColumnModel().getColumn(ReviewTableModel.COL_STATUS);
         statusCol.setPreferredWidth(JBUI.scale(28));
         statusCol.setMaxWidth(JBUI.scale(32));
         statusCol.setCellRenderer(new StatusCellRenderer());
 
+        // COL_FILE — file name + meta (takes remaining space)
         TableColumn fileCol = table.getColumnModel().getColumn(ReviewTableModel.COL_FILE);
         fileCol.setPreferredWidth(JBUI.scale(280));
         fileCol.setCellRenderer(new FileCellRenderer());
 
+        // COL_APPROVE — toggleable checkbox icon
+        TableColumn approveCol = table.getColumnModel().getColumn(ReviewTableModel.COL_APPROVE);
+        approveCol.setPreferredWidth(JBUI.scale(28));
+        approveCol.setMaxWidth(JBUI.scale(32));
+        approveCol.setCellRenderer(new ApproveCheckboxRenderer());
+
+        // COL_REMOVE — X button (only for approved rows)
+        TableColumn removeCol = table.getColumnModel().getColumn(ReviewTableModel.COL_REMOVE);
+        removeCol.setPreferredWidth(JBUI.scale(28));
+        removeCol.setMaxWidth(JBUI.scale(32));
+        removeCol.setCellRenderer(new RemoveButtonRenderer());
+
+        table.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         table.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
                 int row = table.rowAtPoint(e.getPoint());
                 int col = table.columnAtPoint(e.getPoint());
                 if (row < 0 || row >= tableModel.getRowCount()) return;
-
                 ReviewItem item = tableModel.getItem(row);
-                if (col == ReviewTableModel.COL_FILE) {
-                    java.awt.Rectangle cellRect = table.getCellRect(row, ReviewTableModel.COL_FILE, true);
-                    int relX = e.getX() - cellRect.x;
-                    int buttonStart = cellRect.width - JBUI.scale(BUTTON_AREA_WIDTH);
-                    if (relX >= buttonStart) {
-                        handleFileActionClick(item, relX - buttonStart);
+
+                switch (col) {
+                    case ReviewTableModel.COL_APPROVE -> toggleApproval(item);
+                    case ReviewTableModel.COL_REMOVE -> {
+                        if (item.approved()) {
+                            AgentEditSession.getInstance(project).removeApproved(item.path());
+                        }
                     }
+                    default -> navigateToFile(item);
                 }
+            }
+        });
+
+        // Right-click to revert
+        table.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                if (e.isPopupTrigger()) showRevertPopup(e);
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                if (e.isPopupTrigger()) showRevertPopup(e);
             }
         });
 
@@ -216,23 +215,30 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
                 int row = table.getSelectedRow();
                 if (row < 0 || row >= tableModel.getRowCount()) return;
                 ReviewItem item = tableModel.getItem(row);
-                if (item.approvalState() == ApprovalState.APPROVED) {
+                if (item.approved()) {
                     AgentEditSession.getInstance(project).removeApproved(item.path());
                 }
             }
         });
     }
 
-    private void handleFileActionClick(@NotNull ReviewItem item, int relXInButtonArea) {
-        int avail = JBUI.scale(BUTTON_AREA_WIDTH) - JBUI.scale(8);
-        int gap = JBUI.scale(2);
-        int btnW = (avail - 2 * gap) / 3;
-        if (relXInButtonArea < JBUI.scale(4) + btnW + gap) {
-            navigateToFile(item);
-        } else if (relXInButtonArea < JBUI.scale(4) + 2 * btnW + 2 * gap) {
-            AgentEditSession.getInstance(project).acceptFile(item.path());
+    private void showRevertPopup(MouseEvent e) {
+        int row = table.rowAtPoint(e.getPoint());
+        if (row < 0 || row >= tableModel.getRowCount()) return;
+        ReviewItem item = tableModel.getItem(row);
+        javax.swing.JPopupMenu menu = new javax.swing.JPopupMenu();
+        javax.swing.JMenuItem revertItem = new javax.swing.JMenuItem("Revert…", AllIcons.Actions.Rollback);
+        revertItem.addActionListener(ev -> showRevertDialog(item));
+        menu.add(revertItem);
+        menu.show(table, e.getX(), e.getY());
+    }
+
+    private void toggleApproval(@NotNull ReviewItem item) {
+        AgentEditSession session = AgentEditSession.getInstance(project);
+        if (item.approved()) {
+            session.unapproveFile(item.path());
         } else {
-            showRevertDialog(item);
+            session.acceptFile(item.path());
         }
     }
 
@@ -260,12 +266,9 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
 
     private @NotNull ActionToolbar createToolbar() {
         DefaultActionGroup group = new DefaultActionGroup();
-
         group.add(new AutoApproveToggleAction(project));
         group.add(new AutoCleanOnNewPromptToggleAction(project));
-
         group.addSeparator();
-
         group.add(new DumbAwareAction("Clean Approved",
             "Remove all approved rows from the list", AllIcons.Actions.GC) {
             @Override
@@ -282,22 +285,19 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
             public void update(@NotNull AnActionEvent e) {
                 boolean anyApproved = false;
                 for (ReviewItem it : AgentEditSession.getInstance(project).getReviewItems()) {
-                    if (it.approvalState() == ApprovalState.APPROVED) { anyApproved = true; break; }
+                    if (it.approved()) {
+                        anyApproved = true;
+                        break;
+                    }
                 }
                 e.getPresentation().setEnabled(anyApproved);
             }
         });
-
         return ActionManager.getInstance().createActionToolbar("ReviewChangesToolbar", group, true);
     }
 
     // ── Toolbar actions ───────────────────────────────────────────────────────
 
-    /**
-     * Toggles auto-approve. When turned on, also sweeps every existing PENDING row to
-     * APPROVED via {@link AgentEditSession#onAutoApproveTurnedOn()} so the user doesn't
-     * have to click Accept on backlog items.
-     */
     private static final class AutoApproveToggleAction extends ToggleAction {
         private final Project project;
 
@@ -326,10 +326,6 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         }
     }
 
-    /**
-     * Toggles "Auto-clean approved on new prompt": when ON, every fresh user turn sweeps
-     * approved rows out of the list before the message is sent.
-     */
     private static final class AutoCleanOnNewPromptToggleAction extends ToggleAction {
         private final Project project;
 
@@ -361,7 +357,9 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
     private static final class ReviewTableModel extends AbstractTableModel {
         static final int COL_STATUS = 0;
         static final int COL_FILE = 1;
-        private static final String[] COLUMN_NAMES = {"", "File"};
+        static final int COL_APPROVE = 2;
+        static final int COL_REMOVE = 3;
+        private static final String[] COLUMN_NAMES = {"", "File", "", ""};
 
         private final List<ReviewItem> items = new ArrayList<>();
 
@@ -392,16 +390,15 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
 
         @Override
         public Object getValueAt(int rowIndex, int columnIndex) {
-            ReviewItem item = items.get(rowIndex);
-            return switch (columnIndex) {
-                case COL_STATUS, COL_FILE -> item;
-                default -> null;
-            };
+            return items.get(rowIndex);
         }
     }
 
     // ── Cell renderers ────────────────────────────────────────────────────────
 
+    /**
+     * Status icon column: Add/Edit/Remove icon with diff colors.
+     */
     private static final class StatusCellRenderer extends DefaultTableCellRenderer {
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value,
@@ -411,143 +408,155 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
             if (value instanceof ReviewItem item && c instanceof JLabel label) {
                 label.setText("");
                 label.setHorizontalAlignment(CENTER);
-                applyStatusIcon(item, table, isSelected, label);
+                switch (item.status()) {
+                    case ADDED -> {
+                        label.setIcon(AllIcons.General.Add);
+                        label.setToolTipText("Added");
+                    }
+                    case MODIFIED -> {
+                        label.setIcon(AllIcons.Actions.Edit);
+                        label.setToolTipText("Modified");
+                    }
+                    case DELETED -> {
+                        label.setIcon(AllIcons.General.Remove);
+                        label.setToolTipText("Deleted");
+                    }
+                }
+                if (item.approved() && !isSelected) {
+                    label.setForeground(JBColor.GRAY);
+                }
             }
             return c;
-        }
-
-        private static void applyStatusIcon(@NotNull ReviewItem item, @NotNull JTable table,
-                                            boolean isSelected, @NotNull JLabel label) {
-            switch (item.status()) {
-                case ADDED -> {
-                    label.setForeground(isSelected ? table.getSelectionForeground()
-                        : new JBColor(new Color(0, 128, 0), new Color(80, 200, 80)));
-                    label.setIcon(AllIcons.General.Add);
-                    label.setToolTipText(approvedTip("Added", item));
-                }
-                case MODIFIED -> {
-                    label.setForeground(isSelected ? table.getSelectionForeground()
-                        : new JBColor(new Color(0, 100, 200), new Color(80, 160, 255)));
-                    label.setIcon(AllIcons.Actions.Edit);
-                    label.setToolTipText(approvedTip("Modified", item));
-                }
-                case DELETED -> {
-                    label.setForeground(isSelected ? table.getSelectionForeground()
-                        : new JBColor(new Color(200, 0, 0), new Color(255, 80, 80)));
-                    label.setIcon(AllIcons.General.Remove);
-                    label.setToolTipText(approvedTip("Deleted", item));
-                }
-            }
-        }
-
-        private static @NotNull String approvedTip(@NotNull String base, @NotNull ReviewItem item) {
-            return item.approvalState() == ApprovalState.APPROVED ? base + " · Approved" : base + " · Pending";
         }
     }
 
     /**
-     * Renders a row as: [filename · meta(+N −N · 5m ago)] [view | accept | revert].
-     * Approved rows render with muted foreground/background. Pending rows look normal.
+     * File name column: shows file name, diff-colored line counts, and timestamp.
+     * Approved rows are muted.
      */
     private static final class FileCellRenderer extends DefaultTableCellRenderer {
-        private final JPanel cellPanel = new JPanel(new BorderLayout(JBUI.scale(4), 0));
-        private final JLabel nameLabel = new JLabel();
-        private final JLabel metaLabel = new JLabel();
-        private final JPanel centerPanel = new JPanel(new BorderLayout(JBUI.scale(6), 0));
-        private final JPanel buttonsPanel = new JPanel(new GridLayout(1, 3, JBUI.scale(2), 0));
-
-        FileCellRenderer() {
-            cellPanel.setOpaque(true);
-            nameLabel.setOpaque(false);
-            metaLabel.setOpaque(false);
-            metaLabel.setFont(UIUtil.getLabelFont().deriveFont(UIUtil.getLabelFont().getSize() - 1f));
-            metaLabel.setForeground(JBColor.GRAY);
-            metaLabel.setHorizontalAlignment(SwingConstants.RIGHT);
-            metaLabel.setPreferredSize(new Dimension(JBUI.scale(META_AREA_WIDTH), 0));
-
-            JButton viewBtn = createButton(AllIcons.General.InspectionsEye, "View file");
-            JButton acceptBtn = createButton(AllIcons.Actions.Checked, "Approve");
-            JButton revertBtn = createButton(AllIcons.Actions.Rollback, "Revert…");
-            buttonsPanel.add(viewBtn);
-            buttonsPanel.add(acceptBtn);
-            buttonsPanel.add(revertBtn);
-            buttonsPanel.setOpaque(false);
-            buttonsPanel.setPreferredSize(new Dimension(JBUI.scale(BUTTON_AREA_WIDTH), 0));
-
-            centerPanel.setOpaque(false);
-            centerPanel.add(nameLabel, BorderLayout.CENTER);
-            centerPanel.add(metaLabel, BorderLayout.EAST);
-
-            cellPanel.setBorder(BorderFactory.createEmptyBorder(2, 4, 2, 4));
-            cellPanel.add(centerPanel, BorderLayout.CENTER);
-            cellPanel.add(buttonsPanel, BorderLayout.EAST);
-        }
-
-        private static JButton createButton(Icon icon, String tooltip) {
-            JButton btn = new JButton(icon);
-            btn.setToolTipText(tooltip);
-            btn.putClientProperty("JButton.buttonType", "borderless");
-            btn.setFocusPainted(false);
-            btn.setContentAreaFilled(false);
-            btn.setBorderPainted(false);
-            btn.setOpaque(false);
-            btn.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-            return btn;
-        }
-
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value,
                                                        boolean isSelected, boolean hasFocus,
                                                        int row, int column) {
             ReviewItem item = value instanceof ReviewItem ri ? ri : null;
-            String path = item != null ? item.path() : "";
-            String relativePath = item != null ? item.relativePath() : path;
-            java.nio.file.Path p = java.nio.file.Path.of(path);
-            String fileName = p.getFileName() != null ? p.getFileName().toString() : path;
+            super.getTableCellRendererComponent(table, "", isSelected, hasFocus, row, column);
 
-            boolean approved = item != null && item.approvalState() == ApprovalState.APPROVED;
-            String prefix = approved ? "✓ " : "";
-            nameLabel.setText(prefix + fileName);
-            nameLabel.setToolTipText(relativePath
-                + (approved ? " · Approved (DEL to remove)" : " · Pending review"));
+            if (item == null) return this;
 
-            metaLabel.setText(item != null ? buildMeta(item) : "");
-            metaLabel.setToolTipText(item != null && item.lastEditedMillis() > 0
-                ? "Last edited " + TimestampDisplayFormatter.formatEpochMillis(item.lastEditedMillis())
-                : null);
+            java.nio.file.Path p = java.nio.file.Path.of(item.path());
+            String fileName = p.getFileName() != null ? p.getFileName().toString() : item.path();
 
-            Color bg = isSelected ? table.getSelectionBackground() : table.getBackground();
-            Color fg = isSelected ? table.getSelectionForeground() : table.getForeground();
+            boolean approved = item.approved();
+            setText(buildHtml(fileName, item, isSelected, approved));
+            setToolTipText(item.relativePath() + (approved ? " · Approved" : " · Pending review"));
+
             if (approved && !isSelected) {
-                bg = mute(bg);
-                fg = JBColor.GRAY;
+                setForeground(JBColor.GRAY);
+                setBackground(mute(table.getBackground()));
             }
-            cellPanel.setBackground(bg);
-            buttonsPanel.setBackground(bg);
-            centerPanel.setBackground(bg);
-            nameLabel.setForeground(fg);
-
-            return cellPanel;
+            return this;
         }
 
-        private static @NotNull Color mute(@NotNull Color base) {
-            // Slight tint towards the panel background to visually de-emphasise approved rows.
-            int r = (base.getRed() + UIUtil.getPanelBackground().getRed()) / 2;
-            int g = (base.getGreen() + UIUtil.getPanelBackground().getGreen()) / 2;
-            int b = (base.getBlue() + UIUtil.getPanelBackground().getBlue()) / 2;
-            return new Color(r, g, b);
-        }
+        private @NotNull String buildHtml(@NotNull String fileName, @NotNull ReviewItem item,
+                                          boolean isSelected, boolean approved) {
+            StringBuilder sb = new StringBuilder("<html>");
+            if (approved && !isSelected) {
+                sb.append("<font color='gray'>").append(escapeHtml(fileName)).append("</font>");
+            } else {
+                sb.append(escapeHtml(fileName));
+            }
 
-        private static @NotNull String buildMeta(@NotNull ReviewItem item) {
-            StringBuilder sb = new StringBuilder();
+            // Diff-colored line counts
             if (item.linesAdded() > 0 || item.linesRemoved() > 0) {
-                sb.append("+").append(item.linesAdded()).append(" −").append(item.linesRemoved());
+                sb.append(" <font size='-2'>");
+                if (item.linesAdded() > 0) {
+                    String green = colorHex(approved && !isSelected ? JBColor.GRAY : DIFF_GREEN);
+                    sb.append("<font color='").append(green).append("'>+").append(item.linesAdded()).append("</font>");
+                }
+                if (item.linesRemoved() > 0) {
+                    if (item.linesAdded() > 0) sb.append(" ");
+                    String red = colorHex(approved && !isSelected ? JBColor.GRAY : DIFF_RED);
+                    sb.append("<font color='").append(red).append("'>-").append(item.linesRemoved()).append("</font>");
+                }
+                sb.append("</font>");
             }
+
+            // Timestamp
             if (item.lastEditedMillis() > 0) {
-                if (!sb.isEmpty()) sb.append(" · ");
+                sb.append(" <font size='-2' color='gray'>");
                 sb.append(TimestampDisplayFormatter.formatEpochMillis(item.lastEditedMillis()));
+                sb.append("</font>");
             }
+
+            sb.append("</html>");
             return sb.toString();
         }
+
+        private static @NotNull String escapeHtml(@NotNull String s) {
+            return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+        }
+
+        private static @NotNull String colorHex(@NotNull Color c) {
+            return String.format("#%02x%02x%02x", c.getRed(), c.getGreen(), c.getBlue());
+        }
+    }
+
+    /**
+     * Approve checkbox column: green check when approved, gray unchecked when pending.
+     */
+    private static final class ApproveCheckboxRenderer extends DefaultTableCellRenderer {
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value,
+                                                       boolean isSelected, boolean hasFocus,
+                                                       int row, int column) {
+            Component c = super.getTableCellRendererComponent(table, "", isSelected, hasFocus, row, column);
+            if (value instanceof ReviewItem item && c instanceof JLabel label) {
+                label.setText("");
+                label.setHorizontalAlignment(CENTER);
+                if (item.approved()) {
+                    label.setIcon(AllIcons.Diff.GutterCheckBoxSelected);
+                    label.setToolTipText("Approved — click to unapprove");
+                } else {
+                    label.setIcon(AllIcons.Diff.GutterCheckBox);
+                    label.setToolTipText("Pending — click to approve");
+                }
+            }
+            return c;
+        }
+    }
+
+    /**
+     * Remove X column: only active for approved rows.
+     */
+    private static final class RemoveButtonRenderer extends DefaultTableCellRenderer {
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value,
+                                                       boolean isSelected, boolean hasFocus,
+                                                       int row, int column) {
+            Component c = super.getTableCellRendererComponent(table, "", isSelected, hasFocus, row, column);
+            if (value instanceof ReviewItem item && c instanceof JLabel label) {
+                label.setText("");
+                label.setHorizontalAlignment(CENTER);
+                if (item.approved()) {
+                    label.setIcon(AllIcons.Actions.Close);
+                    label.setToolTipText("Remove from list");
+                } else {
+                    label.setIcon(AllIcons.Actions.CloseHovered);
+                    // Dim the icon for pending rows — they should be reverted, not removed
+                    label.setForeground(JBColor.GRAY);
+                    label.setIcon(null);
+                    label.setToolTipText(null);
+                }
+            }
+            return c;
+        }
+    }
+
+    private static @NotNull Color mute(@NotNull Color base) {
+        int r = (base.getRed() + UIUtil.getPanelBackground().getRed()) / 2;
+        int g = (base.getGreen() + UIUtil.getPanelBackground().getGreen()) / 2;
+        int b = (base.getBlue() + UIUtil.getPanelBackground().getBlue()) / 2;
+        return new Color(r, g, b);
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.ui.side;
 
 import com.github.catatafishen.agentbridge.psi.PlatformApiCompat;
+import com.github.catatafishen.agentbridge.services.ActiveAgentManager;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileTypes.FileTypeManager;
@@ -23,6 +24,7 @@ import java.awt.event.MouseEvent;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -105,6 +107,8 @@ final class ProjectFilesPanel extends JPanel {
         kiro.addAll(glob(base, ".agent-work/kiro/skills", "*/SKILL.md"));
         addSection("Kiro", kiro);
 
+        addSessionSection();
+
         treeModel.reload();
         for (int i = 0; i < tree.getRowCount(); i++) {
             tree.expandRow(i);
@@ -118,6 +122,42 @@ final class ProjectFilesPanel extends JPanel {
             section.add(new DefaultMutableTreeNode(fn));
         }
         root.add(section);
+    }
+
+    /**
+     * Adds a "Current Session" section listing files from the active agent's session directory.
+     */
+    private void addSessionSection() {
+        try {
+            var manager = ActiveAgentManager.getInstance(project);
+            var client = manager.getClient();
+            Path sessionDir = client.getSessionDirectory();
+            if (sessionDir == null || !Files.isDirectory(sessionDir)) return;
+
+            List<FileNode> sessionFiles = listSessionFiles(sessionDir.toFile(), sessionDir.toFile());
+            sessionFiles.sort((a, b) -> a.label.compareToIgnoreCase(b.label));
+            addSection("Current Session", sessionFiles);
+        } catch (Throwable ignored) {
+            // agent may not be started yet
+        }
+    }
+
+    /**
+     * Recursively lists files under the session directory, using relative paths as labels.
+     */
+    private static @NotNull List<FileNode> listSessionFiles(@NotNull File root, @NotNull File dir) {
+        List<FileNode> results = new ArrayList<>();
+        File[] children = dir.listFiles();
+        if (children == null) return results;
+        for (File child : children) {
+            if (child.isDirectory()) {
+                results.addAll(listSessionFiles(root, child));
+            } else {
+                String rel = root.toURI().relativize(child.toURI()).getPath();
+                results.add(new FileNode(root.getAbsolutePath(), rel, rel, false));
+            }
+        }
+        return results;
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/PromptsPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/PromptsPanel.kt
@@ -17,9 +17,6 @@ import java.awt.Cursor
 import java.awt.Dimension
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
-import java.time.LocalDate
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 import javax.swing.*
 import javax.swing.event.DocumentEvent
 
@@ -241,24 +238,8 @@ internal class PromptsPanel(
             return if (truncated.length < text.length) truncated.trimEnd() + "…" else text
         }
 
-        fun formatTimestamp(iso: String): String {
-            if (iso.isEmpty()) return ""
-            return try {
-                val instant = java.time.Instant.parse(iso)
-                val zdt = instant.atZone(ZoneId.systemDefault())
-                val today = LocalDate.now()
-                val date = zdt.toLocalDate()
-                val time = DateTimeFormatter.ofPattern("HH:mm").format(zdt)
-                when {
-                    date == today -> "Today $time"
-                    date == today.minusDays(1) -> "Yesterday $time"
-                    date.year == today.year -> "${DateTimeFormatter.ofPattern("MMM d").format(zdt)} $time"
-                    else -> "${DateTimeFormatter.ofPattern("MMM d yyyy").format(zdt)} $time"
-                }
-            } catch (_: Exception) {
-                iso
-            }
-        }
+        fun formatTimestamp(iso: String): String =
+            com.github.catatafishen.agentbridge.ui.util.TimestampDisplayFormatter.formatIsoTimestamp(iso)
 
         fun filterPrompts(prompts: List<EntryData.Prompt>, query: String): List<EntryData.Prompt> {
             val q = query.trim()

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SidePanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SidePanel.java
@@ -14,17 +14,22 @@ import java.awt.*;
 /**
  * Tabbed container for the left-hand tool-window pane.
  * Uses {@link PlatformApiCompat#createJBTabsPanel} for native IntelliJ flat tab styling.
- * Hosts three tabs:
+ * Hosts four tabs:
  * <ol>
  *   <li><b>Review</b> — the existing {@link ReviewChangesPanel} with pending agent edits.</li>
- *   <li><b>Project Files</b> — configuration/agent-definition files for this project.</li>
+ *   <li><b>Files</b> — configuration/agent-definition files for this project.</li>
+ *   <li><b>Todos</b> — rendered view of the active agent session's {@code plan.md},
+ *       with a {@code (done/total)} badge in the tab title when checkbox-style todos exist.</li>
  *   <li><b>Prompts</b> — searchable list of user prompts in the current chat, click to scroll.</li>
  * </ol>
  * Tab order is deliberate: review is the most time-sensitive and sits first.
  */
 public final class SidePanel extends JPanel implements Disposable {
 
+    private static final int TAB_REVIEW = 0;
     private static final int TAB_FILES = 1;
+    private static final int TAB_TODOS = 2;
+    private static final int TAB_PROMPTS = 3;
 
     private final transient PlatformApiCompat.JBTabsPanel tabsPanel;
 
@@ -34,18 +39,29 @@ public final class SidePanel extends JPanel implements Disposable {
         Disposer.register(this, reviewPanel);
 
         ProjectFilesPanel projectFilesPanel = new ProjectFilesPanel(project);
+        TodoPanel todoPanel = new TodoPanel(project);
+        Disposer.register(this, todoPanel);
         PromptsPanel promptsPanel = new PromptsPanel(chatConsole);
         Disposer.register(this, promptsPanel);
 
         tabsPanel = PlatformApiCompat.createJBTabsPanel(project, this);
         tabsPanel.addTab(reviewPanel, "Review");
         tabsPanel.addTab(projectFilesPanel, "Files");
+        tabsPanel.addTab(todoPanel, "Todos");
         tabsPanel.addTab(promptsPanel, "Prompts");
 
-        // Refresh the project-files list each time that tab is selected so newly-created
-        // files appear without requiring the user to reopen the tool window.
+        todoPanel.setOnProgressChanged(() -> {
+            int total = todoPanel.getTotal();
+            int done = todoPanel.getDone();
+            String title = total > 0 ? "Todos (" + done + "/" + total + ")" : "Todos";
+            tabsPanel.setTabTitle(TAB_TODOS, title);
+        });
+
+        // Refresh contextual tabs each time they are selected so changes made elsewhere
+        // (new files on disk, the agent editing plan.md) appear without manual refresh.
         tabsPanel.addSelectionListener(idx -> {
             if (idx == TAB_FILES) projectFilesPanel.refresh();
+            else if (idx == TAB_TODOS) todoPanel.refresh();
         }, this);
 
         add(tabsPanel.getComponent(), BorderLayout.CENTER);
@@ -55,7 +71,7 @@ public final class SidePanel extends JPanel implements Disposable {
      * Switches to the Review tab. Safe to call from the EDT.
      */
     public void selectReviewTab() {
-        tabsPanel.selectTab(0);
+        tabsPanel.selectTab(TAB_REVIEW);
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/TodoPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/TodoPanel.java
@@ -1,0 +1,288 @@
+package com.github.catatafishen.agentbridge.ui.side;
+
+import com.github.catatafishen.agentbridge.services.ActiveAgentManager;
+import com.github.catatafishen.agentbridge.ui.MarkdownRenderer;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+import com.intellij.ui.JBColor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import javax.swing.event.HyperlinkEvent;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Side-panel tab that renders the active agent session's plan/todo file.
+ * <p>
+ * Different agents store their task-list in different places and formats, but the plugin
+ * treats {@code plan.md} inside the active agent's session directory as the canonical
+ * todo file (see {@code SessionSwitchService#PLAN_FILE_NAME}). This panel shows that
+ * file as rendered Markdown and exposes a {@code (done/total)} progress summary that
+ * the parent tab container uses to badge the tab title.
+ * <p>
+ * The panel polls the file's modification time every {@link #POLL_INTERVAL_MS} ms while
+ * showing, so edits made by the agent (or the user) appear without requiring a manual
+ * refresh. Polling stops when the panel is removed from the component hierarchy.
+ */
+final class TodoPanel extends JPanel implements Disposable {
+
+    private static final Pattern CHECKBOX_LINE = Pattern.compile("^\\s*[-*]\\s+\\[([ xX])]\\s+.+$");
+    private static final int POLL_INTERVAL_MS = 1500;
+
+    private final transient Project project;
+    private final JEditorPane markdownPane;
+    private final JBLabel emptyLabel;
+    private final JBLabel headerLabel;
+    private final JPanel contentPanel;
+    private final transient Timer pollTimer;
+    private @Nullable Runnable onProgressChanged;
+
+    /**
+     * Last observed (path, mtime, done, total) so the poll timer can skip work when nothing changed.
+     */
+    private @Nullable Path lastPath;
+    private long lastMtime = -1L;
+    private int lastDone = -1;
+    private int lastTotal = -1;
+
+    TodoPanel(@NotNull Project project) {
+        super(new BorderLayout());
+        this.project = project;
+
+        headerLabel = new JBLabel();
+        headerLabel.setFont(UIUtil.getLabelFont().deriveFont(Font.BOLD));
+        headerLabel.setBorder(JBUI.Borders.empty(6, 8, 4, 8));
+        headerLabel.setVisible(false);
+
+        markdownPane = createMarkdownPane();
+
+        emptyLabel = new JBLabel(
+            "<html><div style='text-align:center; color:#888;'>"
+            + "No todos for the current agent session."
+            + "<br><br><small>Ask the agent to create a plan, or start a new task.</small>"
+            + "</div></html>",
+            SwingConstants.CENTER
+        );
+        emptyLabel.setVerticalAlignment(SwingConstants.CENTER);
+        emptyLabel.setHorizontalAlignment(SwingConstants.CENTER);
+
+        contentPanel = new JPanel(new BorderLayout());
+        contentPanel.add(emptyLabel, BorderLayout.CENTER);
+
+        JPanel body = new JPanel(new BorderLayout());
+        body.add(headerLabel, BorderLayout.NORTH);
+        body.add(contentPanel, BorderLayout.CENTER);
+        add(body, BorderLayout.CENTER);
+
+        pollTimer = new Timer(POLL_INTERVAL_MS, e -> pollIfVisible());
+        pollTimer.setRepeats(true);
+    }
+
+    /**
+     * Registers a callback fired whenever the todo count changes. Called on the EDT.
+     * The consumer receives {@code (done, total)} — both zero when no checkbox-style
+     * items exist (in which case the parent should drop the badge).
+     */
+    void setOnProgressChanged(@NotNull Runnable callback) {
+        this.onProgressChanged = callback;
+    }
+
+    /** Zero when no checkbox-style todos were found. */
+    int getTotal() {
+        return Math.max(0, lastTotal);
+    }
+
+    /** Zero when no checkbox-style todos were found. */
+    int getDone() {
+        return Math.max(0, lastDone);
+    }
+
+    private JEditorPane createMarkdownPane() {
+        JEditorPane pane = new JEditorPane();
+        pane.setContentType("text/html");
+        pane.setEditable(false);
+        pane.setOpaque(true);
+        pane.setBackground(UIUtil.getPanelBackground());
+        pane.setBorder(JBUI.Borders.empty(4, 8, 8, 8));
+        pane.addHyperlinkListener(e -> {
+            if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+                openPlanInEditor();
+            }
+        });
+        pane.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (e.getClickCount() == 2) openPlanInEditor();
+            }
+        });
+        return pane;
+    }
+
+    @Override
+    public void addNotify() {
+        super.addNotify();
+        refresh();
+        pollTimer.start();
+    }
+
+    @Override
+    public void removeNotify() {
+        pollTimer.stop();
+        super.removeNotify();
+    }
+
+    @Override
+    public void dispose() {
+        pollTimer.stop();
+    }
+
+    private void pollIfVisible() {
+        if (!isShowing()) return;
+        refresh();
+    }
+
+    /**
+     * Re-reads the plan file and repaints if anything changed. Safe to call from the EDT.
+     */
+    void refresh() {
+        Path path = resolvePlanPath();
+        if (path == null || !Files.isRegularFile(path)) {
+            renderEmpty();
+            return;
+        }
+
+        long mtime;
+        String content;
+        try {
+            mtime = Files.getLastModifiedTime(path).toMillis();
+            if (path.equals(lastPath) && mtime == lastMtime) return;
+            content = Files.readString(path, StandardCharsets.UTF_8);
+        } catch (IOException ex) {
+            renderEmpty();
+            return;
+        }
+
+        lastPath = path;
+        lastMtime = mtime;
+        renderMarkdown(content);
+    }
+
+    private void renderEmpty() {
+        boolean changed = lastTotal != 0 || lastDone != 0 || lastPath != null;
+        lastPath = null;
+        lastMtime = -1L;
+        lastDone = 0;
+        lastTotal = 0;
+
+        headerLabel.setVisible(false);
+        contentPanel.removeAll();
+        contentPanel.add(emptyLabel, BorderLayout.CENTER);
+        contentPanel.revalidate();
+        contentPanel.repaint();
+        if (changed && onProgressChanged != null) onProgressChanged.run();
+    }
+
+    private void renderMarkdown(@NotNull String markdown) {
+        int[] progress = countCheckboxes(markdown);
+        int done = progress[0];
+        int total = progress[1];
+
+        boolean progressChanged = done != lastDone || total != lastTotal;
+        lastDone = done;
+        lastTotal = total;
+
+        if (total > 0) {
+            headerLabel.setText(done + " / " + total + " completed"
+                + (done == total ? "  ✓" : ""));
+            headerLabel.setForeground(done == total
+                ? new JBColor(new Color(0x2F9E44), new Color(0x6BD968))
+                : UIUtil.getLabelForeground());
+            headerLabel.setVisible(true);
+        } else {
+            headerLabel.setVisible(false);
+        }
+
+        String html = renderHtml(markdown);
+        markdownPane.setText(html);
+        markdownPane.setCaretPosition(0);
+
+        contentPanel.removeAll();
+        JBScrollPane scroll = new JBScrollPane(markdownPane);
+        scroll.setBorder(JBUI.Borders.empty());
+        scroll.getVerticalScrollBar().setUnitIncrement(16);
+        contentPanel.add(scroll, BorderLayout.CENTER);
+        contentPanel.revalidate();
+        contentPanel.repaint();
+
+        if (progressChanged && onProgressChanged != null) onProgressChanged.run();
+    }
+
+    private static @NotNull String renderHtml(@NotNull String markdown) {
+        String body = MarkdownRenderer.INSTANCE.markdownToHtml(markdown);
+        Color fg = UIUtil.getLabelForeground();
+        String fgHex = String.format("#%02x%02x%02x", fg.getRed(), fg.getGreen(), fg.getBlue());
+        return "<html><body style='font-family: sans-serif; font-size: 12px; color: "
+            + fgHex + "; margin: 0; padding: 0;'>"
+            + body
+            + "</body></html>";
+    }
+
+    /**
+     * Counts markdown checkbox lines. Returns {@code [done, total]}. Both zero if none found.
+     */
+    private static int[] countCheckboxes(@NotNull String markdown) {
+        int done = 0;
+        int total = 0;
+        for (String line : markdown.split("\\R", -1)) {
+            Matcher m = CHECKBOX_LINE.matcher(line);
+            if (m.matches()) {
+                total++;
+                if (!" ".equals(m.group(1))) done++;
+            }
+        }
+        return new int[] { done, total };
+    }
+
+    /**
+     * Resolves the plan file for the currently-active agent session.
+     * Returns {@code null} if no agent is running or the session dir is unknown.
+     */
+    private @Nullable Path resolvePlanPath() {
+        try {
+            ActiveAgentManager manager = ActiveAgentManager.getInstance(project);
+            Path sessionDir = manager.getClient().getSessionDirectory();
+            if (sessionDir == null) return null;
+            return sessionDir.resolve("plan.md");
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    private void openPlanInEditor() {
+        Path path = resolvePlanPath();
+        if (path == null || !Files.isRegularFile(path)) return;
+        ApplicationManager.getApplication().invokeLater(() -> {
+            VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(path);
+            if (vf != null) {
+                FileEditorManager.getInstance(project).openFile(vf, true);
+            }
+        });
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/util/TimestampDisplayFormatter.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/util/TimestampDisplayFormatter.kt
@@ -1,0 +1,53 @@
+package com.github.catatafishen.agentbridge.ui.util
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/**
+ * Pure formatting utility for "human-friendly" timestamps used across the side panels
+ * (prompts list, review-changes list, and any future timeline view).
+ *
+ * The display format mirrors the rest of the IDE-side UI:
+ * `Today HH:mm`, `Yesterday HH:mm`, `MMM d HH:mm` (same year), `MMM d yyyy HH:mm` (other year).
+ *
+ * Two entry points are provided so callers can pass whichever representation they have:
+ *  - [formatIsoTimestamp] for ISO 8601 strings (chat events, conversation files).
+ *  - [formatEpochMillis] for `System.currentTimeMillis()`-style longs (review-row last-edited).
+ */
+object TimestampDisplayFormatter {
+
+    private val TIME = DateTimeFormatter.ofPattern("HH:mm")
+    private val MONTH_DAY = DateTimeFormatter.ofPattern("MMM d")
+    private val MONTH_DAY_YEAR = DateTimeFormatter.ofPattern("MMM d yyyy")
+
+    @JvmStatic
+    fun formatIsoTimestamp(iso: String): String {
+        if (iso.isEmpty()) return ""
+        return try {
+            formatInstant(Instant.parse(iso))
+        } catch (_: Exception) {
+            iso
+        }
+    }
+
+    @JvmStatic
+    fun formatEpochMillis(millis: Long): String {
+        if (millis <= 0L) return ""
+        return formatInstant(Instant.ofEpochMilli(millis))
+    }
+
+    private fun formatInstant(instant: Instant): String {
+        val zdt = instant.atZone(ZoneId.systemDefault())
+        val today = LocalDate.now()
+        val date = zdt.toLocalDate()
+        val time = TIME.format(zdt)
+        return when {
+            date == today -> "Today $time"
+            date == today.minusDays(1) -> "Yesterday $time"
+            date.year == today.year -> "${MONTH_DAY.format(zdt)} $time"
+            else -> "${MONTH_DAY_YEAR.format(zdt)} $time"
+        }
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/ReviewItemDerivationTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/ReviewItemDerivationTest.java
@@ -35,17 +35,20 @@ class ReviewItemDerivationTest {
             String path = entry.getKey();
             if (deletedFiles.containsKey(path)) continue;
             items.add(new ReviewItem(path, relativize(path),
-                ReviewItem.Status.MODIFIED, entry.getValue()));
+                ReviewItem.Status.MODIFIED, entry.getValue(),
+                ApprovalState.PENDING, 0L, 0, 0));
         }
         for (String path : newFiles) {
             items.add(new ReviewItem(path, relativize(path),
-                ReviewItem.Status.ADDED, null));
+                ReviewItem.Status.ADDED, null,
+                ApprovalState.PENDING, 0L, 0, 0));
         }
         for (var entry : deletedFiles.entrySet()) {
             String path = entry.getKey();
             String beforeContent = snapshots.getOrDefault(path, entry.getValue());
             items.add(new ReviewItem(path, relativize(path),
-                ReviewItem.Status.DELETED, beforeContent));
+                ReviewItem.Status.DELETED, beforeContent,
+                ApprovalState.PENDING, 0L, 0, 0));
         }
 
         items.sort((a, b) -> a.relativePath().compareToIgnoreCase(b.relativePath()));

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/ReviewItemV2FieldsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/ReviewItemV2FieldsTest.java
@@ -1,0 +1,54 @@
+package com.github.catatafishen.agentbridge.psi.review;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests the pure data shape of {@link ReviewItem} with the v2 fields
+ * ({@code approvalState}, {@code lastEditedMillis}, {@code linesAdded},
+ * {@code linesRemoved}). Persistence and behavioural tests for
+ * {@link AgentEditSession} live in integration tests because they need
+ * the IntelliJ Project + DocumentManager infrastructure.
+ */
+class ReviewItemV2FieldsTest {
+
+    @Test
+    void approvedReturnsTrueOnlyForApprovedState() {
+        ReviewItem pending = new ReviewItem("/p/Foo.java", "Foo.java",
+            ReviewItem.Status.MODIFIED, "before",
+            ApprovalState.PENDING, 1_700_000_000_000L, 5, 2);
+        ReviewItem approved = new ReviewItem("/p/Foo.java", "Foo.java",
+            ReviewItem.Status.MODIFIED, "before",
+            ApprovalState.APPROVED, 1_700_000_000_000L, 5, 2);
+
+        assertFalse(pending.approved());
+        assertTrue(approved.approved());
+    }
+
+    @Test
+    void linesCountsAreExposed() {
+        ReviewItem item = new ReviewItem("/p/Foo.java", "Foo.java",
+            ReviewItem.Status.MODIFIED, "before",
+            ApprovalState.PENDING, 0L, 12, 7);
+        assertEquals(12, item.linesAdded());
+        assertEquals(7, item.linesRemoved());
+    }
+
+    @Test
+    void lastEditedMillisIsExposed() {
+        ReviewItem item = new ReviewItem("/p/Foo.java", "Foo.java",
+            ReviewItem.Status.MODIFIED, null,
+            ApprovalState.PENDING, 1_234_567_890L, 0, 0);
+        assertEquals(1_234_567_890L, item.lastEditedMillis());
+    }
+
+    @Test
+    void approvalStateRoundTripsThroughEnumName() {
+        // Persistence stores the enum as its name() — round-trip safety check
+        // for the load path in AgentEditSession.PersistedState.
+        for (ApprovalState state : ApprovalState.values()) {
+            assertEquals(state, ApprovalState.valueOf(state.name()));
+        }
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsToolStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsToolStaticMethodsTest.java
@@ -349,6 +349,64 @@ class RunTestsToolStaticMethodsTest {
         }
     }
 
+    // ── buildGradleTestFilter ────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("buildGradleTestFilter")
+    class BuildGradleTestFilter {
+
+        @Test
+        @DisplayName("simple class name gets wildcard package prefix")
+        void simpleClassName() {
+            assertEquals("*.FormattingTest", RunTestsTool.buildGradleTestFilter("FormattingTest"));
+        }
+
+        @Test
+        @DisplayName("wildcard class suffix gets wildcard package prefix")
+        void wildcardSuffix() {
+            assertEquals("*.*Test", RunTestsTool.buildGradleTestFilter("*Test"));
+        }
+
+        @Test
+        @DisplayName("double wildcard is unchanged")
+        void doubleWildcard() {
+            assertEquals("*.*Test", RunTestsTool.buildGradleTestFilter("*.*Test"));
+        }
+
+        @Test
+        @DisplayName("fully qualified class name is unchanged")
+        void fullyQualifiedClass() {
+            assertEquals("com.example.FormattingTest",
+                RunTestsTool.buildGradleTestFilter("com.example.FormattingTest"));
+        }
+
+        @Test
+        @DisplayName("class.method with no package gets wildcard package prefix")
+        void classMethodNoPackage() {
+            assertEquals("*.FormattingTest.testFoo",
+                RunTestsTool.buildGradleTestFilter("FormattingTest.testFoo"));
+        }
+
+        @Test
+        @DisplayName("fully qualified class.method is unchanged")
+        void fullyQualifiedClassMethod() {
+            assertEquals("com.example.FormattingTest.testFoo",
+                RunTestsTool.buildGradleTestFilter("com.example.FormattingTest.testFoo"));
+        }
+
+        @Test
+        @DisplayName("wildcard with package qualifier is unchanged")
+        void wildcardWithPackage() {
+            assertEquals("*.FormattingTest", RunTestsTool.buildGradleTestFilter("*.FormattingTest"));
+        }
+
+        @Test
+        @DisplayName("single wildcard gets prefix")
+        void singleWildcard() {
+            assertEquals("*.*", RunTestsTool.buildGradleTestFilter("*"));
+        }
+    }
+
     // ── formatConsoleSection ─────────────────────────────────────────────────
 
     @Nested


### PR DESCRIPTION
## Problem

Gradle's `--tests` filter rejects unqualified patterns:
- `*Test` → `No tests found for given includes: [*Test](--tests filter)`
- `FormattingTest` → `No matching tests found in any candidate test task`

Gradle interprets bare simple names as root-package patterns, not any-package wildcards. It requires either a FQN (`com.example.FormattingTest`) or a wildcard-package form (`*.FormattingTest`, `*.*Test`).

This caused false-negative test failures — the code was fine but the runner reported errors.

## Fix

Added `buildGradleTestFilter()` which normalises the `--tests` argument before passing it to Gradle:

| Input | Output | Reason |
|-------|--------|--------|
| `*Test` | `*.*Test` | no dot — prepend `*.` |
| `FormattingTest` | `*.FormattingTest` | no dot — prepend `*.` |
| `FormattingTest.testFoo` | `*.FormattingTest.testFoo` | first segment uppercase — prepend `*.` |
| `com.example.Foo` | `com.example.Foo` | already package-qualified — unchanged |
| `*.*Test` | `*.*Test` | already wildcarded — unchanged |
| `*.FormattingTest` | `*.FormattingTest` | already wildcarded — unchanged |

8 unit tests added to `RunTestsToolStaticMethodsTest`.