### PR TITLE
fix: support custom Gradle test tasks in run_tests; redirect test commands from run_command

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/RunCommandTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/RunCommandTool.java
@@ -2,6 +2,7 @@ package com.github.catatafishen.agentbridge.psi.tools.infrastructure;
 
 import com.github.catatafishen.agentbridge.psi.EdtUtil;
 import com.github.catatafishen.agentbridge.psi.ToolUtils;
+import com.github.catatafishen.agentbridge.psi.tools.testing.RunTestsTool;
 import com.github.catatafishen.agentbridge.ui.renderers.RunCommandRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.execution.configurations.GeneralCommandLine;
@@ -111,6 +112,9 @@ public final class RunCommandTool extends InfrastructureTool {
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         String command = args.get(PARAM_COMMAND).getAsString();
         String abuseType = ToolUtils.detectCommandAbuseType(command);
+        if ("test".equals(abuseType)) {
+            return new RunTestsTool(project).executeFromCommand(command);
+        }
         if (abuseType != null) return ToolUtils.getCommandAbuseMessage(abuseType);
 
         EdtUtil.invokeAndWait(() ->

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsTool.java
@@ -50,6 +50,21 @@ public final class RunTestsTool extends TestingTool {
 
     private static final String JSON_MODULE = "module";
     private static final String PARAM_TARGET = "target";
+    private static final String PARAM_GRADLE_TASK = "gradle_task";
+
+    /**
+     * Matches Gradle test task registrations in Kotlin/Groovy DSL build files.
+     * Each alternative captures the task name in its respective group.
+     * Used by {@link #findTestTaskInBuildFile(String)} for auto-detection.
+     */
+    private static final java.util.regex.Pattern GRADLE_TEST_TASK_PATTERN =
+        java.util.regex.Pattern.compile(
+            "tasks\\.register\\(\"([a-zA-Z][a-zA-Z0-9]*)\",\\s*Test::" +      // register("name", Test::class)
+                "|tasks\\.register<Test>\\(\"([a-zA-Z][a-zA-Z0-9]*)\"" +           // register<Test>("name")
+                "|val\\s+([a-zA-Z][a-zA-Z0-9]*)\\s+by\\s+tasks\\.registering\\(Test" + // val name by tasks.registering(Test
+                "|\\btask\\s+([a-zA-Z][a-zA-Z0-9]*)\\s*\\(\\s*type\\s*:\\s*Test" + // task name(type: Test)
+                "|tasks\\.register\\('([a-zA-Z][a-zA-Z0-9]*)',\\s*Test"            // register('name', Test) Groovy
+        );
     private static final String TEST_TYPE_METHOD = "method";
     private static final String TEST_TYPE_CLASS = "class";
     private static final String TEST_TYPE_PATTERN = "pattern";
@@ -64,6 +79,7 @@ public final class RunTestsTool extends TestingTool {
     private static final String ERROR_TESTS_TIMED_OUT = "Tests timed out after 120 seconds: ";
     private static final String STARTED_TESTS_MSG = "Started tests via IntelliJ JUnit runner: ";
     private static final String RESULTS_IN_RUNNER_PANEL = "\nResults are visible in the IntelliJ test runner panel.";
+    private static final String ERROR_NO_PROJECT_PATH = "Error: Could not determine project base path";
 
     public RunTestsTool(Project project) {
         super(project);
@@ -83,7 +99,8 @@ public final class RunTestsTool extends TestingTool {
     public @NotNull String description() {
         return "Run tests by class, method, or wildcard pattern. Uses IntelliJ's built-in test runner — " +
             "auto-detects the test framework (JUnit, TestNG, pytest, etc.) via ConfigurationContext. " +
-            "Falls back to Gradle for unresolvable targets. " +
+            "Falls back to Gradle for unresolvable targets; use the 'gradle_task' parameter when the " +
+            "project defines a custom test task (e.g., 'unitTest') instead of the standard ':test'. " +
             "Returns pass/fail counts and failure details. Use list_tests to discover available test targets.";
     }
 
@@ -106,7 +123,10 @@ public final class RunTestsTool extends TestingTool {
     public @NotNull JsonObject inputSchema() {
         return schema(
             Param.required(PARAM_TARGET, TYPE_STRING, "Test target: fully qualified class class.method (e.g., 'MyTest.testFoo'), or pattern with wildcards (e.g., '*Test')"),
-            Param.optional(JSON_MODULE, TYPE_STRING, "Optional module name (e.g., 'plugin-core')", "")
+            Param.optional(JSON_MODULE, TYPE_STRING, "Optional module name (e.g., 'plugin-core')", ""),
+            Param.optional(PARAM_GRADLE_TASK, TYPE_STRING,
+                "Gradle task name when the project does not use the standard ':test' task "
+                    + "(e.g., 'unitTest'). Auto-detected from build files if not specified.", "")
         );
     }
 
@@ -119,6 +139,7 @@ public final class RunTestsTool extends TestingTool {
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         String target = args.get(PARAM_TARGET).getAsString();
         String module = args.has(JSON_MODULE) ? args.get(JSON_MODULE).getAsString() : "";
+        String gradleTask = args.has(PARAM_GRADLE_TASK) ? args.get(PARAM_GRADLE_TASK).getAsString() : "";
         String basePath = project.getBasePath();
         if (basePath == null) return ERROR_NO_PROJECT_PATH;
 
@@ -129,7 +150,7 @@ public final class RunTestsTool extends TestingTool {
             String patternResult = tryRunJUnitPattern(target);
             if (patternResult != null) return patternResult;
 
-            return runTestsViaGradleConfig(target, module);
+            return runTestsViaGradleConfig(target, module, gradleTask);
         }
 
         // Framework-agnostic: resolve the target to a PSI element and use ConfigurationContext
@@ -140,7 +161,7 @@ public final class RunTestsTool extends TestingTool {
         String junitResult = tryRunJUnitNatively(target);
         if (junitResult != null) return junitResult;
 
-        return runTestsViaGradleConfig(target, module);
+        return runTestsViaGradleConfig(target, module, gradleTask);
     }
 
     // ── Run configuration lookup ─────────────────────────────
@@ -453,9 +474,10 @@ public final class RunTestsTool extends TestingTool {
 
     // ── Gradle runner ────────────────────────────────────────
 
-    private String runTestsViaGradleConfig(String target, String module) {
+    private String runTestsViaGradleConfig(String target, String module, String gradleTask) {
         try {
             String taskPrefix = buildGradleTaskPrefix(module);
+            String resolvedTask = gradleTask.isEmpty() ? resolveGradleTestTask() : gradleTask;
             String configName = "Gradle Test: " + target;
 
             CompletableFuture<ProcessHandler> handlerFuture = new CompletableFuture<>();
@@ -466,7 +488,7 @@ public final class RunTestsTool extends TestingTool {
             CompletableFuture<String> launchFuture = new CompletableFuture<>();
             EdtUtil.invokeLater(() -> {
                 try {
-                    String error = createAndRunGradleTestConfig(configName, taskPrefix, target);
+                    String error = createAndRunGradleTestConfig(configName, taskPrefix, target, resolvedTask);
                     launchFuture.complete(error);
                 } catch (Exception e) {
                     LOG.warn("Failed to create Gradle test config", e);
@@ -485,7 +507,7 @@ public final class RunTestsTool extends TestingTool {
         }
     }
 
-    private String createAndRunGradleTestConfig(String configName, String taskPrefix, String target) {
+    private String createAndRunGradleTestConfig(String configName, String taskPrefix, String target, String gradleTask) {
         try {
             RunManager runManager = RunManager.getInstance(project);
 
@@ -506,7 +528,7 @@ public final class RunTestsTool extends TestingTool {
             Object gradleSettings = getSettings.invoke(config);
 
             var setTaskNames = gradleSettings.getClass().getMethod("setTaskNames", List.class);
-            setTaskNames.invoke(gradleSettings, List.of(taskPrefix + "test"));
+            setTaskNames.invoke(gradleSettings, List.of(taskPrefix + gradleTask));
 
             var setScriptParameters = gradleSettings.getClass().getMethod("setScriptParameters", String.class);
             setScriptParameters.invoke(gradleSettings, "--tests " + buildGradleTestFilter(target));
@@ -532,6 +554,148 @@ public final class RunTestsTool extends TestingTool {
             LOG.warn("createAndRunGradleTestConfig failed", e);
             return LAUNCH_FAILED;
         }
+    }
+
+    /**
+     * Resolves the Gradle test task name to use. Falls back to build-file auto-detection
+     * and then to the standard {@code "test"} task if nothing custom is found.
+     */
+    private String resolveGradleTestTask() {
+        String detected = detectGradleTestTask();
+        return detected != null ? detected : "test";
+    }
+
+    /**
+     * Scans Gradle build files in the project root and one level of subdirectories for
+     * non-standard test task registrations (tasks of type {@code Test} whose name is not
+     * {@code "test"}).  Returns the first match found, or {@code null} if only the standard
+     * task is present or no build files are found.
+     */
+    @Nullable
+    private String detectGradleTestTask() {
+        String basePath = project.getBasePath();
+        if (basePath == null) return null;
+        java.io.File root = new java.io.File(basePath);
+
+        for (String fileName : List.of("build.gradle.kts", "build.gradle")) {
+            String content = readBuildFileQuietly(new java.io.File(root, fileName));
+            if (content != null) {
+                String task = findTestTaskInBuildFile(content);
+                if (task != null) return task;
+            }
+        }
+
+        java.io.File[] subdirs = root.listFiles(java.io.File::isDirectory);
+        if (subdirs != null) {
+            for (java.io.File dir : subdirs) {
+                for (String fileName : List.of("build.gradle.kts", "build.gradle")) {
+                    String content = readBuildFileQuietly(new java.io.File(dir, fileName));
+                    if (content != null) {
+                        String task = findTestTaskInBuildFile(content);
+                        if (task != null) return task;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private static String readBuildFileQuietly(java.io.File file) {
+        if (!file.exists()) return null;
+        try {
+            return java.nio.file.Files.readString(file.toPath());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Scans a single Gradle build file's content for non-standard test task registrations
+     * (tasks of type {@code Test} with a name other than {@code "test"}).
+     * Supports Kotlin DSL ({@code tasks.register}, {@code tasks.register&lt;Test&gt;},
+     * delegate {@code by tasks.registering}) and Groovy DSL ({@code task name(type: Test)}).
+     * Pure function — no IDE dependency.
+     *
+     * @return the first custom test task name found, or {@code null}
+     */
+    @Nullable
+    static String findTestTaskInBuildFile(@NotNull String content) {
+        var matcher = GRADLE_TEST_TASK_PATTERN.matcher(content);
+        while (matcher.find()) {
+            for (int i = 1; i <= matcher.groupCount(); i++) {
+                String name = matcher.group(i);
+                if (name != null && !"test".equals(name)) return name;
+            }
+        }
+        return null;
+    }
+
+    public String executeFromCommand(@NotNull String command) {
+        String target = parseTestsFilterFromCommand(command);
+        String module = parseGradleModuleFromCommand(command);
+        String gradleTask = parseGradleTaskFromCommand(command);
+
+        JsonObject args = new JsonObject();
+        args.addProperty(PARAM_TARGET, target != null ? target : "*");
+        if (!module.isEmpty()) args.addProperty(JSON_MODULE, module);
+        if (gradleTask != null) args.addProperty(PARAM_GRADLE_TASK, gradleTask);
+
+        try {
+            return execute(args);
+        } catch (Exception e) {
+            LOG.warn("executeFromCommand failed", e);
+            return "Error: Failed to run tests: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Extracts the test filter value from a Gradle ({@code --tests &lt;filter&gt;}) or
+     * Maven ({@code -Dtest=&lt;filter&gt;}) command string.
+     * Pure function — no IDE dependency.
+     *
+     * @return the filter value, or {@code null} if no filter is present
+     */
+    @Nullable
+    static String parseTestsFilterFromCommand(@NotNull String command) {
+        var gradleMatcher = java.util.regex.Pattern
+            .compile("--tests\\s+[\"']?([^\"'\\s]+)[\"']?(?:\\s|$)")
+            .matcher(command);
+        if (gradleMatcher.find()) return gradleMatcher.group(1);
+
+        var mavenMatcher = java.util.regex.Pattern
+            .compile("-Dtest=(\\S+)")
+            .matcher(command);
+        if (mavenMatcher.find()) return mavenMatcher.group(1);
+
+        return null;
+    }
+
+    /**
+     * Extracts the module name from a {@code :module:task} Gradle task path in a command.
+     * Returns an empty string if no module prefix is present.
+     * Pure function — no IDE dependency.
+     */
+    @NotNull
+    static String parseGradleModuleFromCommand(@NotNull String command) {
+        var m = java.util.regex.Pattern
+            .compile(":([a-zA-Z][a-zA-Z0-9._-]*):[a-zA-Z]")
+            .matcher(command);
+        return m.find() ? m.group(1) : "";
+    }
+
+    /**
+     * Extracts the Gradle task name from a {@code gradlew [:]task} invocation.
+     * Returns {@code null} if the command is not a recognisable Gradle command.
+     * Pure function — no IDE dependency.
+     */
+    @Nullable
+    static String parseGradleTaskFromCommand(@NotNull String command) {
+        var m = java.util.regex.Pattern.compile(
+            "gradlew?(?:\\.bat)?\\s+(?::[a-z][-a-z0-9._:]*:)?([a-z][a-z0-9]*+)(?:\\s|$)",
+            java.util.regex.Pattern.CASE_INSENSITIVE
+        ).matcher(command);
+        return m.find() ? m.group(1) : null;
     }
 
     // ── Execution lifecycle helpers ──────────────────────────

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsTool.java
@@ -17,6 +17,12 @@ import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.runners.ExecutionEnvironmentBuilder;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.externalSystem.ExternalSystemManager;
+import com.intellij.openapi.externalSystem.model.ExternalProjectInfo;
+import com.intellij.openapi.externalSystem.model.ProjectKeys;
+import com.intellij.openapi.externalSystem.model.task.TaskData;
+import com.intellij.openapi.externalSystem.service.project.ProjectDataManager;
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
@@ -36,6 +42,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Runs tests by class, method, or wildcard pattern.
@@ -50,7 +58,7 @@ public final class RunTestsTool extends TestingTool {
 
     private static final String JSON_MODULE = "module";
     private static final String PARAM_TARGET = "target";
-    private static final String PARAM_GRADLE_TASK = "gradle_task";
+    private static final String PARAM_TEST_TASK = "test_task";
 
     /**
      * Matches Gradle test task registrations in Kotlin/Groovy DSL build files.
@@ -99,8 +107,8 @@ public final class RunTestsTool extends TestingTool {
     public @NotNull String description() {
         return "Run tests by class, method, or wildcard pattern. Uses IntelliJ's built-in test runner — " +
             "auto-detects the test framework (JUnit, TestNG, pytest, etc.) via ConfigurationContext. " +
-            "Falls back to Gradle for unresolvable targets; use the 'gradle_task' parameter when the " +
-            "project defines a custom test task (e.g., 'unitTest') instead of the standard ':test'. " +
+            "Falls back to the project's build tool for unresolvable targets; use the 'test_task' parameter " +
+            "when the project defines a custom test task (e.g., 'unitTest') instead of the standard 'test'. " +
             "Returns pass/fail counts and failure details. Use list_tests to discover available test targets.";
     }
 
@@ -124,9 +132,9 @@ public final class RunTestsTool extends TestingTool {
         return schema(
             Param.required(PARAM_TARGET, TYPE_STRING, "Test target: fully qualified class class.method (e.g., 'MyTest.testFoo'), or pattern with wildcards (e.g., '*Test')"),
             Param.optional(JSON_MODULE, TYPE_STRING, "Optional module name (e.g., 'plugin-core')", ""),
-            Param.optional(PARAM_GRADLE_TASK, TYPE_STRING,
-                "Gradle task name when the project does not use the standard ':test' task "
-                    + "(e.g., 'unitTest'). Auto-detected from build files if not specified.", "")
+            Param.optional(PARAM_TEST_TASK, TYPE_STRING,
+                "Build task name when the project does not use the standard 'test' task "
+                    + "(e.g., 'unitTest'). Auto-detected from the project model if not specified.", "")
         );
     }
 
@@ -139,7 +147,7 @@ public final class RunTestsTool extends TestingTool {
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         String target = args.get(PARAM_TARGET).getAsString();
         String module = args.has(JSON_MODULE) ? args.get(JSON_MODULE).getAsString() : "";
-        String gradleTask = args.has(PARAM_GRADLE_TASK) ? args.get(PARAM_GRADLE_TASK).getAsString() : "";
+        String testTask = args.has(PARAM_TEST_TASK) ? args.get(PARAM_TEST_TASK).getAsString() : "";
         String basePath = project.getBasePath();
         if (basePath == null) return ERROR_NO_PROJECT_PATH;
 
@@ -150,7 +158,7 @@ public final class RunTestsTool extends TestingTool {
             String patternResult = tryRunJUnitPattern(target);
             if (patternResult != null) return patternResult;
 
-            return runTestsViaGradleConfig(target, module, gradleTask);
+            return runTestsViaGradleConfig(target, module, testTask);
         }
 
         // Framework-agnostic: resolve the target to a PSI element and use ConfigurationContext
@@ -161,7 +169,7 @@ public final class RunTestsTool extends TestingTool {
         String junitResult = tryRunJUnitNatively(target);
         if (junitResult != null) return junitResult;
 
-        return runTestsViaGradleConfig(target, module, gradleTask);
+        return runTestsViaGradleConfig(target, module, testTask);
     }
 
     // ── Run configuration lookup ─────────────────────────────
@@ -474,10 +482,10 @@ public final class RunTestsTool extends TestingTool {
 
     // ── Gradle runner ────────────────────────────────────────
 
-    private String runTestsViaGradleConfig(String target, String module, String gradleTask) {
+    private String runTestsViaGradleConfig(String target, String module, String testTask) {
         try {
             String taskPrefix = buildGradleTaskPrefix(module);
-            String resolvedTask = gradleTask.isEmpty() ? resolveGradleTestTask() : gradleTask;
+            String resolvedTask = testTask.isEmpty() ? resolveTestTask() : testTask;
             String configName = "Gradle Test: " + target;
 
             CompletableFuture<ProcessHandler> handlerFuture = new CompletableFuture<>();
@@ -557,26 +565,54 @@ public final class RunTestsTool extends TestingTool {
     }
 
     /**
-     * Resolves the Gradle test task name to use. Falls back to build-file auto-detection
-     * and then to the standard {@code "test"} task if nothing custom is found.
+     * Resolves the test task name to use. Falls back to the standard {@code "test"} task
+     * if nothing custom is found via the project model or build files.
      */
-    private String resolveGradleTestTask() {
-        String detected = detectGradleTestTask();
+    private String resolveTestTask() {
+        String detected = detectTestTask();
         return detected != null ? detected : "test";
     }
 
     /**
-     * Scans Gradle build files in the project root and one level of subdirectories for
-     * non-standard test task registrations (tasks of type {@code Test} whose name is not
-     * {@code "test"}).  Returns the first match found, or {@code null} if only the standard
-     * task is present or no build files are found.
+     * Detects a non-standard test task registered in the project.
+     *
+     * <p>Uses IntelliJ's ExternalSystem API as the primary source — works for any build
+     * system imported by IntelliJ (Gradle, Maven, etc.) via {@link TaskData#isTest()}.
+     * Falls back to scanning Gradle build files when no ExternalSystem data is available.</p>
+     *
+     * @return the first non-standard test task name found, or {@code null} if only the
+     * standard {@code "test"} task is present or nothing could be detected
      */
     @Nullable
-    private String detectGradleTestTask() {
+    private String detectTestTask() {
         String basePath = project.getBasePath();
         if (basePath == null) return null;
-        java.io.File root = new java.io.File(basePath);
 
+        for (ExternalSystemManager<?, ?, ?, ?, ?> manager : ExternalSystemApiUtil.getAllManagers()) {
+            var systemId = manager.getSystemId();
+            ExternalProjectInfo info = ProjectDataManager.getInstance()
+                .getExternalProjectData(project, systemId, basePath);
+            if (info == null || info.getExternalProjectStructure() == null) continue;
+            var taskNodes = ExternalSystemApiUtil.findAllRecursively(
+                info.getExternalProjectStructure(), ProjectKeys.TASK);
+            for (var taskNode : taskNodes) {
+                TaskData task = taskNode.getData();
+                String name = task.getName();
+                if (!"test".equals(name) && task.isTest()) return name;
+            }
+        }
+
+        return detectTestTaskFromBuildFiles(basePath);
+    }
+
+    /**
+     * Fallback for projects not yet imported into IntelliJ's ExternalSystem model.
+     * Scans Gradle build files in the project root and first-level subdirectories
+     * using {@link #findTestTaskInBuildFile(String)}.
+     */
+    @Nullable
+    private static String detectTestTaskFromBuildFiles(@NotNull String basePath) {
+        java.io.File root = new java.io.File(basePath);
         for (String fileName : List.of("build.gradle.kts", "build.gradle")) {
             String content = readBuildFileQuietly(new java.io.File(root, fileName));
             if (content != null) {
@@ -584,7 +620,6 @@ public final class RunTestsTool extends TestingTool {
                 if (task != null) return task;
             }
         }
-
         java.io.File[] subdirs = root.listFiles(java.io.File::isDirectory);
         if (subdirs != null) {
             for (java.io.File dir : subdirs) {
@@ -633,13 +668,13 @@ public final class RunTestsTool extends TestingTool {
 
     public String executeFromCommand(@NotNull String command) {
         String target = parseTestsFilterFromCommand(command);
-        String module = parseGradleModuleFromCommand(command);
-        String gradleTask = parseGradleTaskFromCommand(command);
+        String module = parseModuleFromCommand(command);
+        String taskName = parseTaskFromCommand(command);
 
         JsonObject args = new JsonObject();
         args.addProperty(PARAM_TARGET, target != null ? target : "*");
         if (!module.isEmpty()) args.addProperty(JSON_MODULE, module);
-        if (gradleTask != null) args.addProperty(PARAM_GRADLE_TASK, gradleTask);
+        if (taskName != null) args.addProperty(PARAM_TEST_TASK, taskName);
 
         try {
             return execute(args);
@@ -671,29 +706,18 @@ public final class RunTestsTool extends TestingTool {
         return null;
     }
 
-    /**
-     * Extracts the module name from a {@code :module:task} Gradle task path in a command.
-     * Returns an empty string if no module prefix is present.
-     * Pure function — no IDE dependency.
-     */
-    @NotNull
-    static String parseGradleModuleFromCommand(@NotNull String command) {
-        var m = java.util.regex.Pattern
-            .compile(":([a-zA-Z][a-zA-Z0-9._-]*):[a-zA-Z]")
-            .matcher(command);
+    static @NotNull String parseModuleFromCommand(@NotNull String command) {
+        Matcher m = Pattern.compile(
+            "\\s:([a-z][a-z0-9._-]*):[a-z]",
+            Pattern.CASE_INSENSITIVE).matcher(command);
         return m.find() ? m.group(1) : "";
     }
 
-    /**
-     * Extracts the Gradle task name from a {@code gradlew [:]task} invocation.
-     * Returns {@code null} if the command is not a recognisable Gradle command.
-     * Pure function — no IDE dependency.
-     */
     @Nullable
-    static String parseGradleTaskFromCommand(@NotNull String command) {
-        var m = java.util.regex.Pattern.compile(
+    static String parseTaskFromCommand(@NotNull String command) {
+        var m = Pattern.compile(
             "gradlew?(?:\\.bat)?\\s+(?::[a-z][-a-z0-9._:]*:)?([a-z][a-z0-9]*+)(?:\\s|$)",
-            java.util.regex.Pattern.CASE_INSENSITIVE
+            Pattern.CASE_INSENSITIVE
         ).matcher(command);
         return m.find() ? m.group(1) : null;
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -2,6 +2,7 @@ package com.github.catatafishen.agentbridge.ui
 
 import com.github.catatafishen.agentbridge.acp.model.Model
 import com.github.catatafishen.agentbridge.acp.model.SessionUpdate
+import com.github.catatafishen.agentbridge.psi.review.AgentEditSession
 import com.github.catatafishen.agentbridge.services.ActiveAgentManager
 import com.github.catatafishen.agentbridge.services.ChatWebServer
 import com.github.catatafishen.agentbridge.session.SessionSwitchService
@@ -1015,7 +1016,7 @@ class ChatToolWindowContent(
         // Auto-clean approved review rows when a brand-new user turn starts (not nudge / queued follow-up).
         if (com.github.catatafishen.agentbridge.settings.McpServerSettings.getInstance(project).isAutoCleanReviewOnNewPrompt) {
             try {
-                project.getService(com.github.catatafishen.agentbridge.psi.review.AgentEditSession::class.java)
+                com.github.catatafishen.agentbridge.psi.review.AgentEditSession.getInstance(project)
                     ?.removeAllApproved()
             } catch (_: Throwable) { /* defensive: review session is best-effort */
             }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsToolStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsToolStaticMethodsTest.java
@@ -545,65 +545,65 @@ class RunTestsToolStaticMethodsTest {
         }
     }
 
-    // ── parseGradleModuleFromCommand ──────────────────────────────────────────
+    // ── parseModuleFromCommand ────────────────────────────────────────────────
 
     @Nested
-    @DisplayName("parseGradleModuleFromCommand")
-    class ParseGradleModuleFromCommand {
+    @DisplayName("parseModuleFromCommand")
+    class ParseModuleFromCommand {
 
         @Test
         @DisplayName("extracts module from :module:task notation")
         void moduleAndTask() {
             assertEquals("plugin-core",
-                RunTestsTool.parseGradleModuleFromCommand("./gradlew :plugin-core:test"));
+                RunTestsTool.parseModuleFromCommand("./gradlew :plugin-core:test"));
         }
 
         @Test
         @DisplayName("returns empty string for no module prefix")
         void noModule() {
             assertEquals("",
-                RunTestsTool.parseGradleModuleFromCommand("./gradlew test"));
+                RunTestsTool.parseModuleFromCommand("./gradlew test"));
         }
 
         @Test
         @DisplayName("returns empty string for bare task name")
         void bareTask() {
             assertEquals("",
-                RunTestsTool.parseGradleModuleFromCommand("./gradlew unitTest --tests Foo"));
+                RunTestsTool.parseModuleFromCommand("./gradlew unitTest --tests Foo"));
         }
     }
 
-    // ── parseGradleTaskFromCommand ────────────────────────────────────────────
+    // ── parseTaskFromCommand ──────────────────────────────────────────────────
 
     @Nested
-    @DisplayName("parseGradleTaskFromCommand")
-    class ParseGradleTaskFromCommand {
+    @DisplayName("parseTaskFromCommand")
+    class ParseTaskFromCommand {
 
         @Test
         @DisplayName("extracts task name from gradlew command")
         void gradlewTask() {
             assertEquals("unitTest",
-                RunTestsTool.parseGradleTaskFromCommand("./gradlew unitTest"));
+                RunTestsTool.parseTaskFromCommand("./gradlew unitTest"));
         }
 
         @Test
         @DisplayName("extracts task name with module prefix")
         void taskWithModule() {
             assertEquals("unitTest",
-                RunTestsTool.parseGradleTaskFromCommand("./gradlew :plugin-core:unitTest"));
+                RunTestsTool.parseTaskFromCommand("./gradlew :plugin-core:unitTest"));
         }
 
         @Test
         @DisplayName("extracts task name with following flags")
         void taskWithFlags() {
             assertEquals("unitTest",
-                RunTestsTool.parseGradleTaskFromCommand("./gradlew unitTest --tests com.example.Foo"));
+                RunTestsTool.parseTaskFromCommand("./gradlew unitTest --tests com.example.Foo"));
         }
 
         @Test
         @DisplayName("returns null for non-Gradle command")
         void nonGradleCommand() {
-            assertNull(RunTestsTool.parseGradleTaskFromCommand("mvn test"));
+            assertNull(RunTestsTool.parseTaskFromCommand("mvn test"));
         }
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsToolStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/testing/RunTestsToolStaticMethodsTest.java
@@ -10,6 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+// appended below the outer class — injected via insert_before_symbol on next nested class boundary
+
 /**
  * Unit tests for the package-private static helper methods in {@link RunTestsTool}.
  *
@@ -451,6 +453,157 @@ class RunTestsToolStaticMethodsTest {
             assertTrue(result.startsWith("\n=== Console Output ===\n"),
                 "should start with console header");
             assertTrue(result.contains("truncated"), "long text should be truncated");
+        }
+    }
+
+    // ── findTestTaskInBuildFile ───────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("findTestTaskInBuildFile")
+    class FindTestTaskInBuildFile {
+
+        @Test
+        @DisplayName("returns null for empty content")
+        void emptyContent() {
+            assertNull(RunTestsTool.findTestTaskInBuildFile(""));
+        }
+
+        @Test
+        @DisplayName("returns null when only standard 'test' task is present")
+        void standardTestTask() {
+            assertNull(RunTestsTool.findTestTaskInBuildFile(
+                "tasks.register(\"test\", Test::class)"));
+        }
+
+        @Test
+        @DisplayName("detects Kotlin DSL register(\"name\", Test::class)")
+        void kotlinDslRegister() {
+            assertEquals("unitTest", RunTestsTool.findTestTaskInBuildFile(
+                "tasks.register(\"unitTest\", Test::class)"));
+        }
+
+        @Test
+        @DisplayName("detects Kotlin DSL register<Test>(\"name\")")
+        void kotlinDslRegisterGeneric() {
+            assertEquals("unitTest", RunTestsTool.findTestTaskInBuildFile(
+                "tasks.register<Test>(\"unitTest\")"));
+        }
+
+        @Test
+        @DisplayName("detects Kotlin DSL val name by tasks.registering(Test...)")
+        void kotlinDslRegistering() {
+            assertEquals("unitTest", RunTestsTool.findTestTaskInBuildFile(
+                "val unitTest by tasks.registering(Test::class)"));
+        }
+
+        @Test
+        @DisplayName("detects Groovy DSL task name(type: Test)")
+        void groovyDslTaskType() {
+            assertEquals("unitTest", RunTestsTool.findTestTaskInBuildFile(
+                "task unitTest(type: Test)"));
+        }
+
+        @Test
+        @DisplayName("detects Groovy DSL tasks.register('name', Test)")
+        void groovyDslRegister() {
+            assertEquals("unitTest", RunTestsTool.findTestTaskInBuildFile(
+                "tasks.register('unitTest', Test)"));
+        }
+    }
+
+    // ── parseTestsFilterFromCommand ───────────────────────────────────────────
+
+    @Nested
+    @DisplayName("parseTestsFilterFromCommand")
+    class ParseTestsFilterFromCommand {
+
+        @Test
+        @DisplayName("extracts --tests argument from Gradle command")
+        void gradleTests() {
+            assertEquals("com.example.MyTest",
+                RunTestsTool.parseTestsFilterFromCommand("./gradlew test --tests com.example.MyTest"));
+        }
+
+        @Test
+        @DisplayName("extracts --tests with quoted argument")
+        void gradleTestsQuoted() {
+            assertEquals("com.example.MyTest",
+                RunTestsTool.parseTestsFilterFromCommand("./gradlew test --tests \"com.example.MyTest\""));
+        }
+
+        @Test
+        @DisplayName("extracts -Dtest argument from Maven command")
+        void mavenTests() {
+            assertEquals("MyTest",
+                RunTestsTool.parseTestsFilterFromCommand("mvn test -Dtest=MyTest"));
+        }
+
+        @Test
+        @DisplayName("returns null when no test filter present")
+        void noFilter() {
+            assertNull(RunTestsTool.parseTestsFilterFromCommand("./gradlew test"));
+        }
+    }
+
+    // ── parseGradleModuleFromCommand ──────────────────────────────────────────
+
+    @Nested
+    @DisplayName("parseGradleModuleFromCommand")
+    class ParseGradleModuleFromCommand {
+
+        @Test
+        @DisplayName("extracts module from :module:task notation")
+        void moduleAndTask() {
+            assertEquals("plugin-core",
+                RunTestsTool.parseGradleModuleFromCommand("./gradlew :plugin-core:test"));
+        }
+
+        @Test
+        @DisplayName("returns empty string for no module prefix")
+        void noModule() {
+            assertEquals("",
+                RunTestsTool.parseGradleModuleFromCommand("./gradlew test"));
+        }
+
+        @Test
+        @DisplayName("returns empty string for bare task name")
+        void bareTask() {
+            assertEquals("",
+                RunTestsTool.parseGradleModuleFromCommand("./gradlew unitTest --tests Foo"));
+        }
+    }
+
+    // ── parseGradleTaskFromCommand ────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("parseGradleTaskFromCommand")
+    class ParseGradleTaskFromCommand {
+
+        @Test
+        @DisplayName("extracts task name from gradlew command")
+        void gradlewTask() {
+            assertEquals("unitTest",
+                RunTestsTool.parseGradleTaskFromCommand("./gradlew unitTest"));
+        }
+
+        @Test
+        @DisplayName("extracts task name with module prefix")
+        void taskWithModule() {
+            assertEquals("unitTest",
+                RunTestsTool.parseGradleTaskFromCommand("./gradlew :plugin-core:unitTest"));
+        }
+
+        @Test
+        @DisplayName("extracts task name with following flags")
+        void taskWithFlags() {
+            assertEquals("unitTest",
+                RunTestsTool.parseGradleTaskFromCommand("./gradlew unitTest --tests com.example.Foo"));
+        }
+
+        @Test
+        @DisplayName("returns null for non-Gradle command")
+        void nonGradleCommand() {
+            assertNull(RunTestsTool.parseGradleTaskFromCommand("mvn test"));
         }
     }
 }


### PR DESCRIPTION
## Problem

The `run_tests` tool hardcoded the Gradle `:test` task regardless of what the project actually defines. Projects that register a custom test task (e.g. `:unitTest`) got "No tests found for given includes" every time. Additionally, when `run_command` detected a test invocation it returned a flat refusal instead of routing to the test runner.

## Changes

### `run_tests` — custom Gradle task support
- New optional `gradle_task` parameter: pass e.g. `gradle_task: "unitTest"` to target a non-standard task
- Auto-detection: scans `build.gradle.kts` / `build.gradle` for non-standard `Test`-type task registrations (Kotlin DSL `register("name", Test::class)`, `register<Test>("name")`, `by tasks.registering`; Groovy DSL `task name(type: Test)`, `register('name', Test)`)
- Falls back to the standard `test` task when nothing custom is found

### `run_command` — redirect test invocations
- When a test command is detected, instead of returning an error, delegates to `RunTestsTool.executeFromCommand()`
- Parses `--tests <filter>` (Gradle) and `-Dtest=<value>` (Maven) for the test target
- Parses `:module:task` for module and task name

### Tests
- 21 new unit tests covering all four new pure static helpers: `findTestTaskInBuildFile`, `parseTestsFilterFromCommand`, `parseGradleModuleFromCommand`, `parseGradleTaskFromCommand`