### PR TITLE
feat: redesign Session tab with labeled stat rows and thin usage graph

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
@@ -821,10 +821,93 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
         }
     }
 
+    /**
+     * Like {@link #awaitReviewCompletion} but scoped to a specific set of file paths.
+     * Only PENDING files whose absolute path is in {@code scopedPaths} will block.
+     * Files tracked by the review session but not in {@code scopedPaths} are ignored.
+     * <p>
+     * Use this for operations that only affect specific files (e.g. git commit),
+     * as opposed to worktree-wide operations (branch switch, reset) which should
+     * use the unscoped {@link #awaitReviewCompletion}.
+     *
+     * @param operation   human-readable name for error messages
+     * @param scopedPaths absolute paths of files to check
+     * @return error string if blocked or timed out, {@code null} if clear
+     */
+    public @Nullable String awaitReviewForPaths(
+        @NotNull String operation,
+        @NotNull Collection<String> scopedPaths) {
+        if (!hasPendingIn(scopedPaths)) return null;
+
+        int fileCount = countPendingIn(scopedPaths);
+
+        if (!reviewNotificationFired) {
+            reviewNotificationFired = true;
+            notifyReviewRequired(operation);
+        }
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (project.isDisposed()) return;
+            com.github.catatafishen.agentbridge.ui.review.ReviewPanelController
+                .getInstance(project).expandReviewPanel();
+        });
+
+        PsiBridgeService psi = PsiBridgeService.getInstance(project);
+        java.util.concurrent.Semaphore writeSemaphore = psi.getWriteToolSemaphore();
+        java.util.concurrent.locks.ReentrantLock syncLock = psi.getCurrentSyncLock();
+
+        if (syncLock != null) syncLock.unlock();
+        writeSemaphore.release();
+        try {
+            while (hasPendingIn(scopedPaths) && pendingGateCancelMessage == null) {
+                java.util.concurrent.CompletableFuture<Void> future = getOrCreateReviewCompletionFuture();
+                if (!hasPendingIn(scopedPaths) || pendingGateCancelMessage != null) break;
+                future.get(REVIEW_WAIT_TIMEOUT_MINUTES, java.util.concurrent.TimeUnit.MINUTES);
+            }
+            String cancelMessage = pendingGateCancelMessage;
+            if (cancelMessage != null) {
+                pendingGateCancelMessage = null;
+                return "Error: " + operation + " cancelled by user revert.\n" + cancelMessage;
+            }
+            flushBufferedRevertsToPendingNudge();
+            return null;
+        } catch (java.util.concurrent.TimeoutException e) {
+            return formatReviewTimeoutError(operation, fileCount);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "Error: Interrupted while waiting for agent-edit review.";
+        } catch (java.util.concurrent.ExecutionException e) {
+            return "Error: Review wait failed: " + e.getCause();
+        } finally {
+            writeSemaphore.acquireUninterruptibly();
+            if (syncLock != null) syncLock.lock();
+        }
+    }
+
     private int countPending() {
         int n = 0;
         for (Map.Entry<String, ApprovalState> e : approvals.entrySet()) {
             if (e.getValue() == ApprovalState.PENDING && pathIsTracked(e.getKey())) n++;
+        }
+        return n;
+    }
+
+    private boolean hasPendingIn(@NotNull Collection<String> scopedPaths) {
+        Set<String> scope = scopedPaths instanceof Set ? (Set<String>) scopedPaths : new HashSet<>(scopedPaths);
+        for (Map.Entry<String, ApprovalState> e : approvals.entrySet()) {
+            if (e.getValue() == ApprovalState.PENDING && pathIsTracked(e.getKey()) && scope.contains(e.getKey())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private int countPendingIn(@NotNull Collection<String> scopedPaths) {
+        Set<String> scope = scopedPaths instanceof Set ? (Set<String>) scopedPaths : new HashSet<>(scopedPaths);
+        int n = 0;
+        for (Map.Entry<String, ApprovalState> e : approvals.entrySet()) {
+            if (e.getValue() == ApprovalState.PENDING && pathIsTracked(e.getKey()) && scope.contains(e.getKey())) {
+                n++;
+            }
         }
         return n;
     }
@@ -862,11 +945,10 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
     }
 
     static @NotNull String formatReviewTimeoutError(@NotNull String operation, int fileCount) {
-        return "Error: Timed out after " + REVIEW_WAIT_TIMEOUT_MINUTES
-            + " minutes waiting for the user to review " + fileCount
-            + (fileCount == 1 ? " agent-edited file" : " agent-edited files")
-            + " before '" + operation
-            + "' could run. Ask the user to accept or revert the pending edits in the"
+        return "Error: " + fileCount + (fileCount == 1 ? " file has" : " files have")
+            + " not been approved or rejected by the user. '"
+            + operation + "' cannot proceed until all pending agent edits are reviewed."
+            + " The user must accept or revert the pending edits in the"
             + " Review panel (left of chat), then retry.";
     }
 
@@ -1234,6 +1316,16 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
                     linesRemoved.put(e.getKey(), Integer.parseInt(e.getValue()));
                 } catch (NumberFormatException ignored) {
                     // skip malformed entries
+                }
+            }
+        }
+
+        // If auto-approve was turned on while PENDING entries existed (or between
+        // IDE restarts), upgrade them now so they don't block future git operations.
+        if (isAutoApproveOn()) {
+            for (Map.Entry<String, ApprovalState> e : approvals.entrySet()) {
+                if (e.getValue() == ApprovalState.PENDING) {
+                    e.setValue(ApprovalState.APPROVED);
                 }
             }
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
@@ -8,9 +8,12 @@ import com.github.catatafishen.agentbridge.ui.renderers.GitCommitRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Commits staged changes with a message.
@@ -73,11 +76,14 @@ public final class GitCommitTool extends GitTool {
             return "Error: 'message' parameter is required";
         }
 
-        String reviewError = AgentEditSession.getInstance(project)
-            .awaitReviewCompletion("git commit");
-        if (reviewError != null) return reviewError;
-
         boolean commitAll = resolveCommitAll(args);
+
+        // Compute which files will be committed, then only gate on those paths.
+        // This prevents unrelated PENDING review items from blocking the commit.
+        Collection<String> filesToCommit = resolveFilesToCommit(commitAll);
+        String reviewError = AgentEditSession.getInstance(project)
+            .awaitReviewForPaths("git commit", filesToCommit);
+        if (reviewError != null) return reviewError;
 
         if (commitAll) {
             // Stage all changes including new untracked files (equivalent to git add -A)
@@ -169,6 +175,46 @@ public final class GitCommitTool extends GitTool {
      */
     static boolean resolveAmend(JsonObject args) {
         return args.has(PARAM_AMEND) && args.get(PARAM_AMEND).getAsBoolean();
+    }
+
+    /**
+     * Determines which files will be part of the commit, resolved to absolute paths.
+     * For {@code commitAll=true}: all modified, deleted, and untracked files from
+     * {@code git status --porcelain}. For staged-only: files from
+     * {@code git diff --cached --name-only}.
+     */
+    private Collection<String> resolveFilesToCommit(boolean commitAll) {
+        String basePath = project.getBasePath();
+        Set<String> paths = new java.util.HashSet<>();
+        if (commitAll) {
+            String status = runGitQuiet("status", "--porcelain");
+            if (status != null) {
+                for (String line : status.split("\\r?\\n")) {
+                    if (line.length() < 4) continue;
+                    // porcelain format: XY <path> or XY <orig> -> <path>
+                    String filePart = line.substring(3);
+                    int arrow = filePart.indexOf(" -> ");
+                    String relPath = arrow >= 0 ? filePart.substring(arrow + 4) : filePart;
+                    paths.add(toAbsolutePath(relPath.trim(), basePath));
+                }
+            }
+        } else {
+            String staged = runGitQuiet("diff", "--cached", "--name-only");
+            if (staged != null) {
+                for (String line : staged.split("\\r?\\n")) {
+                    String trimmed = line.trim();
+                    if (!trimmed.isEmpty()) {
+                        paths.add(toAbsolutePath(trimmed, basePath));
+                    }
+                }
+            }
+        }
+        return paths;
+    }
+
+    private static @NotNull String toAbsolutePath(@NotNull String path, @Nullable String basePath) {
+        if (basePath == null || path.startsWith("/")) return path;
+        return basePath + "/" + path;
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/BillingDisplayData.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/BillingDisplayData.kt
@@ -1,0 +1,17 @@
+package com.github.catatafishen.agentbridge.ui
+
+/**
+ * Immutable snapshot of billing display state, produced by [BillingManager] after
+ * each API poll or local-session increment. Consumed by the Session tab to render
+ * billing rows without reading raw mutable fields.
+ */
+data class BillingDisplayData(
+    val estimatedUsed: Int,
+    val entitlement: Int,
+    val unlimited: Boolean,
+    val estimatedRemaining: Int,
+    val overagePermitted: Boolean,
+    val resetDate: String,
+    val sessionRequests: Int,
+    val sessionPremiumRequests: Double,
+)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/BillingManager.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/BillingManager.kt
@@ -26,6 +26,9 @@ import javax.swing.JComponent
  */
 class BillingManager {
 
+    /** Callback fired on every billing display refresh. */
+    var onBillingChanged: Runnable? = null
+
     val usageLabel: JBLabel = JBLabel("").apply {
         cursor = java.awt.Cursor.getPredefinedCursor(java.awt.Cursor.HAND_CURSOR)
         toolTipText = "Click to toggle session/monthly view"
@@ -208,7 +211,23 @@ class BillingManager {
                 costLabel.text = ""
             }
         }
+        onBillingChanged?.run()
     }
+
+    /**
+     * Returns an immutable snapshot of billing display state for external consumers.
+     * Includes local-session adjustments (estimated used, estimated remaining).
+     */
+    fun getBillingDisplayData(): BillingDisplayData = BillingDisplayData(
+        estimatedUsed = estimatedUsed(),
+        entitlement = lastBillingEntitlement,
+        unlimited = lastBillingUnlimited,
+        estimatedRemaining = lastBillingRemaining - localSessionPremiumRequests.toInt(),
+        overagePermitted = lastBillingOveragePermitted,
+        resetDate = lastBillingResetDate,
+        sessionRequests = localSessionRequests,
+        sessionPremiumRequests = localSessionPremiumRequests,
+    )
 
     private fun updateUsageGraph(used: Int, entitlement: Int, unlimited: Boolean, resetDate: String) {
         if (!::usageGraphPanel.isInitialized) return

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ProcessingTimerPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ProcessingTimerPanel.kt
@@ -21,6 +21,9 @@ internal class ProcessingTimerPanel(
     private val localSessionRequests: () -> Int,
 ) : JBPanel<ProcessingTimerPanel>(), Disposable {
 
+    /** Callback fired on every stats change (including timer ticks). */
+    var onStatsChanged: Runnable? = null
+
     private val spinner = AsyncProcessIcon("AgentProcessing")
     private val doneIcon = JBLabel(AllIcons.Actions.Checked)
     private val timerLabel = JBLabel("")
@@ -205,6 +208,7 @@ internal class ProcessingTimerPanel(
             modeSession -> refreshSessionMode()
         }
         revalidate(); repaint()
+        onStatsChanged?.run()
     }
 
     private fun refreshTurnMode() {
@@ -268,6 +272,34 @@ internal class ProcessingTimerPanel(
                 requestsLabel.isVisible = false
             }
         }
+    }
+
+    /**
+     * Returns an immutable snapshot of all session statistics for external consumers
+     * (e.g., the Session tab's detailed stats view). Includes current-turn data when running.
+     */
+    fun getSessionSnapshot(): SessionStatsSnapshot {
+        val totalMs = sessionTotalTimeMs + if (isRunning) (System.currentTimeMillis() - startedAt) else 0
+        val totalTools = sessionTotalToolCalls + if (isRunning) toolCallCount else 0
+        val totalAdded = sessionTotalAddedLines + if (isRunning) addedLineCount else 0
+        val totalRemoved = sessionTotalRemovedLines + if (isRunning) removedLineCount else 0
+        val totalInput = sessionTotalInputTokens + if (isRunning) turnInputTokens else 0
+        val totalOutput = sessionTotalOutputTokens + if (isRunning) turnOutputTokens else 0
+        val totalCost = sessionTotalCostUsd + if (isRunning) (turnCostUsd ?: 0.0) else 0.0
+        val totalTurns = sessionTurnCount + if (isRunning) 1 else 0
+        return SessionStatsSnapshot(
+            isRunning = isRunning,
+            turnElapsedSec = if (isRunning) (System.currentTimeMillis() - startedAt) / 1000 else 0,
+            sessionTotalTimeSec = totalMs / 1000,
+            sessionTurnCount = totalTurns,
+            sessionToolCalls = totalTools,
+            sessionLinesAdded = totalAdded,
+            sessionLinesRemoved = totalRemoved,
+            sessionInputTokens = totalInput,
+            sessionOutputTokens = totalOutput,
+            sessionCostUsd = totalCost,
+            multiplierMode = supportsMultiplier(),
+        )
     }
 
     private fun updateLabel() {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/SessionStatsSnapshot.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/SessionStatsSnapshot.kt
@@ -1,0 +1,21 @@
+package com.github.catatafishen.agentbridge.ui
+
+/**
+ * Immutable snapshot of session-level statistics, produced by [ProcessingTimerPanel]
+ * on every data change. Consumed by the side panel's Session tab to render labeled
+ * stat rows without coupling to Swing internals.
+ */
+data class SessionStatsSnapshot(
+    val isRunning: Boolean,
+    val turnElapsedSec: Long,
+    val sessionTotalTimeSec: Long,
+    val sessionTurnCount: Int,
+    val sessionToolCalls: Int,
+    val sessionLinesAdded: Int,
+    val sessionLinesRemoved: Int,
+    val sessionInputTokens: Long,
+    val sessionOutputTokens: Long,
+    val sessionCostUsd: Double,
+    /** True when the agent uses premium-request multipliers (Copilot) rather than raw tokens. */
+    val multiplierMode: Boolean,
+)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/TimerDisplayFormatter.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/TimerDisplayFormatter.kt
@@ -41,4 +41,34 @@ object TimerDisplayFormatter {
         inputTokens: Int,
         outputTokens: Int,
     ): Boolean = !isRunning && ((costUsd?.let { it > 0.0 } ?: false) || (inputTokens + outputTokens) > 0)
+
+    /**
+     * Formats a token count with SI-style suffixes: 0 → "0", 1234 → "1.2k", 1500000 → "1.5M".
+     */
+    fun formatTokenCount(tokens: Long): String = when {
+        tokens >= 1_000_000 -> "%.1fM".format(tokens / 1_000_000.0)
+        tokens >= 1_000 -> "%.1fk".format(tokens / 1_000.0)
+        else -> tokens.toString()
+    }
+
+    /**
+     * Formats a USD cost for display: "$0.00" for zero, 4 decimals for sub-cent values,
+     * 2 decimals otherwise.
+     */
+    fun formatCost(costUsd: Double): String = when {
+        costUsd <= 0.0 -> "\$0.00"
+        costUsd < 0.01 -> "\$${String.format("%.4f", costUsd).trimEnd('0').trimEnd('.')}"
+        else -> "\$${String.format("%.2f", costUsd)}"
+    }
+
+    /**
+     * Formats lines-changed as "+N / -M", showing only the non-zero parts.
+     * Returns empty string when both are zero.
+     */
+    fun formatLinesChanged(added: Int, removed: Int): String = when {
+        added > 0 && removed > 0 -> "+$added / -$removed"
+        added > 0 -> "+$added"
+        removed > 0 -> "-$removed"
+        else -> ""
+    }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/UsageGraphPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/UsageGraphPanel.kt
@@ -38,8 +38,8 @@ class UsageGraphPanel : JBPanel<UsageGraphPanel>() {
         isOpaque = false
         val h = JBUI.scale(28)
         preferredSize = Dimension(JBUI.scale(120), h)
-        minimumSize = preferredSize
-        maximumSize = Dimension(JBUI.scale(120), h)
+        minimumSize = Dimension(0, JBUI.scale(16))
+        maximumSize = Dimension(Integer.MAX_VALUE, h)
         border = JBUI.Borders.empty(1, JBUI.scale(2))
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -1,19 +1,62 @@
 package com.github.catatafishen.agentbridge.ui.side;
 
+import com.github.catatafishen.agentbridge.ui.BillingDisplayData;
 import com.github.catatafishen.agentbridge.ui.BillingManager;
 import com.github.catatafishen.agentbridge.ui.ProcessingTimerPanel;
+import com.github.catatafishen.agentbridge.ui.SessionStatsSnapshot;
+import com.github.catatafishen.agentbridge.ui.TimerDisplayFormatter;
 import com.github.catatafishen.agentbridge.ui.UsageGraphPanel;
+import com.intellij.ui.AnimatedIcon;
 import com.intellij.util.ui.JBUI;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 /**
- * Side panel tab displaying session statistics: processing timer (elapsed time,
- * tool calls, token usage) and billing usage graph with quota information.
+ * Side panel tab displaying session statistics as labeled rows: processing status,
+ * session totals (time, turns, tools, lines, tokens, cost), and a thin billing
+ * usage graph with quota information.
+ *
+ * <p>Subscribes to change callbacks from both {@link ProcessingTimerPanel} and
+ * {@link BillingManager} for a single, consistent refresh model.
  */
 public final class SessionStatsPanel extends JPanel {
+
+    private static final DateTimeFormatter RESET_DATE_FMT = DateTimeFormatter.ofPattern("MMM d, yyyy");
+
+    private final ProcessingTimerPanel timerPanel;
+    private final BillingManager billing;
+
+    // Status row (visible only while processing)
+    private final JLabel spinnerLabel = new JLabel(new AnimatedIcon.Default());
+    private final JLabel statusLabel = new JLabel();
+    private final JPanel statusRow = new JPanel(new FlowLayout(FlowLayout.LEFT, JBUI.scale(4), 0));
+
+    // Session stats value labels
+    private final JLabel timeValue = new JLabel();
+    private final JLabel turnsValue = new JLabel();
+    private final JLabel toolsValue = new JLabel();
+    private final JLabel linesValue = new JLabel();
+    private final JLabel tokensValue = new JLabel();
+    private final JLabel costValue = new JLabel();
+
+    // Dynamic labels whose text changes based on provider mode
+    private final JLabel tokensRowLabel = new JLabel("Tokens");
+    private final JLabel costRowLabel = new JLabel("Cost");
+    private final JPanel tokensRow;
+    private final JPanel costRow;
+
+    // Billing section widgets
+    private final JLabel usageValue = new JLabel();
+    private final JLabel remainingValue = new JLabel();
+    private final JLabel resetsValue = new JLabel();
+    private final JPanel usageRow;
+    private final JPanel remainingRow;
+    private final JPanel resetsRow;
+    private final JPanel billingHeader;
 
     public SessionStatsPanel(
         @NotNull ProcessingTimerPanel timerPanel,
@@ -21,40 +64,215 @@ public final class SessionStatsPanel extends JPanel {
         @NotNull BillingManager billing
     ) {
         super(new BorderLayout());
+        this.timerPanel = timerPanel;
+        this.billing = billing;
 
-        JPanel timerSection = new JPanel(new BorderLayout());
-        timerSection.setBorder(BorderFactory.createEmptyBorder(
-            JBUI.scale(8), JBUI.scale(8), JBUI.scale(4), JBUI.scale(8)));
-        timerSection.setOpaque(false);
-        timerSection.add(timerPanel, BorderLayout.WEST);
+        Font smallFont = UIManager.getFont("Label.font").deriveFont((float) JBUI.scale(11));
+        Color dimColor = JBUI.CurrentTheme.Label.disabledForeground();
 
-        JPanel graphSection = new JPanel(new BorderLayout());
-        graphSection.setBorder(BorderFactory.createEmptyBorder(
+        // Status indicator row
+        statusRow.setOpaque(false);
+        statusRow.setBorder(BorderFactory.createEmptyBorder(
+            JBUI.scale(6), JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
+        spinnerLabel.setVisible(false);
+        statusLabel.setFont(smallFont);
+        statusLabel.setForeground(dimColor);
+        statusRow.add(spinnerLabel);
+        statusRow.add(statusLabel);
+        statusRow.setVisible(false);
+
+        // Session stats grid
+        JPanel statsGrid = new JPanel(new GridBagLayout());
+        statsGrid.setOpaque(false);
+        statsGrid.setBorder(BorderFactory.createEmptyBorder(
             JBUI.scale(4), JBUI.scale(8), JBUI.scale(4), JBUI.scale(8)));
+
+        int row = 0;
+        addStatRow(statsGrid, row++, "Time", timeValue, smallFont, dimColor);
+        addStatRow(statsGrid, row++, "Turns", turnsValue, smallFont, dimColor);
+        addStatRow(statsGrid, row++, "Tool calls", toolsValue, smallFont, dimColor);
+        addStatRow(statsGrid, row++, "Lines changed", linesValue, smallFont, dimColor);
+
+        tokensRow = addStatRowWithLabel(statsGrid, row++, tokensRowLabel, tokensValue, smallFont, dimColor);
+        costRow = addStatRowWithLabel(statsGrid, row, costRowLabel, costValue, smallFont, dimColor);
+
+        // Usage graph — thin full-width sparkline
+        JPanel graphSection = new JPanel(new BorderLayout());
         graphSection.setOpaque(false);
-        usageGraphPanel.setPreferredSize(new Dimension(JBUI.scale(200), JBUI.scale(120)));
+        graphSection.setBorder(BorderFactory.createEmptyBorder(
+            JBUI.scale(4), JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
+        int graphH = JBUI.scale(20);
+        usageGraphPanel.setPreferredSize(new Dimension(0, graphH));
+        usageGraphPanel.setMinimumSize(new Dimension(0, graphH));
+        usageGraphPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, graphH));
         graphSection.add(usageGraphPanel, BorderLayout.CENTER);
 
-        JPanel billingSection = new JPanel(new BorderLayout(0, JBUI.scale(4)));
-        billingSection.setBorder(BorderFactory.createEmptyBorder(
-            JBUI.scale(4), JBUI.scale(8), JBUI.scale(8), JBUI.scale(8)));
-        billingSection.setOpaque(false);
-        JLabel usageLabel = billing.getUsageLabel();
-        JLabel costLabel = billing.getCostLabel();
-        // Cap each label to a single line of text so long billing strings don't wrap and
-        // push the graph out of view.
-        int lineH = JBUI.scale(20);
-        usageLabel.setMaximumSize(new Dimension(Integer.MAX_VALUE, lineH));
-        costLabel.setMaximumSize(new Dimension(Integer.MAX_VALUE, lineH));
-        billingSection.add(usageLabel, BorderLayout.NORTH);
-        billingSection.add(costLabel, BorderLayout.SOUTH);
+        // Billing stats grid
+        JPanel billingGrid = new JPanel(new GridBagLayout());
+        billingGrid.setOpaque(false);
+        billingGrid.setBorder(BorderFactory.createEmptyBorder(
+            JBUI.scale(2), JBUI.scale(8), JBUI.scale(8), JBUI.scale(8)));
 
-        JPanel content = new JPanel(new BorderLayout());
+        billingHeader = createSectionHeader("Monthly quota", smallFont, dimColor);
+        int brow = 0;
+        usageRow = addStatRow(billingGrid, brow++, "Used", usageValue, smallFont, dimColor);
+        remainingRow = addStatRow(billingGrid, brow++, "Remaining", remainingValue, smallFont, dimColor);
+        resetsRow = addStatRow(billingGrid, brow, "Resets", resetsValue, smallFont, dimColor);
+
+        // Assemble the content
+        JPanel content = new JPanel();
+        content.setLayout(new BoxLayout(content, BoxLayout.Y_AXIS));
         content.setOpaque(false);
-        content.add(timerSection, BorderLayout.NORTH);
-        content.add(graphSection, BorderLayout.CENTER);
-        content.add(billingSection, BorderLayout.SOUTH);
+        content.add(statusRow);
+        content.add(createSectionHeader("Session", smallFont, dimColor));
+        content.add(statsGrid);
+        content.add(billingHeader);
+        content.add(graphSection);
+        content.add(billingGrid);
 
-        add(content, BorderLayout.CENTER);
+        JPanel wrapper = new JPanel(new BorderLayout());
+        wrapper.setOpaque(false);
+        wrapper.add(content, BorderLayout.NORTH);
+
+        add(wrapper, BorderLayout.CENTER);
+
+        timerPanel.setOnStatsChanged(this::refresh);
+        billing.setOnBillingChanged(this::refresh);
+        refresh();
+    }
+
+    private JPanel createSectionHeader(String title, Font font, Color color) {
+        JLabel label = new JLabel(title);
+        label.setFont(font.deriveFont(Font.BOLD));
+        label.setForeground(color);
+        JPanel header = new JPanel(new FlowLayout(FlowLayout.LEFT, JBUI.scale(8), 0));
+        header.setOpaque(false);
+        header.setBorder(BorderFactory.createEmptyBorder(
+            JBUI.scale(6), 0, JBUI.scale(2), 0));
+        header.add(label);
+        return header;
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private JPanel addStatRow(JPanel grid, int row, String labelText, JLabel value,
+                              Font font, Color dimColor) {
+        return addStatRowWithLabel(grid, row, new JLabel(labelText), value, font, dimColor);
+    }
+
+    private JPanel addStatRowWithLabel(JPanel grid, int row, JLabel label, JLabel value,
+                                       Font font, Color dimColor) {
+        label.setFont(font);
+        label.setForeground(dimColor);
+        value.setFont(font);
+
+        JPanel rowPanel = new JPanel(new BorderLayout(JBUI.scale(8), 0));
+        rowPanel.setOpaque(false);
+        rowPanel.add(label, BorderLayout.WEST);
+        rowPanel.add(value, BorderLayout.CENTER);
+
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.gridy = row;
+        gbc.weightx = 1.0;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.insets = new Insets(0, 0, JBUI.scale(2), 0);
+        grid.add(rowPanel, gbc);
+        return rowPanel;
+    }
+
+    private void refresh() {
+        SessionStatsSnapshot snap = timerPanel.getSessionSnapshot();
+        BillingDisplayData bill = billing.getBillingDisplayData();
+
+        refreshStatus(snap);
+        refreshSessionStats(snap);
+        refreshBilling(bill);
+
+        revalidate();
+        repaint();
+    }
+
+    private void refreshStatus(SessionStatsSnapshot snap) {
+        if (snap.isRunning()) {
+            spinnerLabel.setVisible(true);
+            String elapsed = TimerDisplayFormatter.INSTANCE.formatElapsedTime(snap.getTurnElapsedSec());
+            statusLabel.setText("Processing… " + elapsed);
+            statusRow.setVisible(true);
+        } else {
+            spinnerLabel.setVisible(false);
+            statusRow.setVisible(false);
+        }
+    }
+
+    private void refreshSessionStats(SessionStatsSnapshot snap) {
+        timeValue.setText(TimerDisplayFormatter.INSTANCE.formatElapsedTime(snap.getSessionTotalTimeSec()));
+        turnsValue.setText(String.valueOf(snap.getSessionTurnCount()));
+        toolsValue.setText(String.valueOf(snap.getSessionToolCalls()));
+
+        String lines = TimerDisplayFormatter.INSTANCE.formatLinesChanged(
+            snap.getSessionLinesAdded(), snap.getSessionLinesRemoved());
+        linesValue.setText(lines.isEmpty() ? "—" : lines);
+
+        if (snap.getMultiplierMode()) {
+            tokensRowLabel.setText("Premium req");
+            tokensValue.setText(String.valueOf(snap.getSessionTurnCount()));
+            tokensRow.setVisible(true);
+            costRow.setVisible(false);
+        } else {
+            long totalTokens = snap.getSessionInputTokens() + snap.getSessionOutputTokens();
+            if (totalTokens > 0 || snap.getSessionCostUsd() > 0.0) {
+                tokensRowLabel.setText("Tokens");
+                tokensValue.setText(
+                    TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getSessionInputTokens()) +
+                        " in / " +
+                        TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getSessionOutputTokens()) +
+                        " out");
+                tokensRow.setVisible(true);
+                costRowLabel.setText("Cost");
+                costValue.setText(TimerDisplayFormatter.INSTANCE.formatCost(snap.getSessionCostUsd()));
+                costRow.setVisible(true);
+            } else {
+                tokensRow.setVisible(false);
+                costRow.setVisible(false);
+            }
+        }
+    }
+
+    private void refreshBilling(BillingDisplayData bill) {
+        boolean hasBilling = bill.getEntitlement() > 0 || bill.getUnlimited();
+        billingHeader.setVisible(hasBilling);
+
+        if (bill.getUnlimited()) {
+            usageValue.setText("Unlimited");
+            usageRow.setVisible(true);
+            remainingRow.setVisible(false);
+        } else if (bill.getEntitlement() > 0) {
+            usageValue.setText(bill.getEstimatedUsed() + " / " + bill.getEntitlement());
+            usageRow.setVisible(true);
+            int remaining = bill.getEstimatedRemaining();
+            if (remaining < 0) {
+                remainingValue.setText("Over by " + (-remaining));
+                remainingValue.setForeground(JBUI.CurrentTheme.Label.errorForeground());
+            } else {
+                remainingValue.setText(String.valueOf(remaining));
+                remainingValue.setForeground(UIManager.getColor("Label.foreground"));
+            }
+            remainingRow.setVisible(true);
+        } else {
+            usageRow.setVisible(false);
+            remainingRow.setVisible(false);
+        }
+
+        if (!bill.getResetDate().isEmpty()) {
+            try {
+                LocalDate reset = LocalDate.parse(bill.getResetDate(), DateTimeFormatter.ISO_LOCAL_DATE);
+                resetsValue.setText(reset.format(RESET_DATE_FMT));
+                resetsRow.setVisible(hasBilling);
+            } catch (Exception ignored) {
+                resetsRow.setVisible(false);
+            }
+        } else {
+            resetsRow.setVisible(false);
+        }
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/ReviewPendingMessageTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/ReviewPendingMessageTest.java
@@ -6,22 +6,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Verifies the timeout error wording returned by {@link AgentEditSession#awaitReviewCompletion}
+ * Verifies the error wording returned by {@link AgentEditSession#awaitReviewCompletion}
  * when a git tool's blocking wait expires. The message must make clear that the block is
- * caused by unresolved review — not a generic timeout — so the agent surfaces actionable
- * guidance to the user instead of retrying blindly.
+ * caused by files that have not been approved or rejected — not a generic timeout — so
+ * the agent surfaces actionable guidance to the user instead of retrying blindly.
  */
 class ReviewPendingMessageTest {
 
     @Test
-    void mentionsTimeoutAndOperation() {
+    void mentionsFileCountAndOperation() {
         String msg = AgentEditSession.formatReviewTimeoutError("git commit", 3);
-        assertTrue(msg.startsWith("Error: Timed out"),
-            "Message must be flagged as an Error and mention the timeout: " + msg);
+        assertTrue(msg.startsWith("Error:"),
+            "Message must be flagged as an Error: " + msg);
         assertTrue(msg.contains("'git commit'"),
             "Message must name the blocked operation: " + msg);
-        assertTrue(msg.contains("3 agent-edited files"),
+        assertTrue(msg.contains("3 files"),
             "Message must report the file count (plural): " + msg);
+        assertTrue(msg.contains("not been approved or rejected"),
+            "Message must clarify the pending state: " + msg);
         assertTrue(msg.contains("Review panel"),
             "Message must direct the user to the Review panel: " + msg);
     }
@@ -29,9 +31,9 @@ class ReviewPendingMessageTest {
     @Test
     void singularPhrasingForOneFile() {
         String msg = AgentEditSession.formatReviewTimeoutError("git merge 'main'", 1);
-        assertTrue(msg.contains("1 agent-edited file"),
+        assertTrue(msg.contains("1 file has"),
             "Singular form expected: " + msg);
-        assertTrue(!msg.contains("1 agent-edited files"),
+        assertTrue(!msg.contains("1 files"),
             "Plural form must not appear for a single file: " + msg);
     }
 
@@ -47,5 +49,12 @@ class ReviewPendingMessageTest {
         String a = AgentEditSession.formatReviewTimeoutError("git commit", 5);
         String b = AgentEditSession.formatReviewTimeoutError("git commit", 5);
         assertEquals(a, b, "Formatter must be deterministic for the same inputs");
+    }
+
+    @Test
+    void cannotProceedMeaning() {
+        String msg = AgentEditSession.formatReviewTimeoutError("git commit", 2);
+        assertTrue(msg.contains("cannot proceed"),
+            "Message must say the operation cannot proceed: " + msg);
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/TimerDisplayFormatterTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/TimerDisplayFormatterTest.java
@@ -2,7 +2,9 @@ package com.github.catatafishen.agentbridge.ui;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TimerDisplayFormatterTest {
 
@@ -159,5 +161,86 @@ class TimerDisplayFormatterTest {
     @Test
     void hasDisplayableUsage_notRunning_negativeCostZeroTokens_false() {
         assertFalse(TimerDisplayFormatter.INSTANCE.hasDisplayableUsage(false, -0.01, 0, 0));
+    }
+
+    // ── formatTokenCount ────────────────────────────────────────────────
+
+    @Test
+    void formatTokenCount_zero() {
+        assertEquals("0", TimerDisplayFormatter.INSTANCE.formatTokenCount(0));
+    }
+
+    @Test
+    void formatTokenCount_below1k() {
+        assertEquals("999", TimerDisplayFormatter.INSTANCE.formatTokenCount(999));
+    }
+
+    @Test
+    void formatTokenCount_exactly1k() {
+        assertEquals("1.0k", TimerDisplayFormatter.INSTANCE.formatTokenCount(1000));
+    }
+
+    @Test
+    void formatTokenCount_fractionalK() {
+        assertEquals("1.2k", TimerDisplayFormatter.INSTANCE.formatTokenCount(1234));
+    }
+
+    @Test
+    void formatTokenCount_exactly1M() {
+        assertEquals("1.0M", TimerDisplayFormatter.INSTANCE.formatTokenCount(1_000_000));
+    }
+
+    @Test
+    void formatTokenCount_fractionalM() {
+        assertEquals("1.5M", TimerDisplayFormatter.INSTANCE.formatTokenCount(1_500_000));
+    }
+
+    // ── formatCost ──────────────────────────────────────────────────────
+
+    @Test
+    void formatCost_zero() {
+        assertEquals("$0.00", TimerDisplayFormatter.INSTANCE.formatCost(0.0));
+    }
+
+    @Test
+    void formatCost_negative() {
+        assertEquals("$0.00", TimerDisplayFormatter.INSTANCE.formatCost(-1.0));
+    }
+
+    @Test
+    void formatCost_subCent() {
+        assertEquals("$0.005", TimerDisplayFormatter.INSTANCE.formatCost(0.005));
+    }
+
+    @Test
+    void formatCost_normal() {
+        assertEquals("$1.23", TimerDisplayFormatter.INSTANCE.formatCost(1.23));
+    }
+
+    @Test
+    void formatCost_wholeDollar() {
+        assertEquals("$5.00", TimerDisplayFormatter.INSTANCE.formatCost(5.0));
+    }
+
+    // ── formatLinesChanged ──────────────────────────────────────────────
+
+    @Test
+    void formatLinesChanged_bothZero() {
+        assertEquals("", TimerDisplayFormatter.INSTANCE.formatLinesChanged(0, 0));
+    }
+
+    @Test
+    void formatLinesChanged_onlyAdded() {
+        assertEquals("+10", TimerDisplayFormatter.INSTANCE.formatLinesChanged(10, 0));
+    }
+
+    @Test
+    void formatLinesChanged_onlyRemoved() {
+        assertEquals("-5", TimerDisplayFormatter.INSTANCE.formatLinesChanged(0, 5));
+    }
+
+    @Test
+    void formatLinesChanged_bothNonZero() {
+        assertEquals("+42 / -7", TimerDisplayFormatter.INSTANCE.formatLinesChanged(42, 7));
     }
 }


### PR DESCRIPTION
## Summary

Redesign the Session tab in the side panel to show all stats as labeled rows with a thin usage graph, replacing the compact click-to-toggle widget.

### Changes

**New layout:**
- Processing status row with animated spinner and elapsed time
- Session totals: time, turns, tool calls, lines changed (separate labeled rows)
- Provider-aware: `Premium req` for multiplier mode, `Tokens` (in/out) + `Cost` for pay-as-you-go
- Thin usage graph (~20px sparkline) with monthly quota stats below
- Section headers for Session and Monthly quota

**Architecture:**
- `SessionStatsSnapshot` — immutable data class for timer/session data
- `BillingDisplayData` — immutable data class for billing display state
- `onStatsChanged` / `onBillingChanged` Runnable callbacks for refresh
- New formatters: `formatTokenCount`, `formatCost`, `formatLinesChanged`
- Relaxed `UsageGraphPanel` sizing for thin mode
- `AnimatedIcon.Default` replaces `AsyncProcessIcon` for daemon compatibility

### Tests

- 15 new tests for formatting functions (all pass)
- All existing `TimerDisplayFormatterTest` tests pass