### PR TITLE
fix: approval gate bugs — auto-approve on restore, scoped commit gate, clear error message

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
@@ -821,10 +821,93 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
         }
     }
 
+    /**
+     * Like {@link #awaitReviewCompletion} but scoped to a specific set of file paths.
+     * Only PENDING files whose absolute path is in {@code scopedPaths} will block.
+     * Files tracked by the review session but not in {@code scopedPaths} are ignored.
+     * <p>
+     * Use this for operations that only affect specific files (e.g. git commit),
+     * as opposed to worktree-wide operations (branch switch, reset) which should
+     * use the unscoped {@link #awaitReviewCompletion}.
+     *
+     * @param operation   human-readable name for error messages
+     * @param scopedPaths absolute paths of files to check
+     * @return error string if blocked or timed out, {@code null} if clear
+     */
+    public @Nullable String awaitReviewForPaths(
+        @NotNull String operation,
+        @NotNull Collection<String> scopedPaths) {
+        if (!hasPendingIn(scopedPaths)) return null;
+
+        int fileCount = countPendingIn(scopedPaths);
+
+        if (!reviewNotificationFired) {
+            reviewNotificationFired = true;
+            notifyReviewRequired(operation);
+        }
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (project.isDisposed()) return;
+            com.github.catatafishen.agentbridge.ui.review.ReviewPanelController
+                .getInstance(project).expandReviewPanel();
+        });
+
+        PsiBridgeService psi = PsiBridgeService.getInstance(project);
+        java.util.concurrent.Semaphore writeSemaphore = psi.getWriteToolSemaphore();
+        java.util.concurrent.locks.ReentrantLock syncLock = psi.getCurrentSyncLock();
+
+        if (syncLock != null) syncLock.unlock();
+        writeSemaphore.release();
+        try {
+            while (hasPendingIn(scopedPaths) && pendingGateCancelMessage == null) {
+                java.util.concurrent.CompletableFuture<Void> future = getOrCreateReviewCompletionFuture();
+                if (!hasPendingIn(scopedPaths) || pendingGateCancelMessage != null) break;
+                future.get(REVIEW_WAIT_TIMEOUT_MINUTES, java.util.concurrent.TimeUnit.MINUTES);
+            }
+            String cancelMessage = pendingGateCancelMessage;
+            if (cancelMessage != null) {
+                pendingGateCancelMessage = null;
+                return "Error: " + operation + " cancelled by user revert.\n" + cancelMessage;
+            }
+            flushBufferedRevertsToPendingNudge();
+            return null;
+        } catch (java.util.concurrent.TimeoutException e) {
+            return formatReviewTimeoutError(operation, fileCount);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "Error: Interrupted while waiting for agent-edit review.";
+        } catch (java.util.concurrent.ExecutionException e) {
+            return "Error: Review wait failed: " + e.getCause();
+        } finally {
+            writeSemaphore.acquireUninterruptibly();
+            if (syncLock != null) syncLock.lock();
+        }
+    }
+
     private int countPending() {
         int n = 0;
         for (Map.Entry<String, ApprovalState> e : approvals.entrySet()) {
             if (e.getValue() == ApprovalState.PENDING && pathIsTracked(e.getKey())) n++;
+        }
+        return n;
+    }
+
+    private boolean hasPendingIn(@NotNull Collection<String> scopedPaths) {
+        Set<String> scope = scopedPaths instanceof Set ? (Set<String>) scopedPaths : new HashSet<>(scopedPaths);
+        for (Map.Entry<String, ApprovalState> e : approvals.entrySet()) {
+            if (e.getValue() == ApprovalState.PENDING && pathIsTracked(e.getKey()) && scope.contains(e.getKey())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private int countPendingIn(@NotNull Collection<String> scopedPaths) {
+        Set<String> scope = scopedPaths instanceof Set ? (Set<String>) scopedPaths : new HashSet<>(scopedPaths);
+        int n = 0;
+        for (Map.Entry<String, ApprovalState> e : approvals.entrySet()) {
+            if (e.getValue() == ApprovalState.PENDING && pathIsTracked(e.getKey()) && scope.contains(e.getKey())) {
+                n++;
+            }
         }
         return n;
     }
@@ -862,11 +945,10 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
     }
 
     static @NotNull String formatReviewTimeoutError(@NotNull String operation, int fileCount) {
-        return "Error: Timed out after " + REVIEW_WAIT_TIMEOUT_MINUTES
-            + " minutes waiting for the user to review " + fileCount
-            + (fileCount == 1 ? " agent-edited file" : " agent-edited files")
-            + " before '" + operation
-            + "' could run. Ask the user to accept or revert the pending edits in the"
+        return "Error: " + fileCount + (fileCount == 1 ? " file has" : " files have")
+            + " not been approved or rejected by the user. '"
+            + operation + "' cannot proceed until all pending agent edits are reviewed."
+            + " The user must accept or revert the pending edits in the"
             + " Review panel (left of chat), then retry.";
     }
 
@@ -1234,6 +1316,16 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
                     linesRemoved.put(e.getKey(), Integer.parseInt(e.getValue()));
                 } catch (NumberFormatException ignored) {
                     // skip malformed entries
+                }
+            }
+        }
+
+        // If auto-approve was turned on while PENDING entries existed (or between
+        // IDE restarts), upgrade them now so they don't block future git operations.
+        if (isAutoApproveOn()) {
+            for (Map.Entry<String, ApprovalState> e : approvals.entrySet()) {
+                if (e.getValue() == ApprovalState.PENDING) {
+                    e.setValue(ApprovalState.APPROVED);
                 }
             }
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
@@ -8,9 +8,12 @@ import com.github.catatafishen.agentbridge.ui.renderers.GitCommitRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Commits staged changes with a message.
@@ -73,11 +76,14 @@ public final class GitCommitTool extends GitTool {
             return "Error: 'message' parameter is required";
         }
 
-        String reviewError = AgentEditSession.getInstance(project)
-            .awaitReviewCompletion("git commit");
-        if (reviewError != null) return reviewError;
-
         boolean commitAll = resolveCommitAll(args);
+
+        // Compute which files will be committed, then only gate on those paths.
+        // This prevents unrelated PENDING review items from blocking the commit.
+        Collection<String> filesToCommit = resolveFilesToCommit(commitAll);
+        String reviewError = AgentEditSession.getInstance(project)
+            .awaitReviewForPaths("git commit", filesToCommit);
+        if (reviewError != null) return reviewError;
 
         if (commitAll) {
             // Stage all changes including new untracked files (equivalent to git add -A)
@@ -169,6 +175,46 @@ public final class GitCommitTool extends GitTool {
      */
     static boolean resolveAmend(JsonObject args) {
         return args.has(PARAM_AMEND) && args.get(PARAM_AMEND).getAsBoolean();
+    }
+
+    /**
+     * Determines which files will be part of the commit, resolved to absolute paths.
+     * For {@code commitAll=true}: all modified, deleted, and untracked files from
+     * {@code git status --porcelain}. For staged-only: files from
+     * {@code git diff --cached --name-only}.
+     */
+    private Collection<String> resolveFilesToCommit(boolean commitAll) {
+        String basePath = project.getBasePath();
+        Set<String> paths = new java.util.HashSet<>();
+        if (commitAll) {
+            String status = runGitQuiet("status", "--porcelain");
+            if (status != null) {
+                for (String line : status.split("\\r?\\n")) {
+                    if (line.length() < 4) continue;
+                    // porcelain format: XY <path> or XY <orig> -> <path>
+                    String filePart = line.substring(3);
+                    int arrow = filePart.indexOf(" -> ");
+                    String relPath = arrow >= 0 ? filePart.substring(arrow + 4) : filePart;
+                    paths.add(toAbsolutePath(relPath.trim(), basePath));
+                }
+            }
+        } else {
+            String staged = runGitQuiet("diff", "--cached", "--name-only");
+            if (staged != null) {
+                for (String line : staged.split("\\r?\\n")) {
+                    String trimmed = line.trim();
+                    if (!trimmed.isEmpty()) {
+                        paths.add(toAbsolutePath(trimmed, basePath));
+                    }
+                }
+            }
+        }
+        return paths;
+    }
+
+    private static @NotNull String toAbsolutePath(@NotNull String path, @Nullable String basePath) {
+        if (basePath == null || path.startsWith("/")) return path;
+        return basePath + "/" + path;
     }
 
     /**

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/ReviewPendingMessageTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/ReviewPendingMessageTest.java
@@ -6,22 +6,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Verifies the timeout error wording returned by {@link AgentEditSession#awaitReviewCompletion}
+ * Verifies the error wording returned by {@link AgentEditSession#awaitReviewCompletion}
  * when a git tool's blocking wait expires. The message must make clear that the block is
- * caused by unresolved review — not a generic timeout — so the agent surfaces actionable
- * guidance to the user instead of retrying blindly.
+ * caused by files that have not been approved or rejected — not a generic timeout — so
+ * the agent surfaces actionable guidance to the user instead of retrying blindly.
  */
 class ReviewPendingMessageTest {
 
     @Test
-    void mentionsTimeoutAndOperation() {
+    void mentionsFileCountAndOperation() {
         String msg = AgentEditSession.formatReviewTimeoutError("git commit", 3);
-        assertTrue(msg.startsWith("Error: Timed out"),
-            "Message must be flagged as an Error and mention the timeout: " + msg);
+        assertTrue(msg.startsWith("Error:"),
+            "Message must be flagged as an Error: " + msg);
         assertTrue(msg.contains("'git commit'"),
             "Message must name the blocked operation: " + msg);
-        assertTrue(msg.contains("3 agent-edited files"),
+        assertTrue(msg.contains("3 files"),
             "Message must report the file count (plural): " + msg);
+        assertTrue(msg.contains("not been approved or rejected"),
+            "Message must clarify the pending state: " + msg);
         assertTrue(msg.contains("Review panel"),
             "Message must direct the user to the Review panel: " + msg);
     }
@@ -29,9 +31,9 @@ class ReviewPendingMessageTest {
     @Test
     void singularPhrasingForOneFile() {
         String msg = AgentEditSession.formatReviewTimeoutError("git merge 'main'", 1);
-        assertTrue(msg.contains("1 agent-edited file"),
+        assertTrue(msg.contains("1 file has"),
             "Singular form expected: " + msg);
-        assertTrue(!msg.contains("1 agent-edited files"),
+        assertTrue(!msg.contains("1 files"),
             "Plural form must not appear for a single file: " + msg);
     }
 
@@ -47,5 +49,12 @@ class ReviewPendingMessageTest {
         String a = AgentEditSession.formatReviewTimeoutError("git commit", 5);
         String b = AgentEditSession.formatReviewTimeoutError("git commit", 5);
         assertEquals(a, b, "Formatter must be deterministic for the same inputs");
+    }
+
+    @Test
+    void cannotProceedMeaning() {
+        String msg = AgentEditSession.formatReviewTimeoutError("git commit", 2);
+        assertTrue(msg.contains("cannot proceed"),
+            "Message must say the operation cannot proceed: " + msg);
     }
 }


### PR DESCRIPTION
## Problem

Three bugs in the review approval gate:

1. **Auto-approve not respected after IDE restart** — `loadState()` restores persisted PENDING entries but never checks if auto-approve was turned on. `onAutoApproveTurnedOn()` only fires from the UI toggle.

2. **Unrelated PENDING files blocking git commit** — `awaitReviewCompletion()` gates on ALL tracked files, not just the ones being committed. Files like `ProjectFilesPanel.java` and `SidePanel.java` that aren't part of the commit shouldn't block it.

3. **Unclear error message** — "Timed out waiting for review" doesn't tell the user what to do. The message should say files are pending approval/rejection.

## Fix

1. `loadState()` now checks `isAutoApproveOn()` after restoring state and upgrades PENDING → APPROVED.

2. `GitCommitTool` computes files-to-commit via `git status --porcelain` (commit-all) or `git diff --cached --name-only` (staged-only), then calls new `awaitReviewForPaths()` that only gates on those specific files. Other tools (branch switch, reset --hard) still use the full gate.

3. `formatReviewTimeoutError()` now says "N file(s) have not been approved or rejected by the user" with guidance to use the Review panel.

## Testing

- Updated `ReviewPendingMessageTest` (5 tests) for new message wording
- All tests pass