### PR TITLE
fix: tail-read session files to fix slow connect with large sessions

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/SessionSwitchService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/SessionSwitchService.java
@@ -618,7 +618,7 @@ public final class SessionSwitchService implements Disposable {
 
     @Nullable
     private List<EntryData> loadCurrentV2Session(@Nullable String basePath) {
-        return SessionStoreV2.getInstance(project).loadEntries(basePath);
+        return SessionStoreV2.getInstance(project).loadRecentEntries(basePath).entries();
     }
 
     // ── Path helpers ──────────────────────────────────────────────────────────

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/session/v2/SessionStoreV2.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
@@ -388,6 +389,24 @@ public final class SessionStoreV2 implements Disposable {
     }
 
     /**
+     * Maximum bytes to read from disk when loading recent entries for UI restore or export.
+     * Files are read newest-first and loading stops once this budget is exceeded, keeping
+     * memory use bounded even for very large sessions.
+     */
+    static final long RECENT_ENTRIES_MAX_BYTES = 20L * 1024 * 1024; // 20 MB
+
+    /**
+     * Result of a tail-limited session load via {@link #loadRecentEntries(String)}.
+     *
+     * @param entries       loaded entries in chronological order
+     * @param hasMoreOnDisk {@code true} when older entries exist in part files that were
+     *                      not loaded because the byte budget was reached
+     */
+    public record RecentEntriesResult(
+        @NotNull List<EntryData> entries,
+        boolean hasMoreOnDisk) {}
+
+    /**
      * Loads conversation directly as EntryData entries from V2 JSONL,
      * bypassing the V1 JSON intermediary. This is the preferred load path.
      * Falls back to V1 if V2 is absent.
@@ -455,34 +474,129 @@ public final class SessionStoreV2 implements Disposable {
         }
     }
 
+    /**
+     * Loads the most recent entries from the current session, bounded by
+     * {@link #RECENT_ENTRIES_MAX_BYTES}. Reads part files in reverse order (active file
+     * first, then part files from highest to lowest) and stops once the cumulative
+     * on-disk byte size of loaded files reaches the budget.
+     *
+     * <p>Use this for UI restore and for export, where only recent context is needed.
+     * Use {@link #loadEntries(String)} only when all historical data is required
+     * (e.g., usage statistics).
+     *
+     * @return a {@link RecentEntriesResult} with entries in chronological order, or
+     *         {@code null} if no v2 session files exist
+     */
+    @Nullable
+    public RecentEntriesResult loadRecentEntries(@Nullable String basePath) {
+        File dir = sessionsDir(basePath);
+        File idFile = currentSessionIdFile(basePath);
+        if (!idFile.exists()) return null;
+
+        String sessionId;
+        try {
+            sessionId = Files.readString(idFile.toPath(), StandardCharsets.UTF_8).trim();
+        } catch (IOException e) {
+            LOG.warn("Could not read current-session-id", e);
+            return null;
+        }
+        if (sessionId.isEmpty()) return null;
+
+        List<Path> allFiles = SessionFileRotation.listAllFiles(dir, sessionId);
+        if (allFiles.isEmpty()) return null;
+
+        // Collect files newest-first until byte budget is reached.
+        List<Path> filesToLoad = new ArrayList<>();
+        long totalBytesRead = 0;
+        boolean hasMoreOnDisk = false;
+        for (int i = allFiles.size() - 1; i >= 0; i--) {
+            if (totalBytesRead >= RECENT_ENTRIES_MAX_BYTES) {
+                hasMoreOnDisk = true;
+                break;
+            }
+            Path file = allFiles.get(i);
+            filesToLoad.add(file);
+            totalBytesRead += file.toFile().length();
+        }
+
+        // Reverse to chronological order and parse.
+        Collections.reverse(filesToLoad);
+        List<EntryData> allDirectEntries = new ArrayList<>();
+        List<JsonObject> allLegacyMessages = new ArrayList<>();
+        int totalSkipped = 0;
+        for (Path file : filesToLoad) {
+            totalSkipped += parseFileIntoCollections(file, allDirectEntries, allLegacyMessages);
+        }
+        if (totalSkipped > 0) {
+            logSkippedLines(allDirectEntries.size() + allLegacyMessages.size(),
+                filesToLoad.size(), totalSkipped, "recent");
+        }
+
+        List<EntryData> entries;
+        if (!allDirectEntries.isEmpty()) entries = allDirectEntries;
+        else if (!allLegacyMessages.isEmpty()) entries = convertLegacyMessages(allLegacyMessages);
+        else return null;
+
+        return new RecentEntriesResult(entries, hasMoreOnDisk);
+    }
+
     @Nullable
     private List<EntryData> loadEntriesFromFiles(@NotNull List<Path> files) {
         List<EntryData> allDirectEntries = new ArrayList<>();
         List<JsonObject> allLegacyMessages = new ArrayList<>();
-        int skippedLines = 0;
+        int totalSkipped = 0;
 
         for (Path file : files) {
-            try (var reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    line = line.trim();
-                    if (line.isEmpty()) continue;
-                    if (!parseOneJsonlLine(line, allDirectEntries, allLegacyMessages)) skippedLines++;
-                }
-            } catch (IOException e) {
-                LOG.warn("Failed to read session file: " + file, e);
-            }
+            totalSkipped += parseFileIntoCollections(file, allDirectEntries, allLegacyMessages);
         }
 
-        if (skippedLines > 0) {
-            int totalParsed = allDirectEntries.size() + allLegacyMessages.size();
-            LOG.warn("JSONL parse: loaded " + totalParsed + " entries across "
-                + files.size() + " file(s), skipped " + skippedLines + " malformed lines");
+        if (totalSkipped > 0) {
+            logSkippedLines(allDirectEntries.size() + allLegacyMessages.size(),
+                files.size(), totalSkipped, null);
         }
 
         if (!allDirectEntries.isEmpty()) return allDirectEntries;
         if (!allLegacyMessages.isEmpty()) return convertLegacyMessages(allLegacyMessages);
         return null;
+    }
+
+    /**
+     * Parses a single JSONL file into the given collections.
+     * Extracted to support both full-load and tail-load paths.
+     *
+     * @return number of malformed lines skipped
+     */
+    private int parseFileIntoCollections(
+        @NotNull Path file,
+        @NotNull List<EntryData> directEntries,
+        @NotNull List<JsonObject> legacyMessages) {
+
+        int skipped = 0;
+        try (var reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty()) continue;
+                if (!parseOneJsonlLine(line, directEntries, legacyMessages)) skipped++;
+            }
+        } catch (IOException e) {
+            LOG.warn("Failed to read session file: " + file, e);
+        }
+        return skipped;
+    }
+
+    /**
+     * Emits a WARN log when malformed JSONL lines were skipped during a load.
+     *
+     * @param totalParsed total entries successfully parsed
+     * @param fileCount   number of files read
+     * @param skipped     number of lines skipped
+     * @param qualifier   optional label inserted before "JSONL parse" (e.g. "recent"); may be null
+     */
+    private static void logSkippedLines(int totalParsed, int fileCount, int skipped, @Nullable String qualifier) {
+        String label = qualifier != null ? "JSONL parse (" + qualifier + ")" : "JSONL parse";
+        LOG.warn(label + ": loaded " + totalParsed + " entries across "
+            + fileCount + " file(s), skipped " + skipped + " malformed lines");
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -183,7 +183,8 @@ class ChatToolWindowContent(
                         // clicked elsewhere in the 150ms window, honour that intent rather than
                         // stealing focus back to the prompt.
                         if (com.github.catatafishen.agentbridge.psi.PsiBridgeService
-                                .isChatToolWindowActive(project)) {
+                                .isChatToolWindowActive(project)
+                        ) {
                             promptTextArea.requestFocusInWindow()
                         }
                     }, 150)
@@ -845,8 +846,10 @@ class ChatToolWindowContent(
         // Auto-clean approved review rows when a brand-new user turn starts (not nudge / queued follow-up).
         if (com.github.catatafishen.agentbridge.settings.McpServerSettings.getInstance(project).isAutoCleanReviewOnNewPrompt) {
             try {
-                project.getService(com.github.catatafishen.agentbridge.psi.review.AgentEditSession::class.java)?.removeAllApproved()
-            } catch (_: Throwable) { /* defensive: review session is best-effort */ }
+                project.getService(com.github.catatafishen.agentbridge.psi.review.AgentEditSession::class.java)
+                    ?.removeAllApproved()
+            } catch (_: Throwable) { /* defensive: review session is best-effort */
+            }
         }
         setSendingState(true)
 
@@ -972,11 +975,13 @@ class ChatToolWindowContent(
                 ApplicationManager.getApplication().invokeLater {
                     consolePanel.removeNudgeBubble(nudgeId)
                     if (nudgeText != null) {
-                        val mode = com.github.catatafishen.agentbridge.settings.ChatInputSettings.getInstance().unhandledNudgeMode
+                        val mode =
+                            com.github.catatafishen.agentbridge.settings.ChatInputSettings.getInstance().unhandledNudgeMode
                         if (mode == com.github.catatafishen.agentbridge.settings.ChatInputSettings.UnhandledNudgeMode.RESTORE_INTO_INPUT) {
                             // Prepend the unhandled nudge to whatever the user is currently typing — do not auto-send.
                             val current = promptTextArea.text
-                            promptTextArea.text = if (current.isNullOrEmpty()) nudgeText else nudgeText + "\n\n" + current
+                            promptTextArea.text =
+                                if (current.isNullOrEmpty()) nudgeText else nudgeText + "\n\n" + current
                             promptTextArea.requestFocusInWindow()
                         } else {
                             // Default: auto-send the nudge as a fresh prompt.
@@ -2072,12 +2077,18 @@ class ChatToolWindowContent(
     private fun restoreConversation(onComplete: () -> Unit = {}) {
         ApplicationManager.getApplication().executeOnPooledThread {
             V1ToV2Migrator.migrateIfNeeded(project.basePath)
-            val entries = conversationStore.loadEntries(project.basePath)
+            val result = conversationStore.loadRecentEntries(project.basePath)
+            val entries = result?.entries() ?: emptyList()
+            val hasMoreOnDisk = result?.hasMoreOnDisk() ?: false
             ApplicationManager.getApplication().invokeLater {
-                if (entries != null) {
+                if (entries.isNotEmpty()) {
                     val histSettings = ChatHistorySettings.getInstance(project)
                     chatConsolePanel.setDomMessageLimit(histSettings.domMessageLimit)
-                    conversationReplayer.loadAndSplit(entries, histSettings.recentTurnsOnRestore)
+                    conversationReplayer.loadAndSplit(
+                        entries,
+                        histSettings.recentTurnsOnRestore,
+                        hasMoreOnDisk
+                    )
                     chatConsolePanel.appendEntries(
                         conversationReplayer.recentEntries(),
                         conversationReplayer.totalPromptCount()
@@ -2192,8 +2203,14 @@ class ChatToolWindowContent(
         val batch = conversationReplayer.loadNextBatch(batchSize)
         if (batch.isNotEmpty()) chatConsolePanel.prependEntries(batch)
         val remaining = conversationReplayer.remainingPromptCount()
-        if (remaining > 0) chatConsolePanel.showLoadMore(remaining)
-        else chatConsolePanel.hideLoadMore()
+        if (remaining > 0) {
+            chatConsolePanel.showLoadMore(remaining)
+        } else {
+            if (conversationReplayer.hasOlderHistoryOnDisk) {
+                LOG.info("Older history exists on disk but was not loaded (session too large for tail-read budget)")
+            }
+            chatConsolePanel.hideLoadMore()
+        }
     }
 
     fun getComponent(): JComponent = rootSplitter

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ConversationReplayer.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ConversationReplayer.kt
@@ -5,12 +5,13 @@ internal class ConversationReplayer {
     private val deferredEntries = ArrayDeque<EntryData>()
     private var recentSnapshot: List<EntryData> = emptyList()
 
-    /**
-     * Splits [entries] into recent/deferred and resets internal state.
-     * Call [recentEntries] to get what should be rendered immediately, and
-     * [loadNextBatch] each time the user scrolls up for more.
-     */
-    fun loadAndSplit(entries: List<EntryData>, recentTurns: Int = 5) {
+    /** True when the 20 MB tail-read budget was hit and older history was not loaded from disk. */
+    var hasOlderHistoryOnDisk: Boolean = false
+        private set
+
+    @JvmOverloads
+    fun loadAndSplit(entries: List<EntryData>, recentTurns: Int = 5, hasMoreOnDisk: Boolean = false) {
+        hasOlderHistoryOnDisk = hasMoreOnDisk
         deferredEntries.clear()
         if (entries.isEmpty()) {
             recentSnapshot = emptyList()


### PR DESCRIPTION
## Problem

Opening the chat pane was slow (~5–10s) for large sessions. The session `d6096324` had ~397MB across 5 JSONL files, with a 364MB legacy part-001 created before file rotation was introduced.

Two bottlenecks:
1. `restoreConversation` (cold start): `loadEntries()` read all 397MB just to show the last 5 turns
2. `exportForRestart` (reconnect): `doExport()` → `loadCurrentV2Session()` read all 397MB to produce a 0.3–3.2MB events.jsonl, blocking `awaitPendingExport(10_000)`

## Fix

**`SessionStoreV2.loadRecentEntries(basePath)`** — reads files newest-first (active → most recent parts), stops once 20MB of on-disk bytes have been consumed. For the current session: reads active (6.9MB) + part-004 (12MB) = 19MB. The 364MB part-001 is never touched.

Returns a `RecentEntriesResult(entries, hasMoreOnDisk)` record so callers know whether older history was skipped.

**`SessionSwitchService.loadCurrentV2Session`** — now delegates to `loadRecentEntries`, fixing the export bottleneck.

**`ConversationReplayer.loadAndSplit`** — gains `hasMoreOnDisk: Boolean = false` parameter (`@JvmOverloads` for Java callers); exposes `hasOlderHistoryOnDisk` flag.

**`ChatToolWindowContent.restoreConversation`** — uses `loadRecentEntries`; passes `hasMoreOnDisk` to the replayer.

**`ChatToolWindowContent.onLoadMoreHistory`** — logs an info message when the deferred queue is exhausted but older history exists on disk (rather than silently hiding Load More).

## Notes

- Rotation was added Apr 16; new part files are ≤10MB. The 364MB file is a one-time artifact.  
- Sessions with normal-sized parts (`loadRecentEntries` hits the budget after 1–2 small files) will be near-instant on connect.