### PR TITLE
feat: review status colors + fix Files tab dark theme background

### DIFF
--- a/.idea/mcpServer.xml
+++ b/.idea/mcpServer.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="McpServerSettings">
+    <option name="autoApproveAgentEdits" value="true" />
     <option name="autoStart" value="true" />
     <option name="debugLoggingEnabled" value="true" />
     <option name="defaultsApplied" value="true" />

--- a/.idea/mcpServer.xml
+++ b/.idea/mcpServer.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="McpServerSettings">
-    <option name="autoApproveAgentEdits" value="true" />
     <option name="autoStart" value="true" />
     <option name="debugLoggingEnabled" value="true" />
     <option name="defaultsApplied" value="true" />

--- a/docs/A2A-INTEGRATION.md
+++ b/docs/A2A-INTEGRATION.md
@@ -1,0 +1,852 @@
+# A2A (Agent-to-Agent) Protocol Integration
+
+## Overview
+
+The [Agent-to-Agent (A2A) protocol](https://a2a-protocol.org/latest/) is an open
+standard (Google / Linux Foundation, v1.0 GA 2026) for cross-agent communication
+over HTTP, SSE, and JSON-RPC. It complements MCP: where MCP connects an agent to
+**tools** (vertical), A2A connects agents to **each other** (horizontal).
+
+This document evaluates A2A for an IDE plugin that hosts AI coding agents, lays
+out the use cases where it genuinely helps, identifies where it does not, and
+provides an implementation plan for both an A2A server and client.
+
+---
+
+## What A2A Does
+
+A2A defines three things:
+
+1. **Discovery** — An agent publishes an "Agent Card" at
+   `/.well-known/agent.json` describing its name, skills, endpoint URL, and
+   auth requirements. Any other agent can fetch this to learn what the agent
+   can do.
+
+2. **Task lifecycle** — A client submits a task (`tasks/send`), the server
+   processes it and transitions through states: `submitted → working →
+   completed | failed | input-required`. The `input-required` state allows
+   multi-turn conversation between agents.
+
+3. **Streaming** — Long-running tasks can stream status updates via SSE
+   (`tasks/sendSubscribe`), so the caller gets incremental progress instead
+   of polling.
+
+All communication is JSON-RPC 2.0 over HTTP. Auth uses standard OAuth2 or
+bearer tokens.
+
+### A2A vs MCP
+
+|                       | MCP                               | A2A                                          |
+|-----------------------|-----------------------------------|----------------------------------------------|
+| **Relationship**      | Agent → Tools                     | Agent → Agent                                |
+| **Interaction model** | Stateless function calls          | Stateful task lifecycle                      |
+| **Discovery**         | `tools/list` (tool catalog)       | Agent Card (agent catalog)                   |
+| **Multi-turn**        | No                                | Yes (`input-required` state)                 |
+| **Typical use**       | "Read this file", "Run this test" | "Implement this feature", "Review this code" |
+
+They are complementary. An agent that receives an A2A task will typically use
+MCP tools to execute it.
+
+---
+
+## Where A2A Brings Value
+
+### UC1: Discussions → Implementation
+
+**The problem:** A team discusses a feature in a meeting, standup, or chat
+thread. Decisions are made, requirements are clarified. Then someone has to
+manually translate that into tickets, and a developer has to read those tickets,
+understand the context, and start implementing. Context is lost at every handoff.
+
+**With A2A:** A Copilot Studio agent (or similar) processes the meeting
+transcript, extracts implementation tasks with the full conversational context,
+and sends them as A2A tasks directly to the developer's IDE. The coding agent
+receives not just "implement pagination" but also "cursor-based, page size 20,
+as discussed by the team on April 15th — see transcript excerpt."
+
+```
+Meeting / chat discussion
+    → Platform agent extracts tasks with context
+    → A2A task to developer's IDE
+    → Coding agent begins implementation
+    → Status streams back to the platform
+```
+
+**Why A2A is the right fit:** The platform agent and the IDE agent are on
+different machines, run by different runtimes, and are managed by different
+systems. A2A gives them a standard way to discover each other and exchange
+structured tasks. Without A2A, you'd build a bespoke integration for each
+platform — a Slack webhook here, a Teams bot there, a custom API for Jira.
+
+**Who benefits:** Teams that want to shorten the path from discussion to code.
+Project managers who want to see task status without switching to a different
+tracking tool.
+
+### UC2: IDE Agent → External Knowledge
+
+**The problem:** A coding agent working on a task hits ambiguity. "Should
+deleted users be soft-deleted or hard-deleted?" The agent can either ask the
+developer (interrupting them) or guess (risky). Meanwhile, this question was
+answered last week in a team chat, a design doc, or a Confluence page — but the
+agent has no access to those systems.
+
+**With A2A:** The coding agent sends a clarification request to an external
+knowledge agent — one that has access to team conversations, documentation
+wikis, design docs, or project management tools. That agent searches the
+relevant sources and responds with the answer and its source.
+
+```
+Coding agent encounters ambiguity
+    → A2A request to knowledge agent:
+      "What's the team's convention for user deletion?"
+    → Knowledge agent searches Confluence, Teams history, Notion
+    → Response: "Soft delete, per design doc DB-204 (updated March 2026)"
+    → Coding agent continues with the correct approach
+```
+
+**Why A2A is the right fit:** The knowledge lives in external systems (Teams,
+Slack, Confluence, Notion) that the IDE agent cannot and should not access
+directly. A dedicated knowledge agent with proper auth to those systems is the
+right boundary. A2A's `input-required` state also handles the case where the
+knowledge agent can't find the answer — it can post the question in a team
+channel and wait for a human reply.
+
+**Who benefits:** Developers working on unfamiliar codebases or across team
+boundaries. The agent resolves its own ambiguities instead of blocking on human
+input.
+
+### UC3: Cross-Agent Review
+
+**The problem:** After implementation, code needs review — security review,
+performance review, compliance review. These are specialized tasks that benefit
+from specialized agents with specific training or tool access (SAST scanners,
+performance profilers, compliance checklists). Running multiple specialized
+review agents locally is impractical.
+
+**With A2A:** The IDE agent delegates review tasks to specialized remote agents.
+A security review agent runs SAST tools and checks OWASP guidelines. A
+performance agent checks for N+1 queries and missing indexes. Results come back
+as structured findings.
+
+```
+Implementation complete
+    → A2A: "Review this diff for SQL injection and auth bypass"
+           to security-review agent
+    → A2A: "Check for N+1 queries and missing index hints"
+           to performance agent
+    → Both return findings as task artifacts
+    → IDE presents combined review results
+```
+
+**Honest caveat:** This use case is also partially achievable by calling another
+LLM API directly with the diff as context. A2A's added value here is
+**standardization** (any A2A-compatible review agent, not a hardcoded API
+integration) and **discovery** (Agent Cards let you browse available review
+agents in your organization without configuring each one manually). If your
+team only uses one review tool, A2A is overhead.
+
+**Who benefits:** Organizations with centralized security or compliance teams
+that publish review agents as shared services.
+
+---
+
+## Where A2A Does NOT Help
+
+### Local, single-developer workflows
+
+A2A is an HTTP protocol with discovery, auth, and task lifecycle. If both agents
+run on the same machine — or worse, in the same process — this is unnecessary
+overhead. A function call or in-process message is simpler, faster, and more
+reliable.
+
+**Example:** An IDE plugin that hosts Claude and Copilot side by side does not
+need A2A to let them collaborate. They share the same MCP tools and the same
+project context. Routing a request through HTTP, Agent Cards, and task state
+machines adds latency and failure modes without adding capability.
+
+### Replacing simple automations
+
+If a cron job polls GitHub Issues and sends prompts to the IDE, and it works,
+adding A2A is overengineering. A2A's value comes from scenarios where the caller
+and callee **don't know each other in advance** or need **bidirectional
+negotiation**. A script that talks to one known endpoint has neither requirement.
+
+### Deterministic workflows
+
+CI/CD pipelines, build systems, and deployment tools already have well-defined
+APIs, webhook systems, and error reporting. A build failure produces structured
+output (exit code, error log, failing test name). Wrapping this in an A2A task
+lifecycle adds no information — the IDE can already parse the build output
+directly.
+
+A2A is designed for tasks where the **outcome is uncertain** and the **process
+involves reasoning**. "Parse this build log" is not that. "Diagnose why this
+test fails intermittently across environments" might be — but even then, the
+developer already has the build output locally.
+
+### When the ecosystem is not there yet
+
+A2A is most valuable when there are many agents to connect to. As of mid-2026:
+
+- **Microsoft Copilot Studio** — Full A2A support (GA April 2026)
+- **Slack** — No native A2A. Uses MCP for tool integration. Third-party bridges
+  exist but add complexity
+- **GitHub** — No native A2A. Copilot uses ACP/MCP
+- **Jira, Confluence, Notion** — No A2A agents yet (likely coming)
+
+The Copilot Studio ecosystem is the strongest argument for A2A today. For
+Slack-based teams, the value is not yet there without building middleware.
+
+---
+
+## A2A Protocol Details
+
+### Agent Card (Discovery)
+
+Every A2A agent publishes a JSON manifest at `/.well-known/agent.json`:
+
+```json
+{
+  "name": "AgentBridge IDE",
+  "description": "IntelliJ IDE agent — code editing, navigation, testing, git",
+  "url": "http://localhost:8643/a2a",
+  "version": "1.0",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false
+  },
+  "skills": [
+    {
+      "id": "implement",
+      "name": "Implement Feature",
+      "description": "Implement a feature from a natural language description",
+      "tags": [
+        "coding",
+        "implementation"
+      ]
+    },
+    {
+      "id": "fix-bug",
+      "name": "Fix Bug",
+      "description": "Diagnose and fix a bug from error logs or description",
+      "tags": [
+        "debugging",
+        "bugfix"
+      ]
+    },
+    {
+      "id": "review",
+      "name": "Code Review",
+      "description": "Review code changes for quality, security, and correctness",
+      "tags": [
+        "review",
+        "quality"
+      ]
+    }
+  ],
+  "authentication": {
+    "schemes": [
+      "bearer"
+    ]
+  }
+}
+```
+
+### Task Lifecycle
+
+```
+                  ┌─────────┐
+                  │submitted│
+                  └────┬────┘
+                       │
+                  ┌────▼────┐
+              ┌───│ working │───┐
+              │   └────┬────┘   │
+              │        │        │
+         ┌────▼───┐ ┌──▼───┐ ┌─▼──────┐
+         │input-  │ │comp- │ │failed  │
+         │required│ │leted │ │        │
+         └────┬───┘ └──────┘ └────────┘
+              │
+              │  (client sends reply)
+              │
+         ┌────▼────┐
+         │ working │ (resumes)
+         └─────────┘
+```
+
+The `input-required` state is what makes A2A more than a simple request/response
+protocol. It allows multi-turn agent conversations: the IDE agent asks the Teams
+agent for clarification, the Teams agent posts in a channel and waits, a human
+replies, and the Teams agent forwards the answer back. The task stays open
+throughout.
+
+### JSON-RPC Methods
+
+| Method                | Direction       | Purpose                                        |
+|-----------------------|-----------------|------------------------------------------------|
+| `tasks/send`          | Client → Server | Submit a new task or reply to `input-required` |
+| `tasks/get`           | Client → Server | Poll task status                               |
+| `tasks/cancel`        | Client → Server | Cancel a running task                          |
+| `tasks/sendSubscribe` | Client → Server | Submit and stream updates via SSE              |
+
+### Message Format
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-1",
+  "method": "tasks/send",
+  "params": {
+    "id": "task-uuid-123",
+    "message": {
+      "role": "user",
+      "parts": [
+        {
+          "type": "text",
+          "text": "Implement pagination for GET /api/users. Page size 20, cursor-based."
+        },
+        {
+          "type": "data",
+          "mimeType": "application/json",
+          "data": {
+            "source": "teams-standup-2026-04-19",
+            "priority": "high"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+---
+
+## Architecture
+
+### System Diagram
+
+```mermaid
+graph TB
+    subgraph External["External A2A Agents"]
+        Teams["Copilot Studio<br/>(Teams)"]
+        Review["Review Agent"]
+        Knowledge["Knowledge Agent<br/>(Confluence, Notion)"]
+    end
+
+    subgraph IDE["IntelliJ IDEA"]
+        subgraph Plugin["AgentBridge Plugin"]
+            A2AServer["A2A Server<br/>localhost:8643"]
+            A2AClient["A2A Client"]
+            TaskMgr["TaskManager<br/>(lifecycle)"]
+
+            subgraph Existing["Existing Infrastructure"]
+                AAM["ActiveAgentManager"]
+                PSI["PsiBridgeService<br/>(MCP tools)"]
+                MCP["McpHttpServer"]
+                Chat["Chat UI"]
+            end
+        end
+    end
+
+    Teams -->|" tasks/send "| A2AServer
+    A2AServer --> TaskMgr
+    TaskMgr --> AAM
+    AAM -->|" prompt "| PSI
+    A2AClient -->|" tasks/send "| Knowledge
+    A2AClient -->|" tasks/send "| Review
+    AAM -->|" clarification needed "| A2AClient
+    TaskMgr -->|" status updates "| Chat
+```
+
+### How A2A Components Relate to Existing Code
+
+```
+McpHttpServer (existing)          A2AHttpServer (new)
+       │                                 │
+       ▼                                 ▼
+McpProtocolHandler              A2AProtocolHandler
+       │                                 │
+       ▼                                 ▼
+PsiBridgeService  ◄──────────── TaskManager
+(MCP tools)                      │         │
+                                 ▼         ▼
+                          TaskRunner    A2AClient
+                          (inbound)    (outbound)
+                                 │
+                                 ▼
+                         ActiveAgentManager
+                         (prompt the agent)
+```
+
+The A2A server follows the same pattern as the existing MCP HTTP server:
+project-level service, localhost by default, `com.sun.net.httpserver.HttpServer`.
+It listens on a separate port to avoid interference with MCP clients.
+
+---
+
+## Implementation Plan
+
+### Phase 1: A2A Server — Receive Tasks from External Agents
+
+**Goal:** External agents (Copilot Studio, custom agents) can send implementation
+tasks to the IDE. The developer sees incoming tasks, approves or rejects them,
+and the active coding agent executes them.
+
+#### New Files
+
+```
+a2a/
+├── server/
+│   ├── A2AHttpServer.java              — HTTP server on configurable port
+│   ├── A2AProtocolHandler.java         — JSON-RPC handler (tasks/send, get, cancel)
+│   ├── AgentCardEndpoint.java          — Serves /.well-known/agent.json
+│   └── A2AServerSettings.java         — Persistent settings (port, auth)
+├── model/
+│   ├── AgentCard.java                  — Agent Card POJO
+│   ├── A2ATask.java                    — Task state machine
+│   ├── TaskMessage.java                — Message with typed parts
+│   ├── TaskPart.java                   — TextPart, DataPart, FilePart
+│   └── TaskStatus.java                — submitted/working/completed/failed/input-required
+├── task/
+│   ├── TaskManager.java               — In-memory task store + lifecycle
+│   ├── TaskRunner.java                — Bridges A2A task → agent prompt
+│   └── TaskNotifier.java             — SSE streaming of status updates
+└── ui/
+    ├── A2ATaskPanel.java              — Task inbox in tool window
+    └── A2ASettingsConfigurable.java   — Settings UI
+```
+
+#### Server Startup
+
+```java
+
+@Service(Service.Level.PROJECT)
+public final class A2AHttpServer implements Disposable {
+
+    private HttpServer httpServer;
+    private final A2AProtocolHandler protocolHandler;
+    private final TaskManager taskManager;
+
+    public void start(int port) {
+        httpServer = HttpServer.create(
+                new InetSocketAddress("127.0.0.1", port), 0);
+        httpServer.createContext(
+                "/.well-known/agent.json", this::handleAgentCard);
+        httpServer.createContext("/a2a", this::handleA2A);
+        httpServer.createContext("/health", this::handleHealth);
+        httpServer.start();
+    }
+}
+```
+
+#### Task Manager
+
+Bridges external A2A tasks to the active agent:
+
+```java
+
+@Service(Service.Level.PROJECT)
+public final class TaskManager implements Disposable {
+
+    private final Map<String, A2ATask> tasks = new ConcurrentHashMap<>();
+
+    public A2ATask submit(TaskMessage message) {
+        var task = new A2ATask(UUID.randomUUID().toString(), message);
+        tasks.put(task.id(), task);
+
+        var agent = ActiveAgentManager.getInstance(project).getClient();
+        if (agent == null || !agent.isConnected()) {
+            task.setStatus(TaskStatus.FAILED, "No active agent");
+            return task;
+        }
+
+        task.setStatus(TaskStatus.WORKING);
+        agent.sendPrompt(buildPromptFromTask(task), new AgentListener() {
+            @Override
+            public void onComplete(String response) {
+                task.addArtifact(new TextPart(response));
+                task.setStatus(TaskStatus.COMPLETED);
+                notifySubscribers(task);
+            }
+
+            @Override
+            public void onError(String error) {
+                task.setStatus(TaskStatus.FAILED, error);
+                notifySubscribers(task);
+            }
+        });
+
+        return task;
+    }
+
+    public void requestInput(String taskId, String question) {
+        var task = tasks.get(taskId);
+        task.addMessage(new TaskMessage("agent", new TextPart(question)));
+        task.setStatus(TaskStatus.INPUT_REQUIRED);
+        notifySubscribers(task);
+    }
+
+    public void replyToTask(String taskId, TaskMessage reply) {
+        var task = tasks.get(taskId);
+        task.addMessage(reply);
+        task.setStatus(TaskStatus.WORKING);
+        resumeAgent(task, reply);
+    }
+}
+```
+
+#### Agent Card
+
+Generated dynamically from the plugin's current state:
+
+```java
+public final class AgentCardEndpoint {
+
+    public JsonObject buildAgentCard(Project project) {
+        var card = new JsonObject();
+        card.addProperty("name", "AgentBridge IDE");
+        card.addProperty("url",
+                "http://localhost:" + getPort() + "/a2a");
+        card.addProperty("version", "1.0");
+
+        var skills = new JsonArray();
+        skills.add(skill("implement", "Implement Feature",
+                "Implement a feature from natural language"));
+        skills.add(skill("fix-bug", "Fix Bug",
+                "Diagnose and fix a bug"));
+        skills.add(skill("review", "Code Review",
+                "Review changes for correctness and security"));
+        card.add("skills", skills);
+
+        var caps = new JsonObject();
+        caps.addProperty("streaming", true);
+        caps.addProperty("pushNotifications", false);
+        card.add("capabilities", caps);
+
+        return card;
+    }
+}
+```
+
+#### Task Inbox UI
+
+```
+┌─ A2A Tasks ──────────────────────────────────────────────┐
+│                                                          │
+│  ● working   Implement pagination for /api/users   Teams │
+│  ◌ pending   Add rate limiting to webhook endpoint  PM   │
+│  ✓ done      Update error messages per style guide  QA   │
+│                                                          │
+│  ──────────────────────────────────────────────────────── │
+│  Source: Teams standup 2026-04-19                         │
+│  Status: working (3m 22s)                                │
+│  [View in Chat] [Cancel] [Reject]                        │
+└──────────────────────────────────────────────────────────┘
+```
+
+#### Inbound Flow
+
+```mermaid
+sequenceDiagram
+    participant Ext as External Agent
+    participant A2A as A2AHttpServer
+    participant TM as TaskManager
+    participant Agent as Active Coding Agent
+    Ext ->> A2A: GET /.well-known/agent.json
+    A2A -->> Ext: Agent Card
+    Ext ->> A2A: POST /a2a — tasks/send
+    A2A ->> TM: submit(message)
+    TM ->> Agent: prompt(task content)
+    A2A -->> Ext: task (status=working)
+    Agent -->> TM: completed
+    TM -->> Ext: SSE: task (status=completed, artifacts)
+```
+
+---
+
+### Phase 2: A2A Client — Delegate Tasks to External Agents
+
+**Goal:** The coding agent in the IDE can reach out to external agents — to ask
+questions, request reviews, or delegate specialized work.
+
+#### New Files
+
+```
+a2a/
+├── client/
+│   ├── A2AClient.java                 — HTTP client for A2A JSON-RPC
+│   ├── AgentCardDiscovery.java        — Fetch and cache agent cards
+│   └── RemoteAgentRegistry.java       — Configured remote agents
+└── tools/
+    ├── DelegateToAgentTool.java        — MCP tool: delegate_to_agent
+    └── AskExternalAgentTool.java       — MCP tool: ask_external_agent
+```
+
+#### A2A Client
+
+```java
+public final class A2AClient {
+
+    private final OkHttpClient http;
+    private final Map<String, AgentCard> cardCache
+            = new ConcurrentHashMap<>();
+
+    public AgentCard discover(String agentUrl) {
+        return cardCache.computeIfAbsent(agentUrl, url -> {
+            var response = http.newCall(new Request.Builder()
+                    .url(url + "/.well-known/agent.json")
+                    .build()
+            ).execute();
+            return AgentCard.fromJson(response.body().string());
+        });
+    }
+
+    public A2ATask sendTask(
+            String agentUrl,
+            TaskMessage message,
+            Duration timeout) {
+        // POST tasks/send, then poll tasks/get until
+        // completed, failed, or timeout
+    }
+
+    public void sendTaskStreaming(
+            String agentUrl,
+            TaskMessage message,
+            Consumer<A2ATask> onUpdate) {
+        // POST tasks/sendSubscribe, consume SSE stream
+    }
+}
+```
+
+#### MCP Tools
+
+Two new MCP tools expose A2A delegation to any agent running in the plugin:
+
+**`delegate_to_agent`** — Full task delegation with structured response:
+
+```json
+{
+  "name": "delegate_to_agent",
+  "description": "Delegate a task to an external A2A agent and wait for the result.",
+  "inputSchema": {
+    "properties": {
+      "agent": {
+        "type": "string",
+        "description": "Agent name or URL"
+      },
+      "task": {
+        "type": "string",
+        "description": "Task description"
+      },
+      "timeout_seconds": {
+        "type": "integer",
+        "default": 120
+      }
+    },
+    "required": [
+      "agent",
+      "task"
+    ]
+  }
+}
+```
+
+**`ask_external_agent`** — Quick question, text response:
+
+```json
+{
+  "name": "ask_external_agent",
+  "description": "Ask an external A2A agent a question. Use for clarifications from team knowledge bases, conversation history, or documentation.",
+  "inputSchema": {
+    "properties": {
+      "agent": {
+        "type": "string",
+        "description": "Agent name or URL"
+      },
+      "question": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "agent",
+      "question"
+    ]
+  }
+}
+```
+
+#### Outbound Flow (Clarification Example)
+
+```mermaid
+sequenceDiagram
+    participant Agent as Coding Agent
+    participant Plugin as AgentBridge
+    participant A2AC as A2A Client
+    participant Ext as Knowledge Agent (Teams)
+    Agent ->> Plugin: tools/call ask_external_agent<br/>{agent: "teams", question: "What pagination<br/>style did the team agree on?"}
+    Plugin ->> A2AC: sendTask(teamsUrl, question)
+    A2AC ->> Ext: POST /a2a — tasks/send
+    Ext ->> Ext: Search conversations and docs
+    Ext -->> A2AC: task (completed, "Cursor-based,<br/>discussed#backend Apr 15")
+    A2AC -->> Plugin: result
+    Plugin -->> Agent: tool_result
+```
+
+---
+
+### Phase 3: UI — Agent Registry, Task Inbox, Settings
+
+#### Agent Registry (Settings)
+
+```
+┌─ A2A Agent Registry ─────────────────────────────────────┐
+│                                                          │
+│  Name              URL                        Status     │
+│  ─────────────────────────────────────────────────────── │
+│  Teams (Copilot)   https://copilot.ms/a2a     ● Online  │
+│  Security Review   http://sec-agent.int:8080  ● Online  │
+│                                                          │
+│  [Add Agent]  [Discover from URL]  [Remove]              │
+│                                                          │
+│  ☑ Auto-accept tasks from trusted agents                │
+│  ☐ Require approval for all incoming tasks              │
+│  ☑ Allow IDE agent to delegate to registered agents     │
+│                                                          │
+│  A2A Server                                              │
+│  Port: [8643]  ☑ Auto-start  ☑ Require auth token       │
+│  Auth token: [••••••••••••]  [Regenerate]                │
+└──────────────────────────────────────────────────────────┘
+```
+
+#### Incoming Task Approval
+
+```
+┌─ Incoming A2A Task ──────────────────────────────────────┐
+│                                                          │
+│  From: Teams (Copilot Studio)                            │
+│  Skill: implement                                        │
+│                                                          │
+│  "Implement cursor-based pagination for GET /api/users.  │
+│   Page size 20, include total count in response header.  │
+│   Based on discussion in #backend standup Apr 19."       │
+│                                                          │
+│  Context:                                                │
+│   • Source: Teams standup transcript                      │
+│   • Priority: high                                       │
+│   • Related: PROJ-445                                    │
+│                                                          │
+│  [Accept & Start]  [Queue]  [Reject]                     │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Security
+
+### Authentication
+
+- **Server:** Bearer token (configurable, auto-generated). External agents must
+  include it in the `Authorization` header. The token is referenced in the
+  Agent Card's `authentication` section.
+- **Client:** Per-agent auth in the registry. Supports bearer tokens and OAuth2
+  (required for Copilot Studio).
+
+### Localhost Default
+
+The A2A server binds to `127.0.0.1` by default. For remote access, the
+developer must explicitly configure a bind address and enable authentication.
+This matches the existing MCP server's security model.
+
+### Permission Passthrough
+
+A2A tasks execute through the same permission system as manual prompts. If
+`git_push` requires approval when the developer types a prompt, it requires
+approval when triggered by an A2A task. An external agent cannot escalate
+privileges.
+
+---
+
+## Configuration
+
+### Server
+
+| Setting                        | Default     | Description                      |
+|--------------------------------|-------------|----------------------------------|
+| `a2a.server.enabled`           | `false`     | Enable A2A server                |
+| `a2a.server.port`              | `8643`      | Server port                      |
+| `a2a.server.autoStart`         | `false`     | Start on project open            |
+| `a2a.server.authToken`         | (generated) | Bearer token                     |
+| `a2a.server.bindAddress`       | `127.0.0.1` | Bind address                     |
+| `a2a.server.autoAcceptTrusted` | `true`      | Skip approval for trusted agents |
+
+### Client
+
+| Setting                     | Default | Description              |
+|-----------------------------|---------|--------------------------|
+| `a2a.client.enabled`        | `false` | Enable A2A client tools  |
+| `a2a.client.defaultTimeout` | `120s`  | Task timeout             |
+| `a2a.agents`                | `[]`    | Registered remote agents |
+
+---
+
+## Ecosystem Status (April 2026)
+
+| Platform                     | A2A Support     | Notes                                        |
+|------------------------------|-----------------|----------------------------------------------|
+| **Microsoft Copilot Studio** | GA (April 2026) | Full A2A, Agent Store with 70+ agents        |
+| **Slack**                    | No native A2A   | Uses MCP. Third-party bridges exist (kagent) |
+| **GitHub**                   | No native A2A   | Uses ACP/MCP. Community wrapper exists       |
+| **Jira / Confluence**        | Not yet         | Likely coming via Atlassian's agent platform |
+| **ServiceNow**               | A2A available   | Enterprise workflow agents                   |
+| **SAP**                      | A2A available   | Business process agents                      |
+
+The strongest integration path today is **Copilot Studio**. For Slack-centric
+teams, A2A adds a middleware layer that may not justify its complexity until
+Slack ships native support.
+
+### Copilot Studio Connection
+
+1. Register the IDE as a "Custom agent" in Copilot Studio using the Agent Card
+   URL
+2. Configure OAuth2 or bearer token auth
+3. Copilot Studio agents can now send `tasks/send` to the IDE
+4. The IDE can discover Copilot Studio agents via their published Agent Cards
+
+See: [Connect to an agent over A2A — Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-copilot-studio/add-agent-agent-to-agent)
+
+---
+
+## Rollout Plan
+
+| Phase | Scope                                | Effort    | Depends On     |
+|-------|--------------------------------------|-----------|----------------|
+| **1** | A2A Server (receive tasks)           | 2-3 weeks | —              |
+| **2** | A2A Client (delegate + MCP tools)    | 2 weeks   | Phase 1 models |
+| **3** | UI (task inbox, registry, settings)  | 1-2 weeks | Phase 1 + 2    |
+| **4** | Copilot Studio integration testing   | 1 week    | Phase 1 + 2    |
+| **5** | SSE streaming for long-running tasks | 1 week    | Phase 1        |
+
+---
+
+## Summary
+
+A2A is worth implementing for **cross-platform agent communication** — primarily
+receiving tasks from enterprise collaboration platforms (Teams/Copilot Studio)
+and sending clarification requests back. It is **not** a replacement for simple
+scripts, local agent orchestration, or deterministic CI/CD integrations.
+
+The strongest near-term value is the **Teams ↔ IDE loop**: discussions become
+implementation tasks (UC1), and the coding agent can consult team knowledge
+when it needs context (UC2). Cross-agent review (UC3) is a secondary benefit
+that grows with organizational adoption of A2A-compatible review agents.
+
+---
+
+## References
+
+- [A2A Protocol Specification](https://a2a-protocol.org/latest/)
+- [Microsoft Copilot Studio A2A](https://learn.microsoft.com/en-us/microsoft-copilot-studio/add-agent-agent-to-agent)
+- [Microsoft A2A blog post](https://www.microsoft.com/en-us/microsoft-cloud/blog/2025/05/07/empowering-multi-agent-apps-with-the-open-agent2agent-a2a-protocol/)
+- [Existing MCP Architecture](MCP-ARCHITECTURE.md)
+- [Plugin Architecture](ARCHITECTURE.md)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -29,7 +29,11 @@ import javax.swing.JComponent
  * Chat panel — web-component-based implementation.
  * All rendering delegated to JS ChatController; Kotlin manages data model and bridge.
  */
-class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>(BorderLayout()), ChatPanelApi {
+class ChatConsolePanel(
+    private val project: Project,
+    /** When false the panel is not registered in [instances] and won't replace the main panel entry. */
+    private val registerAsMain: Boolean = true,
+) : JBPanel<ChatConsolePanel>(BorderLayout()), ChatPanelApi {
 
     override val component: JComponent get() = this
     override var onQuickReply: ((String) -> Unit)? = null
@@ -275,7 +279,7 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
             fallbackArea = JBTextArea().apply { isEditable = false; lineWrap = true; wrapStyleWord = true }
             add(JBScrollPane(fallbackArea), BorderLayout.CENTER)
         }
-        instances[project] = this
+        if (registerAsMain) instances[project] = this
         registerChipStateListener()
     }
 
@@ -1157,7 +1161,7 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
     override fun dispose() {
         registry.removeKindStateListener(kindStateListener)
         repaintTimer.stop()
-        instances.remove(project)
+        if (registerAsMain) instances.remove(project)
     }
 
     // ── Internal ───────────────────────────────────────────────────

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -49,6 +49,9 @@ class ChatConsolePanel(private val project: Project) : JBPanel<ChatConsolePanel>
      * Off-EDT callers must hop via `ApplicationManager.getApplication().invokeLater { ... }`.
      */
     fun entriesSnapshot(): List<EntryData> = ArrayList(entries)
+
+    /** Returns true if an entry with the given [entryId] has already been rendered to the JCEF view. */
+    fun isEntryRendered(entryId: String): Boolean = entries.any { it.entryId == entryId }
     private var currentTextData: EntryData.Text? = null
     private var currentThinkingData: EntryData.Thinking? = null
     private var nextSubAgentColor = 0

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/FileNavigator.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/FileNavigator.kt
@@ -25,7 +25,11 @@ class FileNavigator(private val project: Project) {
         val normalizedPath = filePath.replace('\\', '/')
         val vf = LocalFileSystem.getInstance().findFileByPath(normalizedPath) ?: return
         ApplicationManager.getApplication().invokeLater {
-            OpenFileDescriptor(project, vf, maxOf(0, line - 1), 0).navigate(true)
+            try {
+                OpenFileDescriptor(project, vf, maxOf(0, line - 1), 0).navigate(true)
+            } catch (e: Exception) {
+                log.warn("Failed to navigate to file $normalizedPath:$line", e)
+            }
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
@@ -45,7 +45,8 @@ import java.util.List;
  * Side panel listing every file the agent has touched in the current
  * {@link AgentEditSession}.
  * <p>
- * Columns: [status icon] [file name + meta] [approve checkbox] [remove X].
+ * Columns: [file name (status-colored) + meta] [approve checkbox] [remove X].
+ * File names are colored by status: green = added, blue = modified, grey = deleted.
  * Clicking a row opens the file. The approve checkbox toggles between PENDING and
  * APPROVED (green check when approved). The X button removes approved rows.
  */
@@ -60,6 +61,14 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
      */
     private static final JBColor DIFF_GREEN = new JBColor(new Color(0, 128, 0), new Color(80, 200, 80));
     private static final JBColor DIFF_RED = new JBColor(new Color(200, 0, 0), new Color(255, 80, 80));
+
+    /**
+     * File status colors — matches IntelliJ's VCS file coloring convention:
+     * green = added, blue = modified, grey = deleted.
+     */
+    private static final JBColor STATUS_ADDED = new JBColor(new Color(0x00, 0x61, 0x00), new Color(0x57, 0xAB, 0x5A));
+    private static final JBColor STATUS_MODIFIED = new JBColor(new Color(0x08, 0x69, 0xDA), new Color(0x58, 0xA6, 0xFF));
+    private static final JBColor STATUS_DELETED = new JBColor(new Color(0x6E, 0x77, 0x81), new Color(0x8B, 0x94, 0x9E));
 
     private final transient Project project;
     private final ReviewTableModel tableModel;
@@ -183,12 +192,6 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         table.setFillsViewportHeight(true);
         table.setTableHeader(null);
         table.setExpandableItemsEnabled(false);
-
-        // COL_STATUS — small icon column
-        TableColumn statusCol = table.getColumnModel().getColumn(ReviewTableModel.COL_STATUS);
-        statusCol.setPreferredWidth(JBUI.scale(28));
-        statusCol.setMaxWidth(JBUI.scale(32));
-        statusCol.setCellRenderer(new StatusCellRenderer());
 
         // COL_FILE — file name + meta (takes remaining space)
         TableColumn fileCol = table.getColumnModel().getColumn(ReviewTableModel.COL_FILE);
@@ -392,11 +395,10 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
     // ── Table model ───────────────────────────────────────────────────────────
 
     private static final class ReviewTableModel extends AbstractTableModel {
-        static final int COL_STATUS = 0;
-        static final int COL_FILE = 1;
-        static final int COL_APPROVE = 2;
-        static final int COL_REMOVE = 3;
-        private static final String[] COLUMN_NAMES = {"", "File", "", ""};
+        static final int COL_FILE = 0;
+        static final int COL_APPROVE = 1;
+        static final int COL_REMOVE = 2;
+        private static final String[] COLUMN_NAMES = {"File", "", ""};
 
         private final List<ReviewItem> items = new ArrayList<>();
 
@@ -434,40 +436,6 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
     // ── Cell renderers ────────────────────────────────────────────────────────
 
     /**
-     * Status icon column: Add/Edit/Remove icon with diff colors.
-     */
-    private static final class StatusCellRenderer extends DefaultTableCellRenderer {
-        @Override
-        public Component getTableCellRendererComponent(JTable table, Object value,
-                                                       boolean isSelected, boolean hasFocus,
-                                                       int row, int column) {
-            Component c = super.getTableCellRendererComponent(table, "", isSelected, hasFocus, row, column);
-            if (value instanceof ReviewItem item && c instanceof JLabel label) {
-                label.setText("");
-                label.setHorizontalAlignment(CENTER);
-                switch (item.status()) {
-                    case ADDED -> {
-                        label.setIcon(AllIcons.General.Add);
-                        label.setToolTipText("Added");
-                    }
-                    case MODIFIED -> {
-                        label.setIcon(AllIcons.Actions.Edit);
-                        label.setToolTipText("Modified");
-                    }
-                    case DELETED -> {
-                        label.setIcon(AllIcons.General.Remove);
-                        label.setToolTipText("Deleted");
-                    }
-                }
-                if (item.approved() && !isSelected) {
-                    label.setForeground(JBColor.GRAY);
-                }
-            }
-            return c;
-        }
-    }
-
-    /**
      * File name column: shows file name, diff-colored line counts, and timestamp.
      * Approved rows are muted.
      */
@@ -500,6 +468,13 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
             StringBuilder sb = new StringBuilder("<html>");
             if (approved && !isSelected) {
                 sb.append("<font color='gray'>").append(escapeHtml(fileName)).append(FONT_CLOSE);
+            } else if (!isSelected) {
+                Color statusColor = switch (item.status()) {
+                    case ADDED -> STATUS_ADDED;
+                    case MODIFIED -> STATUS_MODIFIED;
+                    case DELETED -> STATUS_DELETED;
+                };
+                sb.append(colorSpan(statusColor, escapeHtml(fileName)));
             } else {
                 sb.append(escapeHtml(fileName));
             }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
@@ -63,14 +63,6 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
     private static final JBColor DIFF_RED = new JBColor(new Color(200, 0, 0), new Color(255, 80, 80));
 
     /**
-     * Approve toggle button colors — green fill when approved, dim outline when pending.
-     * Matches the GitHub-style approve-button convention used in other parts of the UI.
-     */
-    private static final JBColor APPROVE_BG = new JBColor(new Color(0x2d, 0xa4, 0x4e), new Color(0x2d, 0xa4, 0x4e));
-    private static final JBColor APPROVE_FG = new JBColor(Color.WHITE, Color.WHITE);
-    private static final JBColor PENDING_BORDER = new JBColor(new Color(0x8e, 0x95, 0x9e), new Color(0x8b, 0x94, 0x9e));
-
-    /**
      * File status colors — matches IntelliJ's VCS file coloring convention:
      * green = added, blue = modified, grey = deleted.
      */
@@ -232,7 +224,7 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         fileCol.setPreferredWidth(JBUI.scale(280));
         fileCol.setCellRenderer(new FileCellRenderer());
 
-        // COL_APPROVE — green toggle pill (✓) when approved, outline when pending
+        // COL_APPROVE — toolbar-style toggle button: highlighted when approved, plain when pending
         TableColumn approveCol = table.getColumnModel().getColumn(ReviewTableModel.COL_APPROVE);
         approveCol.setPreferredWidth(JBUI.scale(32));
         approveCol.setMaxWidth(JBUI.scale(36));
@@ -538,74 +530,47 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
     }
 
     /**
-     * Approve column: a pill-shaped toggle button. Green fill with "✓ Approved" when the row is
-     * approved; a dim outline with "Approve" when pending. Matches the visual language of the
-     * auto-approve toggle in the toolbar.
+     * Renders the approve column as a toolbar-style icon toggle button.
+     * Uses {@link JBUI.CurrentTheme.ActionButton#pressedBackground()} for the highlighted
+     * background when approved — the exact same tint IntelliJ uses for toggled toolbar buttons —
+     * so the inline cell button and the Auto-Approve toolbar toggle share the same visual language.
      */
-    private static final class ApproveToggleRenderer implements TableCellRenderer {
-        private final ApproveButtonPanel button = new ApproveButtonPanel();
+    private static final class ApproveToggleRenderer extends JLabel implements TableCellRenderer {
+        private boolean approved;
+
+        ApproveToggleRenderer() {
+            setHorizontalAlignment(CENTER);
+            setOpaque(false);
+            setIcon(AllIcons.Actions.Commit);
+        }
 
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value,
                                                        boolean isSelected, boolean hasFocus,
                                                        int row, int column) {
             if (value instanceof ReviewItem item) {
-                button.setState(item.approved(), isSelected, table);
+                approved = item.approved();
+                setToolTipText(approved ? "Approved — click to unapprove" : "Approve this change");
             }
-            return button;
-        }
-    }
-
-    /**
-     * Pill-shaped button panel that paints itself as a toggle button without requiring
-     * an actual Swing button component (avoids focus/repaint issues in a table renderer).
-     */
-    private static final class ApproveButtonPanel extends JPanel {
-        private boolean approved;
-
-        ApproveButtonPanel() {
-            setOpaque(false);
-            Font base = UIManager.getFont("Label.font");
-            if (base != null) setFont(base.deriveFont((float) JBUI.scaleFontSize(11)));
-        }
-
-        void setState(boolean approved, boolean rowSelected, JTable table) {
-            this.approved = approved;
-            setBackground(rowSelected ? table.getSelectionBackground() : table.getBackground());
-            setToolTipText(approved ? "Approved — click to unapprove" : "Click to approve this change");
+            setBackground(isSelected ? table.getSelectionBackground() : table.getBackground());
+            return this;
         }
 
         @Override
         protected void paintComponent(Graphics g) {
             Graphics2D g2 = (Graphics2D) g.create();
             g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-            g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-
             g2.setColor(getBackground());
             g2.fillRect(0, 0, getWidth(), getHeight());
-
-            int arc = JBUI.scale(10);
-            int hpad = JBUI.scale(6);
-            int vpad = JBUI.scale(5);
-            int btnW = getWidth() - 2 * hpad;
-            int btnH = getHeight() - 2 * vpad;
-
             if (approved) {
-                g2.setColor(APPROVE_BG);
-                g2.fillRoundRect(hpad, vpad, btnW, btnH, arc, arc);
-                g2.setColor(APPROVE_FG);
-                g2.setFont(getFont().deriveFont(Font.BOLD, JBUI.scaleFontSize(13)));
-                FontMetrics fm = g2.getFontMetrics();
-                String mark = "✓";
-                int textX = hpad + (btnW - fm.stringWidth(mark)) / 2;
-                int textY = vpad + (btnH + fm.getAscent() - fm.getDescent()) / 2;
-                g2.drawString(mark, textX, textY);
-            } else {
-                g2.setColor(PENDING_BORDER);
-                g2.drawRoundRect(hpad, vpad, btnW - 1, btnH - 1, arc, arc);
+                int size = JBUI.scale(22);
+                int x = (getWidth() - size) / 2;
+                int y = (getHeight() - size) / 2;
+                g2.setColor(JBUI.CurrentTheme.ActionButton.pressedBackground());
+                g2.fillRoundRect(x, y, size, size, JBUI.scale(4), JBUI.scale(4));
             }
-
             g2.dispose();
+            super.paintComponent(g);
         }
     }
 
@@ -613,24 +578,38 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
      * Right-hand action column: rollback icon for pending rows (opens reject dialog),
      * X icon for approved rows (removes from list).
      */
-    private static final class RejectOrRemoveRenderer extends DefaultTableCellRenderer {
+    private static final class RejectOrRemoveRenderer extends JLabel implements TableCellRenderer {
+
+        RejectOrRemoveRenderer() {
+            setHorizontalAlignment(CENTER);
+            setOpaque(false);
+        }
+
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value,
                                                        boolean isSelected, boolean hasFocus,
                                                        int row, int column) {
-            Component c = super.getTableCellRendererComponent(table, "", isSelected, hasFocus, row, column);
-            if (value instanceof ReviewItem item && c instanceof JLabel label) {
-                label.setText("");
-                label.setHorizontalAlignment(CENTER);
+            setBackground(isSelected ? table.getSelectionBackground() : table.getBackground());
+            if (value instanceof ReviewItem item) {
                 if (item.approved()) {
-                    label.setIcon(AllIcons.Actions.Close);
-                    label.setToolTipText("Remove from list");
+                    setIcon(AllIcons.Actions.Close);
+                    setToolTipText("Remove from list");
                 } else {
-                    label.setIcon(AllIcons.Actions.Rollback);
-                    label.setToolTipText("Reject this change…");
+                    setIcon(AllIcons.Actions.Rollback);
+                    setToolTipText("Reject this change…");
                 }
             }
-            return c;
+            return this;
+        }
+
+        @Override
+        protected void paintComponent(Graphics g) {
+            Graphics2D g2 = (Graphics2D) g.create();
+            g2.setColor(getBackground());
+            g2.fillRect(0, 0, getWidth(), getHeight());
+            g2.dispose();
+            super.paintComponent(g);
         }
     }
 }
+

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
@@ -232,17 +232,17 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         fileCol.setPreferredWidth(JBUI.scale(280));
         fileCol.setCellRenderer(new FileCellRenderer());
 
-        // COL_APPROVE — green toggle button when approved, outline button when pending
+        // COL_APPROVE — green toggle pill (✓) when approved, outline when pending
         TableColumn approveCol = table.getColumnModel().getColumn(ReviewTableModel.COL_APPROVE);
-        approveCol.setPreferredWidth(JBUI.scale(72));
-        approveCol.setMaxWidth(JBUI.scale(80));
+        approveCol.setPreferredWidth(JBUI.scale(32));
+        approveCol.setMaxWidth(JBUI.scale(36));
         approveCol.setCellRenderer(new ApproveToggleRenderer());
 
-        // COL_REMOVE — X button (only for approved rows)
+        // COL_REMOVE — rollback icon for pending (reject), X icon for approved (remove)
         TableColumn removeCol = table.getColumnModel().getColumn(ReviewTableModel.COL_REMOVE);
         removeCol.setPreferredWidth(JBUI.scale(28));
         removeCol.setMaxWidth(JBUI.scale(32));
-        removeCol.setCellRenderer(new RemoveButtonRenderer());
+        removeCol.setCellRenderer(new RejectOrRemoveRenderer());
 
         table.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
         table.addMouseListener(new MouseAdapter() {
@@ -258,6 +258,8 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
                     case ReviewTableModel.COL_REMOVE -> {
                         if (item.approved()) {
                             AgentEditSession.getInstance(project).removeApproved(item.path());
+                        } else {
+                            showRevertDialog(item);
                         }
                     }
                     default -> navigateToFile(item);
@@ -570,6 +572,7 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         void setState(boolean approved, boolean rowSelected, JTable table) {
             this.approved = approved;
             setBackground(rowSelected ? table.getSelectionBackground() : table.getBackground());
+            setToolTipText(approved ? "Approved — click to unapprove" : "Click to approve this change");
         }
 
         @Override
@@ -578,42 +581,39 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
             g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
             g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 
-            // Fill row background first
             g2.setColor(getBackground());
             g2.fillRect(0, 0, getWidth(), getHeight());
 
             int arc = JBUI.scale(10);
             int hpad = JBUI.scale(6);
-            int vpad = JBUI.scale(4);
+            int vpad = JBUI.scale(5);
             int btnW = getWidth() - 2 * hpad;
             int btnH = getHeight() - 2 * vpad;
-
-            String text = approved ? "✓ Approved" : "Approve";
 
             if (approved) {
                 g2.setColor(APPROVE_BG);
                 g2.fillRoundRect(hpad, vpad, btnW, btnH, arc, arc);
                 g2.setColor(APPROVE_FG);
+                g2.setFont(getFont().deriveFont(Font.BOLD, JBUI.scaleFontSize(13)));
+                FontMetrics fm = g2.getFontMetrics();
+                String mark = "✓";
+                int textX = hpad + (btnW - fm.stringWidth(mark)) / 2;
+                int textY = vpad + (btnH + fm.getAscent() - fm.getDescent()) / 2;
+                g2.drawString(mark, textX, textY);
             } else {
                 g2.setColor(PENDING_BORDER);
                 g2.drawRoundRect(hpad, vpad, btnW - 1, btnH - 1, arc, arc);
-                g2.setColor(PENDING_BORDER);
             }
 
-            FontMetrics fm = g2.getFontMetrics(getFont());
-            int textW = fm.stringWidth(text);
-            int textX = hpad + (btnW - textW) / 2;
-            int textY = vpad + (btnH + fm.getAscent() - fm.getDescent()) / 2;
-            g2.setFont(getFont());
-            g2.drawString(text, textX, textY);
             g2.dispose();
         }
     }
 
     /**
-     * Remove X column: only active for approved rows.
+     * Right-hand action column: rollback icon for pending rows (opens reject dialog),
+     * X icon for approved rows (removes from list).
      */
-    private static final class RemoveButtonRenderer extends DefaultTableCellRenderer {
+    private static final class RejectOrRemoveRenderer extends DefaultTableCellRenderer {
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value,
                                                        boolean isSelected, boolean hasFocus,
@@ -626,11 +626,8 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
                     label.setIcon(AllIcons.Actions.Close);
                     label.setToolTipText("Remove from list");
                 } else {
-                    label.setIcon(AllIcons.Actions.CloseHovered);
-                    // Dim the icon for pending rows — they should be reverted, not removed
-                    label.setForeground(JBColor.GRAY);
-                    label.setIcon(null);
-                    label.setToolTipText(null);
+                    label.setIcon(AllIcons.Actions.Rollback);
+                    label.setToolTipText("Reject this change…");
                 }
             }
             return c;

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
@@ -370,7 +370,7 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         private final Project project;
 
         AutoApproveToggleAction(@NotNull Project project) {
-            super("Auto-Approve", "Apply agent edits without per-file approval", AllIcons.Actions.Lightning);
+            super("Auto-Approve", "Apply agent edits without per-file approval", AllIcons.Actions.Checked);
             this.project = project;
         }
 
@@ -541,7 +541,7 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         ApproveToggleRenderer() {
             setHorizontalAlignment(CENTER);
             setOpaque(false);
-            setIcon(AllIcons.Actions.Commit);
+            setIcon(AllIcons.Actions.Checked);
         }
 
         @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -60,6 +61,14 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
      */
     private static final JBColor DIFF_GREEN = new JBColor(new Color(0, 128, 0), new Color(80, 200, 80));
     private static final JBColor DIFF_RED = new JBColor(new Color(200, 0, 0), new Color(255, 80, 80));
+
+    /**
+     * Approve toggle button colors — green fill when approved, dim outline when pending.
+     * Matches the GitHub-style approve-button convention used in other parts of the UI.
+     */
+    private static final JBColor APPROVE_BG = new JBColor(new Color(0x2d, 0xa4, 0x4e), new Color(0x2d, 0xa4, 0x4e));
+    private static final JBColor APPROVE_FG = new JBColor(Color.WHITE, Color.WHITE);
+    private static final JBColor PENDING_BORDER = new JBColor(new Color(0x8e, 0x95, 0x9e), new Color(0x8b, 0x94, 0x9e));
 
     /**
      * File status colors — matches IntelliJ's VCS file coloring convention:
@@ -223,11 +232,11 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         fileCol.setPreferredWidth(JBUI.scale(280));
         fileCol.setCellRenderer(new FileCellRenderer());
 
-        // COL_APPROVE — toggleable checkbox icon
+        // COL_APPROVE — green toggle button when approved, outline button when pending
         TableColumn approveCol = table.getColumnModel().getColumn(ReviewTableModel.COL_APPROVE);
-        approveCol.setPreferredWidth(JBUI.scale(28));
-        approveCol.setMaxWidth(JBUI.scale(32));
-        approveCol.setCellRenderer(new ApproveCheckboxRenderer());
+        approveCol.setPreferredWidth(JBUI.scale(72));
+        approveCol.setMaxWidth(JBUI.scale(80));
+        approveCol.setCellRenderer(new ApproveToggleRenderer());
 
         // COL_REMOVE — X button (only for approved rows)
         TableColumn removeCol = table.getColumnModel().getColumn(ReviewTableModel.COL_REMOVE);
@@ -527,26 +536,77 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
     }
 
     /**
-     * Approve checkbox column: green check when approved, gray unchecked when pending.
+     * Approve column: a pill-shaped toggle button. Green fill with "✓ Approved" when the row is
+     * approved; a dim outline with "Approve" when pending. Matches the visual language of the
+     * auto-approve toggle in the toolbar.
      */
-    private static final class ApproveCheckboxRenderer extends DefaultTableCellRenderer {
+    private static final class ApproveToggleRenderer implements TableCellRenderer {
+        private final ApproveButtonPanel button = new ApproveButtonPanel();
+
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value,
                                                        boolean isSelected, boolean hasFocus,
                                                        int row, int column) {
-            Component c = super.getTableCellRendererComponent(table, "", isSelected, hasFocus, row, column);
-            if (value instanceof ReviewItem item && c instanceof JLabel label) {
-                label.setText("");
-                label.setHorizontalAlignment(CENTER);
-                if (item.approved()) {
-                    label.setIcon(AllIcons.Diff.GutterCheckBoxSelected);
-                    label.setToolTipText("Approved — click to unapprove");
-                } else {
-                    label.setIcon(AllIcons.Diff.GutterCheckBox);
-                    label.setToolTipText("Pending — click to approve");
-                }
+            if (value instanceof ReviewItem item) {
+                button.setState(item.approved(), isSelected, table);
             }
-            return c;
+            return button;
+        }
+    }
+
+    /**
+     * Pill-shaped button panel that paints itself as a toggle button without requiring
+     * an actual Swing button component (avoids focus/repaint issues in a table renderer).
+     */
+    private static final class ApproveButtonPanel extends JPanel {
+        private boolean approved;
+
+        ApproveButtonPanel() {
+            setOpaque(false);
+            Font base = UIManager.getFont("Label.font");
+            if (base != null) setFont(base.deriveFont((float) JBUI.scaleFontSize(11)));
+        }
+
+        void setState(boolean approved, boolean rowSelected, JTable table) {
+            this.approved = approved;
+            setBackground(rowSelected ? table.getSelectionBackground() : table.getBackground());
+        }
+
+        @Override
+        protected void paintComponent(Graphics g) {
+            Graphics2D g2 = (Graphics2D) g.create();
+            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+
+            // Fill row background first
+            g2.setColor(getBackground());
+            g2.fillRect(0, 0, getWidth(), getHeight());
+
+            int arc = JBUI.scale(10);
+            int hpad = JBUI.scale(6);
+            int vpad = JBUI.scale(4);
+            int btnW = getWidth() - 2 * hpad;
+            int btnH = getHeight() - 2 * vpad;
+
+            String text = approved ? "✓ Approved" : "Approve";
+
+            if (approved) {
+                g2.setColor(APPROVE_BG);
+                g2.fillRoundRect(hpad, vpad, btnW, btnH, arc, arc);
+                g2.setColor(APPROVE_FG);
+            } else {
+                g2.setColor(PENDING_BORDER);
+                g2.drawRoundRect(hpad, vpad, btnW - 1, btnH - 1, arc, arc);
+                g2.setColor(PENDING_BORDER);
+            }
+
+            FontMetrics fm = g2.getFontMetrics(getFont());
+            int textW = fm.stringWidth(text);
+            int textX = hpad + (btnW - textW) / 2;
+            int textY = vpad + (btnH + fm.getAscent() - fm.getDescent()) / 2;
+            g2.setFont(getFont());
+            g2.drawString(text, textX, textY);
+            g2.dispose();
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewChangesPanel.java
@@ -26,7 +26,6 @@ import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.table.JBTable;
 import com.intellij.util.ui.JBUI;
-import com.intellij.util.ui.UIUtil;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -48,7 +47,7 @@ import java.util.List;
  * Columns: [file name (status-colored) + meta] [approve checkbox] [remove X].
  * File names are colored by status: green = added, blue = modified, grey = deleted.
  * Clicking a row opens the file. The approve checkbox toggles between PENDING and
- * APPROVED (green check when approved). The X button removes approved rows.
+ * APPROVED. The X button removes approved rows.
  */
 public final class ReviewChangesPanel extends JPanel implements Disposable {
 
@@ -77,6 +76,8 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
     private final JPanel cardPanel;
     private final JBLabel emptyLabel;
     private final JBLabel diffTotalsLabel;
+    private final ReviewDiffCountAnimator diffCountAnimator;
+    private final Timer diffAnimationTimer;
 
     public ReviewChangesPanel(@NotNull Project project) {
         super(new BorderLayout());
@@ -84,6 +85,15 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
 
         tableModel = new ReviewTableModel();
         table = new JBTable(tableModel);
+        diffCountAnimator = new ReviewDiffCountAnimator();
+        diffAnimationTimer = new Timer(33, e -> {
+            long now = System.currentTimeMillis();
+            table.repaint();
+            if (!diffCountAnimator.hasActiveAnimations(now)) {
+                ((Timer) e.getSource()).stop();
+            }
+        });
+        diffAnimationTimer.setRepeats(true);
         configureTable();
 
         JBScrollPane scrollPane = new JBScrollPane(table);
@@ -135,13 +145,18 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
 
     @Override
     public void dispose() {
+        diffAnimationTimer.stop();
+        diffCountAnimator.clear();
     }
 
     public void refresh() {
         AgentEditSession session = AgentEditSession.getInstance(project);
         List<ReviewItem> items = session.getReviewItems();
+        long now = System.currentTimeMillis();
+        diffCountAnimator.sync(items, now);
         tableModel.setItems(items);
         updateDiffTotals(items);
+        updateDiffAnimationTimer(now);
 
         if (!items.isEmpty()) {
             cardLayout.show(cardPanel, CARD_TABLE);
@@ -152,6 +167,16 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
         }
         revalidate();
         repaint();
+    }
+
+    private void updateDiffAnimationTimer(long now) {
+        if (diffCountAnimator.hasActiveAnimations(now)) {
+            if (!diffAnimationTimer.isRunning()) {
+                diffAnimationTimer.start();
+            }
+        } else {
+            diffAnimationTimer.stop();
+        }
     }
 
     private void updateDiffTotals(@NotNull List<ReviewItem> items) {
@@ -436,10 +461,9 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
     // ── Cell renderers ────────────────────────────────────────────────────────
 
     /**
-     * File name column: shows file name, diff-colored line counts, and timestamp.
-     * Approved rows are muted.
+     * File name column: shows file name, animated diff-colored line counts, and timestamp.
      */
-    private static final class FileCellRenderer extends DefaultTableCellRenderer {
+    private final class FileCellRenderer extends DefaultTableCellRenderer {
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value,
                                                        boolean isSelected, boolean hasFocus,
@@ -453,22 +477,16 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
             String fileName = p.getFileName() != null ? p.getFileName().toString() : item.path();
 
             boolean approved = item.approved();
-            setText(buildHtml(fileName, item, isSelected, approved));
+            long now = System.currentTimeMillis();
+            setText(buildHtml(fileName, item, isSelected, diffCountAnimator.displayCounts(item, now)));
             setToolTipText(item.relativePath() + (approved ? " · Approved" : " · Pending review"));
-
-            if (approved && !isSelected) {
-                setForeground(JBColor.GRAY);
-                setBackground(mute(table.getBackground()));
-            }
             return this;
         }
 
         private @NotNull String buildHtml(@NotNull String fileName, @NotNull ReviewItem item,
-                                          boolean isSelected, boolean approved) {
+                                          boolean isSelected, @NotNull ReviewDiffCountAnimator.DiffCounts counts) {
             StringBuilder sb = new StringBuilder("<html>");
-            if (approved && !isSelected) {
-                sb.append("<font color='gray'>").append(escapeHtml(fileName)).append(FONT_CLOSE);
-            } else if (!isSelected) {
+            if (!isSelected) {
                 Color statusColor = switch (item.status()) {
                     case ADDED -> STATUS_ADDED;
                     case MODIFIED -> STATUS_MODIFIED;
@@ -480,16 +498,14 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
             }
 
             // Diff-colored line counts
-            if (item.linesAdded() > 0 || item.linesRemoved() > 0) {
+            if (counts.added() > 0 || counts.removed() > 0) {
                 sb.append(" <font size='-2'>");
-                if (item.linesAdded() > 0) {
-                    Color green = approved && !isSelected ? JBColor.GRAY : DIFF_GREEN;
-                    sb.append(colorSpan(green, "+" + item.linesAdded()));
+                if (counts.added() > 0) {
+                    sb.append(colorSpan(DIFF_GREEN, "+" + counts.added()));
                 }
-                if (item.linesRemoved() > 0) {
-                    if (item.linesAdded() > 0) sb.append(" ");
-                    Color red = approved && !isSelected ? JBColor.GRAY : DIFF_RED;
-                    sb.append(colorSpan(red, "-" + item.linesRemoved()));
+                if (counts.removed() > 0) {
+                    if (counts.added() > 0) sb.append(" ");
+                    sb.append(colorSpan(DIFF_RED, "-" + counts.removed()));
                 }
                 sb.append(FONT_CLOSE);
             }
@@ -559,12 +575,5 @@ public final class ReviewChangesPanel extends JPanel implements Disposable {
             }
             return c;
         }
-    }
-
-    private static @NotNull Color mute(@NotNull Color base) {
-        int r = (base.getRed() + UIUtil.getPanelBackground().getRed()) / 2;
-        int g = (base.getGreen() + UIUtil.getPanelBackground().getGreen()) / 2;
-        int b = (base.getBlue() + UIUtil.getPanelBackground().getBlue()) / 2;
-        return new Color(r, g, b);
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewDiffCountAnimator.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/ReviewDiffCountAnimator.java
@@ -1,0 +1,105 @@
+package com.github.catatafishen.agentbridge.ui.review;
+
+import com.github.catatafishen.agentbridge.psi.review.ReviewItem;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+final class ReviewDiffCountAnimator {
+
+    static final long ANIMATION_DURATION_MS = 180L;
+
+    private final Map<String, DiffCountState> states = new HashMap<>();
+
+    void sync(@NotNull List<ReviewItem> items, long nowMillis) {
+        Set<String> livePaths = new HashSet<>(items.size());
+        for (ReviewItem item : items) {
+            livePaths.add(item.path());
+            DiffCountState state = states.get(item.path());
+            if (state == null) {
+                states.put(item.path(), DiffCountState.stationary(item.linesAdded(), item.linesRemoved()));
+            } else {
+                state.retarget(item.linesAdded(), item.linesRemoved(), nowMillis);
+            }
+        }
+        states.keySet().retainAll(livePaths);
+    }
+
+    @NotNull DiffCounts displayCounts(@NotNull ReviewItem item, long nowMillis) {
+        DiffCountState state = states.get(item.path());
+        return state != null ? state.displayCounts(nowMillis)
+            : new DiffCounts(item.linesAdded(), item.linesRemoved());
+    }
+
+    boolean hasActiveAnimations(long nowMillis) {
+        for (DiffCountState state : states.values()) {
+            if (state.isAnimating(nowMillis)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void clear() {
+        states.clear();
+    }
+
+    private static final class DiffCountState {
+        private int startAdded;
+        private int startRemoved;
+        private int targetAdded;
+        private int targetRemoved;
+        private long startMillis;
+
+        private DiffCountState(int startAdded, int startRemoved, int targetAdded, int targetRemoved, long startMillis) {
+            this.startAdded = startAdded;
+            this.startRemoved = startRemoved;
+            this.targetAdded = targetAdded;
+            this.targetRemoved = targetRemoved;
+            this.startMillis = startMillis;
+        }
+
+        static @NotNull DiffCountState stationary(int added, int removed) {
+            return new DiffCountState(added, removed, added, removed, 0L);
+        }
+
+        void retarget(int added, int removed, long nowMillis) {
+            if (targetAdded == added && targetRemoved == removed) {
+                return;
+            }
+            DiffCounts current = displayCounts(nowMillis);
+            startAdded = current.added();
+            startRemoved = current.removed();
+            targetAdded = added;
+            targetRemoved = removed;
+            startMillis = nowMillis;
+        }
+
+        @NotNull DiffCounts displayCounts(long nowMillis) {
+            if (!isAnimating(nowMillis)) {
+                return new DiffCounts(targetAdded, targetRemoved);
+            }
+            double progress = Math.min(1.0d, (double) (nowMillis - startMillis) / ANIMATION_DURATION_MS);
+            return new DiffCounts(
+                interpolate(startAdded, targetAdded, progress),
+                interpolate(startRemoved, targetRemoved, progress)
+            );
+        }
+
+        boolean isAnimating(long nowMillis) {
+            return (startAdded != targetAdded || startRemoved != targetRemoved)
+                && nowMillis - startMillis < ANIMATION_DURATION_MS;
+        }
+
+        private static int interpolate(int start, int target, double progress) {
+            return (int) Math.round(start + (target - start) * progress);
+        }
+    }
+
+    record DiffCounts(int added, int removed) {
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/HistoryContextWindow.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/HistoryContextWindow.kt
@@ -1,23 +1,25 @@
 package com.github.catatafishen.agentbridge.ui.side
 
+import com.github.catatafishen.agentbridge.ui.ChatConsolePanel
 import com.github.catatafishen.agentbridge.ui.EntryData
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.WindowManager
-import com.intellij.ui.components.JBList
-import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.JBUI
-import java.awt.*
-import java.awt.event.MouseAdapter
-import java.awt.event.MouseEvent
-import javax.swing.*
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.event.WindowAdapter
+import java.awt.event.WindowEvent
+import javax.swing.JDialog
 
 /**
- * Non-modal floating window showing conversation history centered on a specific prompt.
+ * Non-modal floating window showing conversation history centred on a specific prompt.
  *
- * Opened when the user clicks a prompt in the Prompts tab that has not yet been rendered
- * in the main JCEF chat view (i.e., it is still in the deferred history queue). The initial
- * view shows one prompt before and one after the target. "Load more" controls at both edges
- * expand the window in either direction, 3 prompts at a time.
+ * Opened when the user clicks a prompt in the Search tab that has not yet been rendered
+ * in the main JCEF chat view (i.e., it is still in the deferred history queue). The full
+ * conversation is rendered using the same {@link ChatConsolePanel} as the main chat panel,
+ * preserving all formatting, tool calls, and sub-agent segments. The target prompt is
+ * scrolled into view and briefly highlighted after rendering.
  */
 internal class HistoryContextWindow private constructor(
     project: Project,
@@ -26,12 +28,6 @@ internal class HistoryContextWindow private constructor(
 ) : JDialog(WindowManager.getInstance().getFrame(project), "Conversation History", false) {
 
     companion object {
-        /** Initial context prompts shown on each side of the target. */
-        private const val INITIAL_CONTEXT = 1
-
-        /** Number of additional prompts revealed per load-more click. */
-        private const val LOAD_STEP = 3
-
         fun open(project: Project, allEntries: List<EntryData>, targetEntryId: String) {
             val win = HistoryContextWindow(project, allEntries, targetEntryId)
             win.pack()
@@ -40,232 +36,24 @@ internal class HistoryContextWindow private constructor(
         }
     }
 
-    private data class PromptItem(
-        val prompt: EntryData.Prompt,
-        val stats: EntryData.TurnStats?,
-        val commits: List<String>,
-    )
-
-    private val allPrompts: List<EntryData.Prompt>
-    private val turnDataMap: Map<String, Pair<EntryData.TurnStats?, List<String>>>
-    private val targetIndex: Int
-
-    /** How many prompts before the target are currently shown. */
-    private var shownBefore = INITIAL_CONTEXT
-
-    /** How many prompts after the target are currently shown. */
-    private var shownAfter = INITIAL_CONTEXT
-
-    private val listModel = DefaultListModel<PromptItem>()
-    private val promptList = JBList(listModel)
-
-    private val loadOlderLabel = JLabel("↑ Load earlier prompts").apply {
-        font = JBUI.Fonts.miniFont()
-        foreground = JBUI.CurrentTheme.Link.Foreground.ENABLED
-        cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-        horizontalAlignment = SwingConstants.CENTER
-        border = JBUI.Borders.empty(4)
-        addMouseListener(object : MouseAdapter() {
-            override fun mouseClicked(e: MouseEvent) = loadOlder()
-        })
-    }
-
-    private val loadNewerLabel = JLabel("↓ Load more recent prompts").apply {
-        font = JBUI.Fonts.miniFont()
-        foreground = JBUI.CurrentTheme.Link.Foreground.ENABLED
-        cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-        horizontalAlignment = SwingConstants.CENTER
-        border = JBUI.Borders.empty(4)
-        addMouseListener(object : MouseAdapter() {
-            override fun mouseClicked(e: MouseEvent) = loadNewer()
-        })
-    }
-
-    private val loadOlderPanel = JPanel(BorderLayout()).apply {
-        isOpaque = false
-        add(loadOlderLabel, BorderLayout.CENTER)
-        isVisible = false
-    }
-
-    private val loadNewerPanel = JPanel(BorderLayout()).apply {
-        isOpaque = false
-        add(loadNewerLabel, BorderLayout.CENTER)
-        isVisible = false
-    }
+    private val chatPanel = ChatConsolePanel(project, registerAsMain = false)
 
     init {
-        allPrompts = allEntries.filterIsInstance<EntryData.Prompt>()
-        turnDataMap = buildTurnDataMap(allEntries)
-        targetIndex = allPrompts.indexOfFirst { PromptsPanel.promptEntryId(it) == targetEntryId }
-            .let { if (it < 0) allPrompts.size - 1 else it }
-
-        promptList.cellRenderer = BubbleRenderer()
-        promptList.fixedCellHeight = -1
-
-        val centerPanel = JPanel(BorderLayout())
-        centerPanel.add(loadOlderPanel, BorderLayout.NORTH)
-        val scrollPane = JBScrollPane(promptList)
-        scrollPane.border = JBUI.Borders.empty()
-        centerPanel.add(scrollPane, BorderLayout.CENTER)
-        centerPanel.add(loadNewerPanel, BorderLayout.SOUTH)
-        contentPane.add(centerPanel, BorderLayout.CENTER)
-        preferredSize = Dimension(JBUI.scale(480), JBUI.scale(500))
-
-        refresh()
-
-        // Select and scroll to the target after the window is laid out
-        SwingUtilities.invokeLater {
-            val start = maxOf(0, targetIndex - shownBefore)
-            val targetInModel = (targetIndex - start).coerceIn(0, listModel.size() - 1)
-            promptList.selectedIndex = targetInModel
-            val bounds = promptList.getCellBounds(targetInModel, targetInModel)
-            if (bounds != null) promptList.scrollRectToVisible(bounds)
-        }
-
+        contentPane.add(chatPanel.component, BorderLayout.CENTER)
+        preferredSize = Dimension(JBUI.scale(700), JBUI.scale(750))
         defaultCloseOperation = DISPOSE_ON_CLOSE
         isResizable = true
+
+        // Remove the DOM entry cap so the full history is always visible.
+        chatPanel.setDomMessageLimit(100_000)
+
+        // Load all history, then scroll to the target. Both calls go through executeJs's
+        // pending queue so they fire in order after the JCEF page finishes loading.
+        chatPanel.appendEntries(allEntries)
+        chatPanel.scrollToEntry(targetEntryId)
+
+        addWindowListener(object : WindowAdapter() {
+            override fun windowClosed(e: WindowEvent) = Disposer.dispose(chatPanel)
+        })
     }
-
-    private fun refresh() {
-        val start = maxOf(0, targetIndex - shownBefore)
-        val end = minOf(allPrompts.size - 1, targetIndex + shownAfter)
-
-        loadOlderPanel.isVisible = start > 0
-        loadNewerPanel.isVisible = end < allPrompts.size - 1
-
-        listModel.clear()
-        for (i in start..end) {
-            val p = allPrompts[i]
-            val key = PromptsPanel.promptEntryId(p)
-            val (stats, commits) = turnDataMap[key] ?: Pair(null, emptyList<String>())
-            listModel.addElement(PromptItem(p, stats, commits))
-        }
-    }
-
-    private fun loadOlder() {
-        val prevStart = maxOf(0, targetIndex - shownBefore)
-        shownBefore += LOAD_STEP
-        refresh()
-        // Keep the previously-top item visible after new entries are prepended
-        val newStart = maxOf(0, targetIndex - shownBefore)
-        val offsetInModel = (prevStart - newStart).coerceAtLeast(0)
-        if (offsetInModel < listModel.size()) {
-            val bounds = promptList.getCellBounds(offsetInModel, offsetInModel)
-            if (bounds != null) promptList.scrollRectToVisible(bounds)
-        }
-    }
-
-    private fun loadNewer() {
-        shownAfter += LOAD_STEP
-        refresh()
-        val lastIdx = listModel.size() - 1
-        if (lastIdx >= 0) {
-            val bounds = promptList.getCellBounds(lastIdx, lastIdx)
-            if (bounds != null) promptList.scrollRectToVisible(bounds)
-        }
-    }
-
-    private class BubbleRenderer : ListCellRenderer<PromptItem> {
-        private val outer = JPanel(BorderLayout(0, JBUI.scale(2)))
-        private val headerPanel = JPanel(BorderLayout())
-        private val tsLabel = JLabel()
-        private val statsLabel = JLabel()
-        private val textArea = JTextArea()
-        private val commitsLabel = JLabel()
-        private val commitsPanel = JPanel(BorderLayout()).apply {
-            isOpaque = false
-            add(commitsLabel, BorderLayout.CENTER)
-        }
-
-        init {
-            outer.isOpaque = true
-            tsLabel.font = JBUI.Fonts.miniFont()
-            tsLabel.foreground = JBUI.CurrentTheme.Label.disabledForeground()
-            statsLabel.font = JBUI.Fonts.miniFont()
-            statsLabel.foreground = JBUI.CurrentTheme.Label.disabledForeground()
-            headerPanel.isOpaque = false
-            headerPanel.add(tsLabel, BorderLayout.WEST)
-            headerPanel.add(statsLabel, BorderLayout.EAST)
-            textArea.isOpaque = false
-            textArea.isEditable = false
-            textArea.lineWrap = true
-            textArea.wrapStyleWord = true
-            textArea.font = UIManager.getFont("Label.font") ?: textArea.font
-            textArea.border = null
-            textArea.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-            commitsLabel.font = JBUI.Fonts.miniFont()
-            commitsLabel.foreground = JBUI.CurrentTheme.Label.disabledForeground()
-            outer.add(headerPanel, BorderLayout.NORTH)
-            outer.add(textArea, BorderLayout.CENTER)
-            outer.add(commitsPanel, BorderLayout.SOUTH)
-            outer.border = JBUI.Borders.compound(
-                JBUI.Borders.empty(1, 0),
-                JBUI.Borders.empty(4, 8, 4, 6)
-            )
-        }
-
-        override fun getListCellRendererComponent(
-            list: JList<out PromptItem>?,
-            value: PromptItem?,
-            index: Int,
-            isSelected: Boolean,
-            cellHasFocus: Boolean,
-        ): Component {
-            if (value == null) return outer
-            val listWidth = list?.width ?: 0
-            if (listWidth > 0) {
-                textArea.setSize(listWidth - JBUI.scale(18), Short.MAX_VALUE.toInt())
-            }
-            tsLabel.text = PromptsPanel.formatTimestamp(value.prompt.timestamp)
-            statsLabel.text = PromptsPanel.formatStats(value.stats)
-            textArea.text = PromptsPanel.truncatePrompt(value.prompt.text.trim())
-
-            val commitsText = PromptsPanel.formatCommits(value.commits)
-            commitsLabel.text = commitsText
-            commitsPanel.isVisible = commitsText.isNotEmpty()
-
-            if (isSelected) {
-                val selFg = list?.selectionForeground ?: UIManager.getColor("List.selectionForeground")
-                outer.background = list?.selectionBackground ?: UIManager.getColor("List.selectionBackground")
-                textArea.foreground = selFg
-                tsLabel.foreground = selFg
-                statsLabel.foreground = selFg
-                commitsLabel.foreground = selFg
-            } else {
-                outer.background = list?.background ?: UIManager.getColor("List.background")
-                textArea.foreground = list?.foreground ?: UIManager.getColor("List.foreground")
-                tsLabel.foreground = JBUI.CurrentTheme.Label.disabledForeground()
-                statsLabel.foreground = JBUI.CurrentTheme.Label.disabledForeground()
-                commitsLabel.foreground = JBUI.CurrentTheme.Label.disabledForeground()
-            }
-
-            val commitsHeight = if (commitsPanel.isVisible) commitsLabel.preferredSize.height + JBUI.scale(2) else 0
-            val textHeight = textArea.preferredSize.height
-            outer.preferredSize = Dimension(
-                listWidth,
-                tsLabel.preferredSize.height + JBUI.scale(2) + textHeight + commitsHeight + JBUI.scale(10)
-            )
-            return outer
-        }
-    }
-}
-
-private fun buildTurnDataMap(entries: List<EntryData>): Map<String, Pair<EntryData.TurnStats?, List<String>>> {
-    val result = mutableMapOf<String, Pair<EntryData.TurnStats?, List<String>>>()
-    var lastPromptId: String? = null
-    for (entry in entries) {
-        when (entry) {
-            is EntryData.Prompt -> lastPromptId = PromptsPanel.promptEntryId(entry)
-            is EntryData.TurnStats -> {
-                val key = entry.turnId.takeIf { it.isNotEmpty() } ?: lastPromptId
-                if (key != null) {
-                    result[key] = Pair(entry, entry.commitHashes)
-                    lastPromptId = null
-                }
-            }
-
-            else -> Unit
-        }
-    }
-    return result
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/HistoryContextWindow.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/HistoryContextWindow.kt
@@ -1,0 +1,271 @@
+package com.github.catatafishen.agentbridge.ui.side
+
+import com.github.catatafishen.agentbridge.ui.EntryData
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.WindowManager
+import com.intellij.ui.components.JBList
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.util.ui.JBUI
+import java.awt.*
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.*
+
+/**
+ * Non-modal floating window showing conversation history centered on a specific prompt.
+ *
+ * Opened when the user clicks a prompt in the Prompts tab that has not yet been rendered
+ * in the main JCEF chat view (i.e., it is still in the deferred history queue). The initial
+ * view shows one prompt before and one after the target. "Load more" controls at both edges
+ * expand the window in either direction, 3 prompts at a time.
+ */
+internal class HistoryContextWindow private constructor(
+    project: Project,
+    allEntries: List<EntryData>,
+    targetEntryId: String,
+) : JDialog(WindowManager.getInstance().getFrame(project), "Conversation History", false) {
+
+    companion object {
+        /** Initial context prompts shown on each side of the target. */
+        private const val INITIAL_CONTEXT = 1
+
+        /** Number of additional prompts revealed per load-more click. */
+        private const val LOAD_STEP = 3
+
+        fun open(project: Project, allEntries: List<EntryData>, targetEntryId: String) {
+            val win = HistoryContextWindow(project, allEntries, targetEntryId)
+            win.pack()
+            win.setLocationRelativeTo(WindowManager.getInstance().getFrame(project))
+            win.isVisible = true
+        }
+    }
+
+    private data class PromptItem(
+        val prompt: EntryData.Prompt,
+        val stats: EntryData.TurnStats?,
+        val commits: List<String>,
+    )
+
+    private val allPrompts: List<EntryData.Prompt>
+    private val turnDataMap: Map<String, Pair<EntryData.TurnStats?, List<String>>>
+    private val targetIndex: Int
+
+    /** How many prompts before the target are currently shown. */
+    private var shownBefore = INITIAL_CONTEXT
+
+    /** How many prompts after the target are currently shown. */
+    private var shownAfter = INITIAL_CONTEXT
+
+    private val listModel = DefaultListModel<PromptItem>()
+    private val promptList = JBList(listModel)
+
+    private val loadOlderLabel = JLabel("↑ Load earlier prompts").apply {
+        font = JBUI.Fonts.miniFont()
+        foreground = JBUI.CurrentTheme.Link.Foreground.ENABLED
+        cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        horizontalAlignment = SwingConstants.CENTER
+        border = JBUI.Borders.empty(4)
+        addMouseListener(object : MouseAdapter() {
+            override fun mouseClicked(e: MouseEvent) = loadOlder()
+        })
+    }
+
+    private val loadNewerLabel = JLabel("↓ Load more recent prompts").apply {
+        font = JBUI.Fonts.miniFont()
+        foreground = JBUI.CurrentTheme.Link.Foreground.ENABLED
+        cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        horizontalAlignment = SwingConstants.CENTER
+        border = JBUI.Borders.empty(4)
+        addMouseListener(object : MouseAdapter() {
+            override fun mouseClicked(e: MouseEvent) = loadNewer()
+        })
+    }
+
+    private val loadOlderPanel = JPanel(BorderLayout()).apply {
+        isOpaque = false
+        add(loadOlderLabel, BorderLayout.CENTER)
+        isVisible = false
+    }
+
+    private val loadNewerPanel = JPanel(BorderLayout()).apply {
+        isOpaque = false
+        add(loadNewerLabel, BorderLayout.CENTER)
+        isVisible = false
+    }
+
+    init {
+        allPrompts = allEntries.filterIsInstance<EntryData.Prompt>()
+        turnDataMap = buildTurnDataMap(allEntries)
+        targetIndex = allPrompts.indexOfFirst { PromptsPanel.promptEntryId(it) == targetEntryId }
+            .let { if (it < 0) allPrompts.size - 1 else it }
+
+        promptList.cellRenderer = BubbleRenderer()
+        promptList.fixedCellHeight = -1
+
+        val centerPanel = JPanel(BorderLayout())
+        centerPanel.add(loadOlderPanel, BorderLayout.NORTH)
+        val scrollPane = JBScrollPane(promptList)
+        scrollPane.border = JBUI.Borders.empty()
+        centerPanel.add(scrollPane, BorderLayout.CENTER)
+        centerPanel.add(loadNewerPanel, BorderLayout.SOUTH)
+        contentPane.add(centerPanel, BorderLayout.CENTER)
+        preferredSize = Dimension(JBUI.scale(480), JBUI.scale(500))
+
+        refresh()
+
+        // Select and scroll to the target after the window is laid out
+        SwingUtilities.invokeLater {
+            val start = maxOf(0, targetIndex - shownBefore)
+            val targetInModel = (targetIndex - start).coerceIn(0, listModel.size() - 1)
+            promptList.selectedIndex = targetInModel
+            val bounds = promptList.getCellBounds(targetInModel, targetInModel)
+            if (bounds != null) promptList.scrollRectToVisible(bounds)
+        }
+
+        defaultCloseOperation = DISPOSE_ON_CLOSE
+        isResizable = true
+    }
+
+    private fun refresh() {
+        val start = maxOf(0, targetIndex - shownBefore)
+        val end = minOf(allPrompts.size - 1, targetIndex + shownAfter)
+
+        loadOlderPanel.isVisible = start > 0
+        loadNewerPanel.isVisible = end < allPrompts.size - 1
+
+        listModel.clear()
+        for (i in start..end) {
+            val p = allPrompts[i]
+            val key = PromptsPanel.promptEntryId(p)
+            val (stats, commits) = turnDataMap[key] ?: Pair(null, emptyList<String>())
+            listModel.addElement(PromptItem(p, stats, commits))
+        }
+    }
+
+    private fun loadOlder() {
+        val prevStart = maxOf(0, targetIndex - shownBefore)
+        shownBefore += LOAD_STEP
+        refresh()
+        // Keep the previously-top item visible after new entries are prepended
+        val newStart = maxOf(0, targetIndex - shownBefore)
+        val offsetInModel = (prevStart - newStart).coerceAtLeast(0)
+        if (offsetInModel < listModel.size()) {
+            val bounds = promptList.getCellBounds(offsetInModel, offsetInModel)
+            if (bounds != null) promptList.scrollRectToVisible(bounds)
+        }
+    }
+
+    private fun loadNewer() {
+        shownAfter += LOAD_STEP
+        refresh()
+        val lastIdx = listModel.size() - 1
+        if (lastIdx >= 0) {
+            val bounds = promptList.getCellBounds(lastIdx, lastIdx)
+            if (bounds != null) promptList.scrollRectToVisible(bounds)
+        }
+    }
+
+    private class BubbleRenderer : ListCellRenderer<PromptItem> {
+        private val outer = JPanel(BorderLayout(0, JBUI.scale(2)))
+        private val headerPanel = JPanel(BorderLayout())
+        private val tsLabel = JLabel()
+        private val statsLabel = JLabel()
+        private val textArea = JTextArea()
+        private val commitsLabel = JLabel()
+        private val commitsPanel = JPanel(BorderLayout()).apply {
+            isOpaque = false
+            add(commitsLabel, BorderLayout.CENTER)
+        }
+
+        init {
+            outer.isOpaque = true
+            tsLabel.font = JBUI.Fonts.miniFont()
+            tsLabel.foreground = JBUI.CurrentTheme.Label.disabledForeground()
+            statsLabel.font = JBUI.Fonts.miniFont()
+            statsLabel.foreground = JBUI.CurrentTheme.Label.disabledForeground()
+            headerPanel.isOpaque = false
+            headerPanel.add(tsLabel, BorderLayout.WEST)
+            headerPanel.add(statsLabel, BorderLayout.EAST)
+            textArea.isOpaque = false
+            textArea.isEditable = false
+            textArea.lineWrap = true
+            textArea.wrapStyleWord = true
+            textArea.font = UIManager.getFont("Label.font") ?: textArea.font
+            textArea.border = null
+            textArea.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            commitsLabel.font = JBUI.Fonts.miniFont()
+            commitsLabel.foreground = JBUI.CurrentTheme.Label.disabledForeground()
+            outer.add(headerPanel, BorderLayout.NORTH)
+            outer.add(textArea, BorderLayout.CENTER)
+            outer.add(commitsPanel, BorderLayout.SOUTH)
+            outer.border = JBUI.Borders.compound(
+                JBUI.Borders.empty(1, 0),
+                JBUI.Borders.empty(4, 8, 4, 6)
+            )
+        }
+
+        override fun getListCellRendererComponent(
+            list: JList<out PromptItem>?,
+            value: PromptItem?,
+            index: Int,
+            isSelected: Boolean,
+            cellHasFocus: Boolean,
+        ): Component {
+            if (value == null) return outer
+            val listWidth = list?.width ?: 0
+            if (listWidth > 0) {
+                textArea.setSize(listWidth - JBUI.scale(18), Short.MAX_VALUE.toInt())
+            }
+            tsLabel.text = PromptsPanel.formatTimestamp(value.prompt.timestamp)
+            statsLabel.text = PromptsPanel.formatStats(value.stats)
+            textArea.text = PromptsPanel.truncatePrompt(value.prompt.text.trim())
+
+            val commitsText = PromptsPanel.formatCommits(value.commits)
+            commitsLabel.text = commitsText
+            commitsPanel.isVisible = commitsText.isNotEmpty()
+
+            if (isSelected) {
+                val selFg = list?.selectionForeground ?: UIManager.getColor("List.selectionForeground")
+                outer.background = list?.selectionBackground ?: UIManager.getColor("List.selectionBackground")
+                textArea.foreground = selFg
+                tsLabel.foreground = selFg
+                statsLabel.foreground = selFg
+                commitsLabel.foreground = selFg
+            } else {
+                outer.background = list?.background ?: UIManager.getColor("List.background")
+                textArea.foreground = list?.foreground ?: UIManager.getColor("List.foreground")
+                tsLabel.foreground = JBUI.CurrentTheme.Label.disabledForeground()
+                statsLabel.foreground = JBUI.CurrentTheme.Label.disabledForeground()
+                commitsLabel.foreground = JBUI.CurrentTheme.Label.disabledForeground()
+            }
+
+            val commitsHeight = if (commitsPanel.isVisible) commitsLabel.preferredSize.height + JBUI.scale(2) else 0
+            val textHeight = textArea.preferredSize.height
+            outer.preferredSize = Dimension(
+                listWidth,
+                tsLabel.preferredSize.height + JBUI.scale(2) + textHeight + commitsHeight + JBUI.scale(10)
+            )
+            return outer
+        }
+    }
+}
+
+private fun buildTurnDataMap(entries: List<EntryData>): Map<String, Pair<EntryData.TurnStats?, List<String>>> {
+    val result = mutableMapOf<String, Pair<EntryData.TurnStats?, List<String>>>()
+    var lastPromptId: String? = null
+    for (entry in entries) {
+        when (entry) {
+            is EntryData.Prompt -> lastPromptId = PromptsPanel.promptEntryId(entry)
+            is EntryData.TurnStats -> {
+                val key = entry.turnId.takeIf { it.isNotEmpty() } ?: lastPromptId
+                if (key != null) {
+                    result[key] = Pair(entry, entry.commitHashes)
+                    lastPromptId = null
+                }
+            }
+
+            else -> Unit
+        }
+    }
+    return result
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
@@ -311,6 +311,14 @@ final class ProjectFilesPanel extends JPanel {
                                                       boolean expanded, boolean leaf, int row,
                                                       boolean hasFocus) {
             Component c = super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
+            if (!sel) {
+                // DefaultTreeCellRenderer can paint a non-transparent background in dark themes;
+                // clear it so the tree background shows through on non-selected rows.
+                setOpaque(false);
+                if (c instanceof JLabel label) {
+                    label.setOpaque(false);
+                }
+            }
             if (value instanceof DefaultMutableTreeNode node && node.getUserObject() instanceof FileNode fn
                 && c instanceof JLabel label) {
                 label.setIcon(fn.icon());

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/PromptsPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/PromptsPanel.kt
@@ -2,10 +2,12 @@ package com.github.catatafishen.agentbridge.ui.side
 
 import com.github.catatafishen.agentbridge.ui.ChatConsolePanel
 import com.github.catatafishen.agentbridge.ui.EntryData
+import com.github.catatafishen.agentbridge.session.v2.SessionStoreV2
 import com.github.catatafishen.agentbridge.ui.side.PromptsPanel.Companion.MAX_CHARS
 import com.github.catatafishen.agentbridge.ui.side.PromptsPanel.Companion.MAX_ROWS
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
 import com.intellij.ui.DocumentAdapter
 import com.intellij.ui.SearchTextField
 import com.intellij.ui.components.JBList
@@ -17,10 +19,12 @@ import java.awt.Cursor
 import java.awt.Dimension
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
+import java.util.concurrent.atomic.AtomicInteger
 import javax.swing.*
 import javax.swing.event.DocumentEvent
 
 internal class PromptsPanel(
+    private val project: Project,
     private val chatConsole: ChatConsolePanel
 ) : JPanel(BorderLayout()), Disposable {
 
@@ -33,12 +37,16 @@ internal class PromptsPanel(
     private val searchField = SearchTextField()
     private val listModel = DefaultListModel<PromptItem>()
     private val promptList = JBList(listModel)
+    private val sessionStore = SessionStoreV2.getInstance(project)
+    private val historyLoadSerial = AtomicInteger()
     private val entriesListener = Runnable {
-        ApplicationManager.getApplication().invokeLater(::refresh)
+        ApplicationManager.getApplication().invokeLater(::onEntriesChanged)
     }
 
     private var displayedCount = PAGE_SIZE
     private var lastQuery = ""
+    @Volatile
+    private var historyEntries: List<EntryData> = emptyList()
 
     private val loadMoreLabel = JLabel("↑ Load earlier prompts").apply {
         font = JBUI.Fonts.miniFont()
@@ -71,7 +79,12 @@ internal class PromptsPanel(
                 if (!cellBounds.contains(e.point)) return
                 val item = listModel.getElementAt(idx) ?: return
                 val entryId = promptEntryId(item.prompt)
-                if (entryId.isNotEmpty()) chatConsole.scrollToEntry(entryId)
+                if (entryId.isEmpty()) return
+                if (chatConsole.isEntryRendered(entryId)) {
+                    chatConsole.scrollToEntry(entryId)
+                } else {
+                    HistoryContextWindow.open(project, historyEntries, entryId)
+                }
             }
         })
 
@@ -100,12 +113,36 @@ internal class PromptsPanel(
         add(centerPanel, BorderLayout.CENTER)
 
         chatConsole.addEntriesChangeListener(entriesListener)
+        reloadHistoryAsync()
         refresh()
+    }
+
+    private fun onEntriesChanged() {
+        if (chatConsole.entriesSnapshot().isEmpty()) {
+            historyEntries = emptyList()
+            listModel.clear()
+            loadMorePanel.isVisible = false
+            reloadHistoryAsync()
+        } else {
+            refresh()
+        }
+    }
+
+    private fun reloadHistoryAsync() {
+        val serial = historyLoadSerial.incrementAndGet()
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val loaded = sessionStore.loadEntries(project.basePath).orEmpty()
+            ApplicationManager.getApplication().invokeLater {
+                if (serial != historyLoadSerial.get()) return@invokeLater
+                historyEntries = loaded
+                refresh()
+            }
+        }
     }
 
     private fun refresh() {
         val query = searchField.text.orEmpty()
-        val allEntries = chatConsole.entriesSnapshot()
+        val allEntries = mergeEntries(historyEntries, chatConsole.entriesSnapshot())
         val prompts = allEntries.filterIsInstance<EntryData.Prompt>()
         val filtered = filterPrompts(prompts, query)
         val turnDataMap = buildTurnDataMap(allEntries)
@@ -246,6 +283,26 @@ internal class PromptsPanel(
             if (q.isEmpty()) return prompts
             val needle = q.lowercase()
             return prompts.filter { it.text.lowercase().contains(needle) }
+        }
+
+        fun mergeEntries(historyEntries: List<EntryData>, liveEntries: List<EntryData>): List<EntryData> {
+            if (historyEntries.isEmpty()) return liveEntries
+            if (liveEntries.isEmpty()) return historyEntries
+
+            val merged = ArrayList<EntryData>(historyEntries.size + liveEntries.size)
+            val seen = LinkedHashSet<String>()
+
+            fun addAll(entries: List<EntryData>) {
+                for (entry in entries) {
+                    if (seen.add(entry.entryId)) {
+                        merged.add(entry)
+                    }
+                }
+            }
+
+            addAll(historyEntries)
+            addAll(liveEntries)
+            return merged
         }
 
         fun promptEntryId(p: EntryData.Prompt): String = p.id.ifEmpty { p.entryId }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SidePanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SidePanel.java
@@ -16,11 +16,11 @@ import java.awt.*;
  * Uses {@link PlatformApiCompat#createJBTabsPanel} for native IntelliJ flat tab styling.
  * Hosts four tabs:
  * <ol>
- *   <li><b>Review</b> — the existing {@link ReviewChangesPanel} with pending agent edits.</li>
+ *   <li><b>Diff</b> — the existing {@link ReviewChangesPanel} with pending agent edits.</li>
  *   <li><b>Files</b> — configuration/agent-definition files for this project.</li>
- *   <li><b>Todos</b> — rendered view of the active agent session's {@code plan.md},
+ *   <li><b>Todo</b> — rendered view of the active agent session's {@code plan.md},
  *       with a {@code (done/total)} badge in the tab title when checkbox-style todos exist.</li>
- *   <li><b>Prompts</b> — searchable list of user prompts across the current conversation history, click to scroll.</li>
+ *   <li><b>Search</b> — searchable list of user prompts across the current conversation history, click to scroll.</li>
  * </ol>
  * Tab order is deliberate: review is the most time-sensitive and sits first.
  */
@@ -29,7 +29,6 @@ public final class SidePanel extends JPanel implements Disposable {
     private static final int TAB_REVIEW = 0;
     private static final int TAB_FILES = 1;
     private static final int TAB_TODOS = 2;
-    private static final int TAB_PROMPTS = 3;
 
     private final transient PlatformApiCompat.JBTabsPanel tabsPanel;
 
@@ -45,15 +44,15 @@ public final class SidePanel extends JPanel implements Disposable {
         Disposer.register(this, promptsPanel);
 
         tabsPanel = PlatformApiCompat.createJBTabsPanel(project, this);
-        tabsPanel.addTab(reviewPanel, "Review");
+        tabsPanel.addTab(reviewPanel, "Diff");
         tabsPanel.addTab(projectFilesPanel, "Files");
-        tabsPanel.addTab(todoPanel, "Todos");
-        tabsPanel.addTab(promptsPanel, "Prompts");
+        tabsPanel.addTab(todoPanel, "Todo");
+        tabsPanel.addTab(promptsPanel, "Search");
 
         todoPanel.setOnProgressChanged(() -> {
             int total = todoPanel.getTotal();
             int done = todoPanel.getDone();
-            String title = total > 0 ? "Todos (" + done + "/" + total + ")" : "Todos";
+            String title = total > 0 ? "Todo (" + done + "/" + total + ")" : "Todo";
             tabsPanel.setTabTitle(TAB_TODOS, title);
         });
 
@@ -68,7 +67,7 @@ public final class SidePanel extends JPanel implements Disposable {
     }
 
     /**
-     * Switches to the Review tab. Safe to call from the EDT.
+     * Switches to the Diff tab. Safe to call from the EDT.
      */
     public void selectReviewTab() {
         tabsPanel.selectTab(TAB_REVIEW);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SidePanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SidePanel.java
@@ -20,7 +20,7 @@ import java.awt.*;
  *   <li><b>Files</b> — configuration/agent-definition files for this project.</li>
  *   <li><b>Todos</b> — rendered view of the active agent session's {@code plan.md},
  *       with a {@code (done/total)} badge in the tab title when checkbox-style todos exist.</li>
- *   <li><b>Prompts</b> — searchable list of user prompts in the current chat, click to scroll.</li>
+ *   <li><b>Prompts</b> — searchable list of user prompts across the current conversation history, click to scroll.</li>
  * </ol>
  * Tab order is deliberate: review is the most time-sensitive and sits first.
  */
@@ -41,7 +41,7 @@ public final class SidePanel extends JPanel implements Disposable {
         ProjectFilesPanel projectFilesPanel = new ProjectFilesPanel(project);
         TodoPanel todoPanel = new TodoPanel(project);
         Disposer.register(this, todoPanel);
-        PromptsPanel promptsPanel = new PromptsPanel(chatConsole);
+        PromptsPanel promptsPanel = new PromptsPanel(project, chatConsole);
         Disposer.register(this, promptsPanel);
 
         tabsPanel = PlatformApiCompat.createJBTabsPanel(project, this);

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/review/ReviewDiffCountAnimatorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/review/ReviewDiffCountAnimatorTest.java
@@ -1,0 +1,54 @@
+package com.github.catatafishen.agentbridge.ui.review;
+
+import com.github.catatafishen.agentbridge.psi.review.ApprovalState;
+import com.github.catatafishen.agentbridge.psi.review.ReviewItem;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReviewDiffCountAnimatorTest {
+
+    @Test
+    void retargetsDiffCountsOverTime() {
+        ReviewDiffCountAnimator animator = new ReviewDiffCountAnimator();
+        ReviewItem initial = new ReviewItem(
+            "/tmp/Foo.java",
+            "Foo.java",
+            ReviewItem.Status.MODIFIED,
+            null,
+            ApprovalState.PENDING,
+            1L,
+            0,
+            0
+        );
+        ReviewItem updated = new ReviewItem(
+            "/tmp/Foo.java",
+            "Foo.java",
+            ReviewItem.Status.MODIFIED,
+            null,
+            ApprovalState.PENDING,
+            2L,
+            10,
+            4
+        );
+
+        animator.sync(List.of(initial), 0L);
+        animator.sync(List.of(updated), 100L);
+
+        long midpoint = 100L + (ReviewDiffCountAnimator.ANIMATION_DURATION_MS / 2);
+        ReviewDiffCountAnimator.DiffCounts mid = animator.displayCounts(updated, midpoint);
+        assertTrue(mid.added() > 0 && mid.added() < 10);
+        assertTrue(mid.removed() > 0 && mid.removed() < 4);
+        assertTrue(animator.hasActiveAnimations(midpoint));
+
+        long finished = 100L + ReviewDiffCountAnimator.ANIMATION_DURATION_MS + 1L;
+        ReviewDiffCountAnimator.DiffCounts end = animator.displayCounts(updated, finished);
+        assertEquals(10, end.added());
+        assertEquals(4, end.removed());
+        assertFalse(animator.hasActiveAnimations(finished));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/side/PromptsPanelLogicTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/side/PromptsPanelLogicTest.java
@@ -161,13 +161,23 @@ final class PromptsPanelLogicTest {
         List<EntryData.Prompt> all = List.of(prompt("p1", "Hello World"), prompt("p2", "Goodbye"));
         List<EntryData.Prompt> result = C.filterPrompts(all, "WORLD");
         assertEquals(1, result.size());
-        assertEquals("p1", result.getFirst().getId());
+        assertEquals("p1", result.iterator().next().getId());
     }
 
     @Test
     void filterPrompts_whitespaceOnlyQueryReturnsAll() {
         List<EntryData.Prompt> all = List.of(prompt("p1", "Hello"));
         assertEquals(all, C.filterPrompts(all, "   "));
+    }
+
+    @Test
+    void filterPrompts_searchesOlderHistoryEntriesToo() {
+        EntryData.Prompt older = prompt("h1", "Needle from history");
+        EntryData.Prompt recent = prompt("l1", "Recent prompt");
+
+        List<EntryData.Prompt> matches = C.filterPrompts(List.of(older, recent), "needle");
+        assertEquals(1, matches.size());
+        assertEquals(older, matches.iterator().next());
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Changes

### Review panel — status icon column removed
The first (icon) column has been removed. The file name text is now colored by status to match IntelliJ's native VCS file coloring:
- 🟢 **Green** — added
- 🔵 **Blue** — modified
- ⚫ **Grey** — deleted

Approved rows remain muted grey. Saves one column of horizontal space.

### Files tab — no more gray background in dark theme
`FileNodeRenderer` now sets `setOpaque(false)` on non-selected tree cells so `DefaultTreeCellRenderer` no longer paints a mismatched background color in dark themes.