### PR TITLE
fix: add offset parameter to read_build_output and read_run_output

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/InfrastructureTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/InfrastructureTool.java
@@ -225,19 +225,41 @@ public abstract class InfrastructureTool extends Tool {
         return null;
     }
 
-    protected String formatRunOutput(String displayName, String text, int maxChars) {
+    /**
+     * Formats build/run output for the MCP response.
+     *
+     * @param offset character offset to start reading from ({@code -1} = show last {@code maxChars} chars).
+     *               Pass {@code 0} or a positive value to read from the beginning or a specific position.
+     */
+    protected String formatRunOutput(String displayName, String text, int maxChars, int offset) {
         StringBuilder result = new StringBuilder();
         result.append("Tab: ").append(displayName).append("\n");
         result.append("Total length: ").append(text.length()).append(" chars\n\n");
 
-        if (text.length() > maxChars) {
-            result.append("...(truncated, showing last ").append(maxChars).append(" of ").append(text.length())
-                .append(" chars. Use max_chars parameter to read more.)\n");
-            result.append(text.substring(text.length() - maxChars));
+        if (offset < 0) {
+            // Default: show the tail (most recent output)
+            if (text.length() > maxChars) {
+                result.append("...(truncated, showing last ").append(maxChars)
+                    .append(" of ").append(text.length())
+                    .append(" chars. Use offset=0 to read from beginning.)\n");
+                result.append(text, text.length() - maxChars, text.length());
+            } else {
+                result.append(text);
+            }
         } else {
-            result.append(text);
+            // Paginated read from a specific position
+            int start = Math.min(offset, text.length());
+            int end = Math.min(start + maxChars, text.length());
+            if (start > 0) {
+                result.append("...(showing chars ").append(start).append("-").append(end)
+                    .append(" of ").append(text.length()).append(")\n");
+            }
+            result.append(text, start, end);
+            if (end < text.length()) {
+                result.append("\n...(").append(text.length() - end)
+                    .append(" more chars. Use offset=").append(end).append(" to continue.)");
+            }
         }
-
         return result.toString();
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/ReadBuildOutputTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/ReadBuildOutputTool.java
@@ -17,6 +17,7 @@ public final class ReadBuildOutputTool extends InfrastructureTool {
 
     private static final Logger LOG = Logger.getInstance(ReadBuildOutputTool.class);
     private static final String PARAM_MAX_CHARS = "max_chars";
+    private static final String PARAM_OFFSET = "offset";
     private static final String JSON_TAB_NAME = "tab_name";
 
     public ReadBuildOutputTool(Project project) {
@@ -52,18 +53,20 @@ public final class ReadBuildOutputTool extends InfrastructureTool {
     public @NotNull JsonObject inputSchema() {
         return schema(
             Param.optional(JSON_TAB_NAME, TYPE_STRING, "Name of the Build tab to read (default: currently selected or most recent). Use tab names shown in IntelliJ's Build tool window."),
-            Param.optional(PARAM_MAX_CHARS, TYPE_INTEGER, "Maximum characters to return (default: 8000)")
+            Param.optional(PARAM_MAX_CHARS, TYPE_INTEGER, "Maximum characters to return (default: 8000)"),
+            Param.optional(PARAM_OFFSET, TYPE_INTEGER, "Character offset to start from (default: -1 = show last max_chars chars). Use 0 to read from the beginning, or a previous end offset to paginate forward.")
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) {
         int maxChars = args.has(PARAM_MAX_CHARS) ? args.get(PARAM_MAX_CHARS).getAsInt() : 8000;
+        int offset = args.has(PARAM_OFFSET) ? args.get(PARAM_OFFSET).getAsInt() : -1;
         String tabName = args.has(JSON_TAB_NAME) ? args.get(JSON_TAB_NAME).getAsString() : null;
 
         try {
             var textRef = new AtomicReference<String>();
-            EdtUtil.invokeAndWait(() -> textRef.set(readBuildOutputOnEdt(tabName, maxChars)));
+            EdtUtil.invokeAndWait(() -> textRef.set(readBuildOutputOnEdt(tabName, maxChars, offset)));
             return textRef.get();
         } catch (Exception e) {
             LOG.warn("Failed to read Build output", e);
@@ -76,7 +79,7 @@ public final class ReadBuildOutputTool extends InfrastructureTool {
         return TerminalOutputRenderer.INSTANCE;
     }
 
-    private String readBuildOutputOnEdt(String tabName, int maxChars) {
+    private String readBuildOutputOnEdt(String tabName, int maxChars, int offset) {
         var toolWindow = com.intellij.openapi.wm.ToolWindowManager.getInstance(project)
             .getToolWindow("Build");
         if (toolWindow == null) {
@@ -96,7 +99,7 @@ public final class ReadBuildOutputTool extends InfrastructureTool {
         if (text == null || text.isBlank()) {
             return buildEmptyContentMessage(displayName, contents, target);
         }
-        return formatRunOutput(displayName, text, maxChars);
+        return formatRunOutput(displayName, text, maxChars, offset);
     }
 
     @Nullable

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/ReadRunOutputTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/ReadRunOutputTool.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public final class ReadRunOutputTool extends InfrastructureTool {
 
     private static final String PARAM_MAX_CHARS = "max_chars";
+    private static final String PARAM_OFFSET = "offset";
     private static final String JSON_TAB_NAME = "tab_name";
 
     public ReadRunOutputTool(Project project) {
@@ -53,13 +54,15 @@ public final class ReadRunOutputTool extends InfrastructureTool {
     public @NotNull JsonObject inputSchema() {
         return schema(
             Param.optional(JSON_TAB_NAME, TYPE_STRING, "Name of the Run tab to read (default: most recent)"),
-            Param.optional(PARAM_MAX_CHARS, TYPE_INTEGER, "Maximum characters to return (default: 8000)")
+            Param.optional(PARAM_MAX_CHARS, TYPE_INTEGER, "Maximum characters to return (default: 8000)"),
+            Param.optional(PARAM_OFFSET, TYPE_INTEGER, "Character offset to start from (default: -1 = show last max_chars chars). Use 0 to read from the beginning, or a previous end offset to paginate forward.")
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) {
         int maxChars = args.has(PARAM_MAX_CHARS) ? args.get(PARAM_MAX_CHARS).getAsInt() : 8000;
+        int offset = args.has(PARAM_OFFSET) ? args.get(PARAM_OFFSET).getAsInt() : -1;
         String tabName = args.has(JSON_TAB_NAME) ? args.get(JSON_TAB_NAME).getAsString() : null;
 
         try {
@@ -89,7 +92,7 @@ public final class ReadRunOutputTool extends InfrastructureTool {
                     + "' has no text content (console type: " + consoleClass
                     + "). The run may still be in progress or the console type is unsupported.";
             }
-            return formatRunOutput(target.getDisplayName(), text, maxChars);
+            return formatRunOutput(target.getDisplayName(), text, maxChars, offset);
         } catch (Exception e) {
             return "Error reading Run output: " + e.getMessage();
         }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/InfrastructureToolFormatTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/InfrastructureToolFormatTest.java
@@ -5,10 +5,12 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests for {@link InfrastructureTool#formatRunOutput(String, String, int)}.
+ * Tests for {@link InfrastructureTool#formatRunOutput(String, String, int, int)}.
  * <p>
  * Uses a minimal concrete subclass to invoke the protected method directly.
  * The method uses no instance state, so passing {@code null} as the project is safe.
@@ -92,6 +94,51 @@ class InfrastructureToolFormatTest {
         assertFalse(result.contains("truncated"), "Should not contain truncation notice");
     }
 
+    @Test
+    void truncationHintMentionsOffset() {
+        String text = "a".repeat(200);
+        String result = tool.callFormatRunOutput("Tab", text, 50);
+
+        assertTrue(result.contains("offset=0"),
+            "Truncation notice should suggest using offset=0 to read from beginning");
+    }
+
+    @Test
+    void offsetZero_readsFromBeginning() {
+        String text = "abcdefghijklmnopqrstuvwxyz"; // 26 chars
+        String result = tool.callFormatRunOutput("Tab", text, 10, 0);
+
+        assertTrue(result.contains("abcdefghij"), "Should start from the beginning");
+        assertFalse(result.contains("qrstuvwxyz"), "Should not contain the tail");
+    }
+
+    @Test
+    void offsetMid_readsFromPosition() {
+        String text = "abcdefghijklmnopqrstuvwxyz"; // 26 chars
+        String result = tool.callFormatRunOutput("Tab", text, 10, 5);
+
+        assertTrue(result.contains("fghijklmno"), "Should start from offset 5");
+        assertFalse(result.contains("abcde"), "Should not contain text before offset");
+    }
+
+    @Test
+    void offsetPaginationHintShowsNextOffset() {
+        String text = "a".repeat(100);
+        String result = tool.callFormatRunOutput("Tab", text, 30, 0);
+
+        assertTrue(result.contains("offset=30"),
+            "Should hint the next offset to continue reading");
+    }
+
+    @Test
+    void offsetBeyondEnd_returnsEmptyChunk() {
+        String text = "short"; // 5 chars
+        String result = tool.callFormatRunOutput("Tab", text, 10, 100);
+
+        assertFalse(result.contains("truncated"), "Should not show truncation for empty chunk");
+        assertFalse(result.contains("offset="), "Should not show next-offset hint when at end");
+    }
+
     // ── Concrete test subclass ──────────────────────────────
 
     /**
@@ -105,7 +152,11 @@ class InfrastructureToolFormatTest {
         }
 
         String callFormatRunOutput(String displayName, String text, int maxChars) {
-            return formatRunOutput(displayName, text, maxChars);
+            return formatRunOutput(displayName, text, maxChars, -1);
+        }
+
+        String callFormatRunOutput(String displayName, String text, int maxChars, int offset) {
+            return formatRunOutput(displayName, text, maxChars, offset);
         }
 
         @Override


### PR DESCRIPTION
## Problem

Both `read_build_output` and `read_run_output` always showed the **last** `max_chars` characters with no way to read from the beginning or paginate. The truncation message also misleadingly said "Use `max_chars` parameter to read more" when `max_chars` only changes how many chars are shown from the tail.

Agents that tried to use `offset` parameter got the same tail content regardless, because the parameter didn't exist.

## Fix

- **`formatRunOutput` gains an `offset` parameter** (int, -1 = show-tail mode):
  - `offset < 0` (default): show last `max_chars` chars — most useful for monitoring builds in progress. Truncation hint now says "Use offset=0 to read from beginning"
  - `offset >= 0`: paginated read from that character position; appends "Use offset=N to continue" when more content follows
- **`read_build_output`** and **`read_run_output`** now expose an optional `offset` parameter in their input schemas
- **5 new unit tests** in `InfrastructureToolFormatTest` covering offset behavior