### PR TITLE
feat: colored animated diff numbers in session tab

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
@@ -23,7 +23,7 @@ import com.intellij.openapi.ui.MessageType;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.Key;
-import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.io.OSAgnosticPathUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
@@ -507,7 +507,7 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
      * returned as-is; otherwise it is joined to {@code basePath}.
      */
     static @NotNull String toAbsolutePath(@NotNull String path, @Nullable String basePath) {
-        if (basePath == null || FileUtil.isAbsolutePlatformIndependent(path)) return path;
+        if (basePath == null || OSAgnosticPathUtil.isAbsolute(path)) return path;
         return basePath + "/" + path;
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
@@ -7,6 +7,7 @@ import com.github.catatafishen.agentbridge.psi.review.AgentEditSession;
 import com.github.catatafishen.agentbridge.ui.renderers.GitCommitRenderer;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.io.OSAgnosticPathUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -213,7 +214,7 @@ public final class GitCommitTool extends GitTool {
     }
 
     private static @NotNull String toAbsolutePath(@NotNull String path, @Nullable String basePath) {
-        if (basePath == null || path.startsWith("/")) return path;
+        if (basePath == null || OSAgnosticPathUtil.isAbsolute(path)) return path;
         return basePath + "/" + path;
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ProcessingTimerPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ProcessingTimerPanel.kt
@@ -290,6 +290,12 @@ internal class ProcessingTimerPanel(
         return SessionStatsSnapshot(
             isRunning = isRunning,
             turnElapsedSec = if (isRunning) (System.currentTimeMillis() - startedAt) / 1000 else 0,
+            turnToolCalls = if (isRunning) toolCallCount else 0,
+            turnLinesAdded = if (isRunning) addedLineCount else 0,
+            turnLinesRemoved = if (isRunning) removedLineCount else 0,
+            turnInputTokens = if (isRunning) turnInputTokens else 0,
+            turnOutputTokens = if (isRunning) turnOutputTokens else 0,
+            turnCostUsd = if (isRunning) turnCostUsd else null,
             sessionTotalTimeSec = totalMs / 1000,
             sessionTurnCount = totalTurns,
             sessionToolCalls = totalTools,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/SessionStatsSnapshot.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/SessionStatsSnapshot.kt
@@ -1,13 +1,19 @@
 package com.github.catatafishen.agentbridge.ui
 
 /**
- * Immutable snapshot of session-level statistics, produced by [ProcessingTimerPanel]
- * on every data change. Consumed by the side panel's Session tab to render labeled
- * stat rows without coupling to Swing internals.
+ * Immutable snapshot of session-level and turn-level statistics, produced by
+ * [ProcessingTimerPanel] on every data change. Consumed by the side panel's Session
+ * tab to render labeled stat rows without coupling to Swing internals.
  */
 data class SessionStatsSnapshot(
     val isRunning: Boolean,
     val turnElapsedSec: Long,
+    val turnToolCalls: Int,
+    val turnLinesAdded: Int,
+    val turnLinesRemoved: Int,
+    val turnInputTokens: Int,
+    val turnOutputTokens: Int,
+    val turnCostUsd: Double?,
     val sessionTotalTimeSec: Long,
     val sessionTurnCount: Int,
     val sessionToolCalls: Int,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/TimerDisplayFormatter.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/TimerDisplayFormatter.kt
@@ -76,7 +76,7 @@ object TimerDisplayFormatter {
 
     /**
      * Formats diff counts as colored HTML for use inside a `JLabel` with `<html>` support.
-     * Returns `"<html><font color='#HEX'>+N</font> <font color='#HEX'>-M</font></html>"`
+     * Returns `"<html><font color='#HEX'>+N</font> <font color='#HEX'>−M</font></html>"`
      * with green for additions and red for removals, or empty string when both are zero.
      */
     @JvmStatic

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/TimerDisplayFormatter.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/TimerDisplayFormatter.kt
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.ui
 
 import java.awt.Color
+import java.util.Locale
 
 /**
  * Pure formatting functions for timer and stats display in [ProcessingTimerPanel].
@@ -48,8 +49,8 @@ object TimerDisplayFormatter {
      * Formats a token count with SI-style suffixes: 0 → "0", 1234 → "1.2k", 1500000 → "1.5M".
      */
     fun formatTokenCount(tokens: Long): String = when {
-        tokens >= 1_000_000 -> "%.1fM".format(tokens / 1_000_000.0)
-        tokens >= 1_000 -> "%.1fk".format(tokens / 1_000.0)
+        tokens >= 1_000_000 -> String.format(Locale.ROOT, "%.1fM", tokens / 1_000_000.0)
+        tokens >= 1_000 -> String.format(Locale.ROOT, "%.1fk", tokens / 1_000.0)
         else -> tokens.toString()
     }
 
@@ -58,9 +59,9 @@ object TimerDisplayFormatter {
      * 2 decimals otherwise.
      */
     fun formatCost(costUsd: Double): String = when {
-        costUsd <= 0.0 -> "\$0.00"
-        costUsd < 0.01 -> "\$${String.format("%.4f", costUsd).trimEnd('0').trimEnd('.')}"
-        else -> "\$${String.format("%.2f", costUsd)}"
+        costUsd <= 0.0 -> $$"$0.00"
+        costUsd < 0.01 -> $$"$$${String.format(Locale.ROOT, "%.4f", costUsd).trimEnd('0').trimEnd('.')}"
+        else -> $$"$$${String.format(Locale.ROOT, "%.2f", costUsd)}"
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/TimerDisplayFormatter.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/TimerDisplayFormatter.kt
@@ -1,5 +1,7 @@
 package com.github.catatafishen.agentbridge.ui
 
+import java.awt.Color
+
 /**
  * Pure formatting functions for timer and stats display in [ProcessingTimerPanel].
  * Extracted to enable unit testing without Swing dependencies.
@@ -71,4 +73,26 @@ object TimerDisplayFormatter {
         removed > 0 -> "-$removed"
         else -> ""
     }
+
+    /**
+     * Formats diff counts as colored HTML for use inside a `JLabel` with `<html>` support.
+     * Returns `"<html><font color='#HEX'>+N</font> <font color='#HEX'>-M</font></html>"`
+     * with green for additions and red for removals, or empty string when both are zero.
+     */
+    @JvmStatic
+    fun formatDiffCountHtml(added: Int, removed: Int, addedColor: Color, removedColor: Color): String {
+        if (added <= 0 && removed <= 0) return ""
+        val sb = StringBuilder("<html>")
+        if (added > 0) sb.append("<font color='").append(colorHex(addedColor)).append("'>+").append(added)
+            .append("</font>")
+        if (removed > 0) {
+            if (added > 0) sb.append(" ")
+            sb.append("<font color='").append(colorHex(removedColor)).append("'>\u2212").append(removed)
+                .append("</font>")
+        }
+        sb.append("</html>")
+        return sb.toString()
+    }
+
+    private fun colorHex(c: Color): String = "#%02x%02x%02x".format(c.red, c.green, c.blue)
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionDiffAnimator.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionDiffAnimator.java
@@ -42,7 +42,7 @@ final class SessionDiffAnimator {
         if (!isAnimating(nowMillis)) {
             return new DiffCounts(targetAdded, targetRemoved);
         }
-        double progress = Math.min(1.0d, (double) (nowMillis - startMillis) / ANIMATION_DURATION_MS);
+        double progress = Math.max(0.0d, Math.min(1.0d, (double) (nowMillis - startMillis) / ANIMATION_DURATION_MS));
         return new DiffCounts(
             interpolate(startAdded, targetAdded, progress),
             interpolate(startRemoved, targetRemoved, progress)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionDiffAnimator.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionDiffAnimator.java
@@ -1,0 +1,63 @@
+package com.github.catatafishen.agentbridge.ui.side;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Animates a single pair of (added, removed) diff counts using linear interpolation.
+ * Used by {@link SessionStatsPanel} to animate lines-changed numbers when they update.
+ * <p>
+ * Mirrors the interpolation approach used by the diff tab's per-file animator
+ * but tracks a single value pair instead of per-file state.
+ */
+final class SessionDiffAnimator {
+
+    static final long ANIMATION_DURATION_MS = 600L;
+
+    private int startAdded;
+    private int startRemoved;
+    private int targetAdded;
+    private int targetRemoved;
+    private long startMillis;
+
+    /**
+     * Updates the target values. If they changed, captures the current display value
+     * as the new start and begins a fresh animation.
+     */
+    void update(int added, int removed, long nowMillis) {
+        if (targetAdded == added && targetRemoved == removed) {
+            return;
+        }
+        DiffCounts current = displayCounts(nowMillis);
+        startAdded = current.added();
+        startRemoved = current.removed();
+        targetAdded = added;
+        targetRemoved = removed;
+        startMillis = nowMillis;
+    }
+
+    /**
+     * Returns the interpolated counts for the current moment.
+     */
+    @NotNull DiffCounts displayCounts(long nowMillis) {
+        if (!isAnimating(nowMillis)) {
+            return new DiffCounts(targetAdded, targetRemoved);
+        }
+        double progress = Math.min(1.0d, (double) (nowMillis - startMillis) / ANIMATION_DURATION_MS);
+        return new DiffCounts(
+            interpolate(startAdded, targetAdded, progress),
+            interpolate(startRemoved, targetRemoved, progress)
+        );
+    }
+
+    boolean isAnimating(long nowMillis) {
+        return (startAdded != targetAdded || startRemoved != targetRemoved)
+            && nowMillis - startMillis < ANIMATION_DURATION_MS;
+    }
+
+    private static int interpolate(int start, int target, double progress) {
+        return (int) Math.round(start + (target - start) * progress);
+    }
+
+    record DiffCounts(int added, int removed) {
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -79,9 +79,9 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
     private final JPanel billingHeader;
 
     public SessionStatsPanel(
-        @NotNull ProcessingTimerPanel timerPanel,
-        @NotNull UsageGraphPanel usageGraphPanel,
-        @NotNull BillingManager billing
+            @NotNull ProcessingTimerPanel timerPanel,
+            @NotNull UsageGraphPanel usageGraphPanel,
+            @NotNull BillingManager billing
     ) {
         super(new BorderLayout());
         this.timerPanel = timerPanel;
@@ -95,7 +95,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         JPanel turnStatusRow = new JPanel(new FlowLayout(FlowLayout.LEFT, JBUI.scale(4), 0));
         turnStatusRow.setOpaque(false);
         turnStatusRow.setBorder(BorderFactory.createEmptyBorder(
-            JBUI.scale(2), JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
+                JBUI.scale(2), JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
         spinnerLabel.setVisible(false);
         turnStatusLabel.setFont(smallFont);
         turnStatusLabel.setForeground(dimColor);
@@ -105,7 +105,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         JPanel turnGrid = new JPanel(new GridBagLayout());
         turnGrid.setOpaque(false);
         turnGrid.setBorder(BorderFactory.createEmptyBorder(
-            JBUI.scale(2), JBUI.scale(8), JBUI.scale(4), JBUI.scale(8)));
+                JBUI.scale(2), JBUI.scale(8), JBUI.scale(4), JBUI.scale(8)));
 
         int tRow = 0;
         addStatRow(turnGrid, tRow++, "Tool calls", turnToolsValue, smallFont, dimColor);
@@ -125,7 +125,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         JPanel statsGrid = new JPanel(new GridBagLayout());
         statsGrid.setOpaque(false);
         statsGrid.setBorder(BorderFactory.createEmptyBorder(
-            JBUI.scale(4), JBUI.scale(8), JBUI.scale(4), JBUI.scale(8)));
+                JBUI.scale(4), JBUI.scale(8), JBUI.scale(4), JBUI.scale(8)));
 
         int row = 0;
         addStatRow(statsGrid, row++, "Time", timeValue, smallFont, dimColor);
@@ -140,7 +140,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         JPanel graphSection = new JPanel(new BorderLayout());
         graphSection.setOpaque(false);
         graphSection.setBorder(BorderFactory.createEmptyBorder(
-            JBUI.scale(4), JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
+                JBUI.scale(4), JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
         int graphH = JBUI.scale(20);
         usageGraphPanel.setPreferredSize(new Dimension(0, graphH));
         usageGraphPanel.setMinimumSize(new Dimension(0, graphH));
@@ -151,7 +151,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         JPanel billingGrid = new JPanel(new GridBagLayout());
         billingGrid.setOpaque(false);
         billingGrid.setBorder(BorderFactory.createEmptyBorder(
-            JBUI.scale(2), JBUI.scale(8), JBUI.scale(8), JBUI.scale(8)));
+                JBUI.scale(2), JBUI.scale(8), JBUI.scale(8), JBUI.scale(8)));
 
         billingHeader = createSectionHeader("Monthly quota", smallFont, dimColor);
         int brow = 0;
@@ -193,6 +193,10 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
 
     @Override
     public void dispose() {
+        timerPanel.setOnStatsChanged(() -> {
+        });
+        billing.setOnBillingChanged(() -> {
+        });
         animationTimer.stop();
     }
 
@@ -206,7 +210,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         JPanel header = new JPanel(new FlowLayout(FlowLayout.LEFT, JBUI.scale(8), 0));
         header.setOpaque(false);
         header.setBorder(BorderFactory.createEmptyBorder(
-            JBUI.scale(6), 0, JBUI.scale(2), 0));
+                JBUI.scale(6), 0, JBUI.scale(2), 0));
         header.add(label);
         return header;
     }
@@ -283,10 +287,10 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
             if (hasTurnUsage) {
                 turnTokensRowLabel.setText(LABEL_TOKENS);
                 turnTokensValue.setText(
-                    TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getTurnInputTokens()) +
-                        " in / " +
-                        TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getTurnOutputTokens()) +
-                        " out");
+                        TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getTurnInputTokens()) +
+                                " in / " +
+                                TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getTurnOutputTokens()) +
+                                " out");
                 turnTokensRow.setVisible(true);
                 turnCostRowLabel.setText("Cost");
                 turnCostValue.setText(TimerDisplayFormatter.INSTANCE.formatCost(turnCost != null ? turnCost : 0.0));
@@ -313,10 +317,10 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
             if (totalTokens > 0 || snap.getSessionCostUsd() > 0.0) {
                 tokensRowLabel.setText(LABEL_TOKENS);
                 tokensValue.setText(
-                    TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getSessionInputTokens()) +
-                        " in / " +
-                        TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getSessionOutputTokens()) +
-                        " out");
+                        TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getSessionInputTokens()) +
+                                " in / " +
+                                TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getSessionOutputTokens()) +
+                                " out");
                 tokensRow.setVisible(true);
                 costRowLabel.setText("Cost");
                 costValue.setText(TimerDisplayFormatter.INSTANCE.formatCost(snap.getSessionCostUsd()));
@@ -334,13 +338,13 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
 
         SessionDiffAnimator.DiffCounts sCounts = sessionDiffAnimator.displayCounts(now);
         String sHtml = TimerDisplayFormatter.formatDiffCountHtml(
-            sCounts.added(), sCounts.removed(), addColor, delColor);
+                sCounts.added(), sCounts.removed(), addColor, delColor);
         linesValue.setText(sHtml.isEmpty() ? "—" : sHtml);
 
         if (turnSection.isVisible()) {
             SessionDiffAnimator.DiffCounts tCounts = turnDiffAnimator.displayCounts(now);
             String tHtml = TimerDisplayFormatter.formatDiffCountHtml(
-                tCounts.added(), tCounts.removed(), addColor, delColor);
+                    tCounts.added(), tCounts.removed(), addColor, delColor);
             turnLinesValue.setText(tHtml.isEmpty() ? "—" : tHtml);
         }
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -6,6 +6,8 @@ import com.github.catatafishen.agentbridge.ui.ProcessingTimerPanel;
 import com.github.catatafishen.agentbridge.ui.SessionStatsSnapshot;
 import com.github.catatafishen.agentbridge.ui.TimerDisplayFormatter;
 import com.github.catatafishen.agentbridge.ui.UsageGraphPanel;
+import com.github.catatafishen.agentbridge.ui.renderers.ToolRenderers;
+import com.intellij.openapi.Disposable;
 import com.intellij.ui.AnimatedIcon;
 import com.intellij.util.ui.JBUI;
 import org.jetbrains.annotations.NotNull;
@@ -16,24 +18,42 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 /**
- * Side panel tab displaying session statistics as labeled rows: processing status,
- * session totals (time, turns, tools, lines, tokens, cost), and a thin billing
- * usage graph with quota information.
+ * Side panel tab displaying session statistics as labeled rows: an optional
+ * "Current turn" section (visible while the agent is processing) and cumulative
+ * session totals (time, turns, tools, lines, tokens, cost), followed by a thin
+ * billing usage graph with quota information.
+ *
+ * <p>Lines-changed values are rendered with colored numbers (green for additions,
+ * red for removals) and animate smoothly when the counts update.
  *
  * <p>Subscribes to change callbacks from both {@link ProcessingTimerPanel} and
  * {@link BillingManager} for a single, consistent refresh model.
  */
-public final class SessionStatsPanel extends JPanel {
+public final class SessionStatsPanel extends JPanel implements Disposable {
 
     private static final DateTimeFormatter RESET_DATE_FMT = DateTimeFormatter.ofPattern("MMM d, yyyy");
+    private static final String LABEL_TOKENS = "Tokens";
 
     private final ProcessingTimerPanel timerPanel;
     private final BillingManager billing;
 
-    // Status row (visible only while processing)
+    private final SessionDiffAnimator sessionDiffAnimator = new SessionDiffAnimator();
+    private final SessionDiffAnimator turnDiffAnimator = new SessionDiffAnimator();
+    private final Timer animationTimer;
+
+    // Current turn section
+    private final JLabel turnHeaderLabel = new JLabel("Current turn");
     private final JLabel spinnerLabel = new JLabel(new AnimatedIcon.Default());
-    private final JLabel statusLabel = new JLabel();
-    private final JPanel statusRow = new JPanel(new FlowLayout(FlowLayout.LEFT, JBUI.scale(4), 0));
+    private final JLabel turnStatusLabel = new JLabel();
+    private final JLabel turnToolsValue = new JLabel();
+    private final JLabel turnLinesValue = new JLabel();
+    private final JLabel turnTokensRowLabel = new JLabel(LABEL_TOKENS);
+    private final JLabel turnTokensValue = new JLabel();
+    private final JLabel turnCostRowLabel = new JLabel("Cost");
+    private final JLabel turnCostValue = new JLabel();
+    private final JPanel turnTokensRow;
+    private final JPanel turnCostRow;
+    private final JPanel turnSection;
 
     // Session stats value labels
     private final JLabel timeValue = new JLabel();
@@ -44,7 +64,7 @@ public final class SessionStatsPanel extends JPanel {
     private final JLabel costValue = new JLabel();
 
     // Dynamic labels whose text changes based on provider mode
-    private final JLabel tokensRowLabel = new JLabel("Tokens");
+    private final JLabel tokensRowLabel = new JLabel(LABEL_TOKENS);
     private final JLabel costRowLabel = new JLabel("Cost");
     private final JPanel tokensRow;
     private final JPanel costRow;
@@ -70,16 +90,36 @@ public final class SessionStatsPanel extends JPanel {
         Font smallFont = UIManager.getFont("Label.font").deriveFont((float) JBUI.scale(11));
         Color dimColor = JBUI.CurrentTheme.Label.disabledForeground();
 
-        // Status indicator row
-        statusRow.setOpaque(false);
-        statusRow.setBorder(BorderFactory.createEmptyBorder(
-            JBUI.scale(6), JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
+        // Current turn section
+        JPanel turnHeader = createSectionHeader(turnHeaderLabel, smallFont, dimColor);
+        JPanel turnStatusRow = new JPanel(new FlowLayout(FlowLayout.LEFT, JBUI.scale(4), 0));
+        turnStatusRow.setOpaque(false);
+        turnStatusRow.setBorder(BorderFactory.createEmptyBorder(
+            JBUI.scale(2), JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
         spinnerLabel.setVisible(false);
-        statusLabel.setFont(smallFont);
-        statusLabel.setForeground(dimColor);
-        statusRow.add(spinnerLabel);
-        statusRow.add(statusLabel);
-        statusRow.setVisible(false);
+        turnStatusLabel.setFont(smallFont);
+        turnStatusLabel.setForeground(dimColor);
+        turnStatusRow.add(spinnerLabel);
+        turnStatusRow.add(turnStatusLabel);
+
+        JPanel turnGrid = new JPanel(new GridBagLayout());
+        turnGrid.setOpaque(false);
+        turnGrid.setBorder(BorderFactory.createEmptyBorder(
+            JBUI.scale(2), JBUI.scale(8), JBUI.scale(4), JBUI.scale(8)));
+
+        int tRow = 0;
+        addStatRow(turnGrid, tRow++, "Tool calls", turnToolsValue, smallFont, dimColor);
+        addStatRow(turnGrid, tRow++, "Lines changed", turnLinesValue, smallFont, dimColor);
+        turnTokensRow = addStatRowWithLabel(turnGrid, tRow++, turnTokensRowLabel, turnTokensValue, smallFont, dimColor);
+        turnCostRow = addStatRowWithLabel(turnGrid, tRow, turnCostRowLabel, turnCostValue, smallFont, dimColor);
+
+        turnSection = new JPanel();
+        turnSection.setLayout(new BoxLayout(turnSection, BoxLayout.Y_AXIS));
+        turnSection.setOpaque(false);
+        turnSection.add(turnHeader);
+        turnSection.add(turnStatusRow);
+        turnSection.add(turnGrid);
+        turnSection.setVisible(false);
 
         // Session stats grid
         JPanel statsGrid = new JPanel(new GridBagLayout());
@@ -123,7 +163,7 @@ public final class SessionStatsPanel extends JPanel {
         JPanel content = new JPanel();
         content.setLayout(new BoxLayout(content, BoxLayout.Y_AXIS));
         content.setOpaque(false);
-        content.add(statusRow);
+        content.add(turnSection);
         content.add(createSectionHeader("Session", smallFont, dimColor));
         content.add(statsGrid);
         content.add(billingHeader);
@@ -136,13 +176,31 @@ public final class SessionStatsPanel extends JPanel {
 
         add(wrapper, BorderLayout.CENTER);
 
+        animationTimer = new Timer(33, e -> {
+            long now = System.currentTimeMillis();
+            updateDiffLabels(now);
+            repaint();
+            if (!sessionDiffAnimator.isAnimating(now) && !turnDiffAnimator.isAnimating(now)) {
+                ((Timer) e.getSource()).stop();
+            }
+        });
+        animationTimer.setRepeats(true);
+
         timerPanel.setOnStatsChanged(this::refresh);
         billing.setOnBillingChanged(this::refresh);
         refresh();
     }
 
+    @Override
+    public void dispose() {
+        animationTimer.stop();
+    }
+
     private JPanel createSectionHeader(String title, Font font, Color color) {
-        JLabel label = new JLabel(title);
+        return createSectionHeader(new JLabel(title), font, color);
+    }
+
+    private JPanel createSectionHeader(JLabel label, Font font, Color color) {
         label.setFont(font.deriveFont(Font.BOLD));
         label.setForeground(color);
         JPanel header = new JPanel(new FlowLayout(FlowLayout.LEFT, JBUI.scale(8), 0));
@@ -183,24 +241,60 @@ public final class SessionStatsPanel extends JPanel {
     private void refresh() {
         SessionStatsSnapshot snap = timerPanel.getSessionSnapshot();
         BillingDisplayData bill = billing.getBillingDisplayData();
+        long now = System.currentTimeMillis();
 
-        refreshStatus(snap);
+        sessionDiffAnimator.update(snap.getSessionLinesAdded(), snap.getSessionLinesRemoved(), now);
+        turnDiffAnimator.update(snap.getTurnLinesAdded(), snap.getTurnLinesRemoved(), now);
+
+        refreshTurnSection(snap);
         refreshSessionStats(snap);
         refreshBilling(bill);
+        updateDiffLabels(now);
+        startAnimationTimerIfNeeded(now);
 
         revalidate();
         repaint();
     }
 
-    private void refreshStatus(SessionStatsSnapshot snap) {
-        if (snap.isRunning()) {
-            spinnerLabel.setVisible(true);
-            String elapsed = TimerDisplayFormatter.INSTANCE.formatElapsedTime(snap.getTurnElapsedSec());
-            statusLabel.setText("Processing… " + elapsed);
-            statusRow.setVisible(true);
-        } else {
+    private void refreshTurnSection(SessionStatsSnapshot snap) {
+        if (!snap.isRunning()) {
             spinnerLabel.setVisible(false);
-            statusRow.setVisible(false);
+            turnSection.setVisible(false);
+            return;
+        }
+
+        turnHeaderLabel.setText("Current turn");
+        spinnerLabel.setVisible(true);
+        String elapsed = TimerDisplayFormatter.INSTANCE.formatElapsedTime(snap.getTurnElapsedSec());
+        turnStatusLabel.setText("Processing… " + elapsed);
+        turnSection.setVisible(true);
+
+        turnToolsValue.setText(String.valueOf(snap.getTurnToolCalls()));
+
+        if (snap.getMultiplierMode()) {
+            turnTokensRowLabel.setText("Premium req");
+            turnTokensValue.setText("1");
+            turnTokensRow.setVisible(true);
+            turnCostRow.setVisible(false);
+        } else {
+            long turnTok = snap.getTurnInputTokens() + snap.getTurnOutputTokens();
+            Double turnCost = snap.getTurnCostUsd();
+            boolean hasTurnUsage = turnTok > 0 || (turnCost != null && turnCost > 0.0);
+            if (hasTurnUsage) {
+                turnTokensRowLabel.setText(LABEL_TOKENS);
+                turnTokensValue.setText(
+                    TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getTurnInputTokens()) +
+                        " in / " +
+                        TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getTurnOutputTokens()) +
+                        " out");
+                turnTokensRow.setVisible(true);
+                turnCostRowLabel.setText("Cost");
+                turnCostValue.setText(TimerDisplayFormatter.INSTANCE.formatCost(turnCost != null ? turnCost : 0.0));
+                turnCostRow.setVisible(true);
+            } else {
+                turnTokensRow.setVisible(false);
+                turnCostRow.setVisible(false);
+            }
         }
     }
 
@@ -208,10 +302,6 @@ public final class SessionStatsPanel extends JPanel {
         timeValue.setText(TimerDisplayFormatter.INSTANCE.formatElapsedTime(snap.getSessionTotalTimeSec()));
         turnsValue.setText(String.valueOf(snap.getSessionTurnCount()));
         toolsValue.setText(String.valueOf(snap.getSessionToolCalls()));
-
-        String lines = TimerDisplayFormatter.INSTANCE.formatLinesChanged(
-            snap.getSessionLinesAdded(), snap.getSessionLinesRemoved());
-        linesValue.setText(lines.isEmpty() ? "—" : lines);
 
         if (snap.getMultiplierMode()) {
             tokensRowLabel.setText("Premium req");
@@ -221,7 +311,7 @@ public final class SessionStatsPanel extends JPanel {
         } else {
             long totalTokens = snap.getSessionInputTokens() + snap.getSessionOutputTokens();
             if (totalTokens > 0 || snap.getSessionCostUsd() > 0.0) {
-                tokensRowLabel.setText("Tokens");
+                tokensRowLabel.setText(LABEL_TOKENS);
                 tokensValue.setText(
                     TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getSessionInputTokens()) +
                         " in / " +
@@ -235,6 +325,31 @@ public final class SessionStatsPanel extends JPanel {
                 tokensRow.setVisible(false);
                 costRow.setVisible(false);
             }
+        }
+    }
+
+    private void updateDiffLabels(long now) {
+        Color addColor = ToolRenderers.INSTANCE.getADD_COLOR();
+        Color delColor = ToolRenderers.INSTANCE.getDEL_COLOR();
+
+        SessionDiffAnimator.DiffCounts sCounts = sessionDiffAnimator.displayCounts(now);
+        String sHtml = TimerDisplayFormatter.formatDiffCountHtml(
+            sCounts.added(), sCounts.removed(), addColor, delColor);
+        linesValue.setText(sHtml.isEmpty() ? "—" : sHtml);
+
+        if (turnSection.isVisible()) {
+            SessionDiffAnimator.DiffCounts tCounts = turnDiffAnimator.displayCounts(now);
+            String tHtml = TimerDisplayFormatter.formatDiffCountHtml(
+                tCounts.added(), tCounts.removed(), addColor, delColor);
+            turnLinesValue.setText(tHtml.isEmpty() ? "—" : tHtml);
+        }
+    }
+
+    private void startAnimationTimerIfNeeded(long now) {
+        if (sessionDiffAnimator.isAnimating(now) || turnDiffAnimator.isAnimating(now)) {
+            if (!animationTimer.isRunning()) animationTimer.start();
+        } else {
+            animationTimer.stop();
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -16,6 +16,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * Side panel tab displaying session statistics as labeled rows: an optional
@@ -36,6 +37,8 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
 
     private final ProcessingTimerPanel timerPanel;
     private final BillingManager billing;
+    private final Font smallFont;
+    private final Color dimColor;
 
     private final SessionDiffAnimator sessionDiffAnimator = new SessionDiffAnimator();
     private final SessionDiffAnimator turnDiffAnimator = new SessionDiffAnimator();
@@ -79,23 +82,23 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
     private final JPanel billingHeader;
 
     public SessionStatsPanel(
-            @NotNull ProcessingTimerPanel timerPanel,
-            @NotNull UsageGraphPanel usageGraphPanel,
-            @NotNull BillingManager billing
+        @NotNull ProcessingTimerPanel timerPanel,
+        @NotNull UsageGraphPanel usageGraphPanel,
+        @NotNull BillingManager billing
     ) {
         super(new BorderLayout());
         this.timerPanel = timerPanel;
         this.billing = billing;
 
-        Font smallFont = UIManager.getFont("Label.font").deriveFont((float) JBUI.scale(11));
-        Color dimColor = JBUI.CurrentTheme.Label.disabledForeground();
+        this.smallFont = UIManager.getFont("Label.font").deriveFont((float) JBUI.scale(11));
+        this.dimColor = JBUI.CurrentTheme.Label.disabledForeground();
 
         // Current turn section
-        JPanel turnHeader = createSectionHeader(turnHeaderLabel, smallFont, dimColor);
+        JPanel turnHeader = createSectionHeader(turnHeaderLabel);
         JPanel turnStatusRow = new JPanel(new FlowLayout(FlowLayout.LEFT, JBUI.scale(4), 0));
         turnStatusRow.setOpaque(false);
         turnStatusRow.setBorder(BorderFactory.createEmptyBorder(
-                JBUI.scale(2), JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
+            JBUI.scale(2), JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
         spinnerLabel.setVisible(false);
         turnStatusLabel.setFont(smallFont);
         turnStatusLabel.setForeground(dimColor);
@@ -105,13 +108,13 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         JPanel turnGrid = new JPanel(new GridBagLayout());
         turnGrid.setOpaque(false);
         turnGrid.setBorder(BorderFactory.createEmptyBorder(
-                JBUI.scale(2), JBUI.scale(8), JBUI.scale(4), JBUI.scale(8)));
+            JBUI.scale(2), JBUI.scale(8), JBUI.scale(4), JBUI.scale(8)));
 
         int tRow = 0;
-        addStatRow(turnGrid, tRow++, "Tool calls", turnToolsValue, smallFont, dimColor);
-        addStatRow(turnGrid, tRow++, "Lines changed", turnLinesValue, smallFont, dimColor);
-        turnTokensRow = addStatRowWithLabel(turnGrid, tRow++, turnTokensRowLabel, turnTokensValue, smallFont, dimColor);
-        turnCostRow = addStatRowWithLabel(turnGrid, tRow, turnCostRowLabel, turnCostValue, smallFont, dimColor);
+        addStatRow(turnGrid, tRow++, "Tool calls", turnToolsValue);
+        addStatRow(turnGrid, tRow++, "Lines changed", turnLinesValue);
+        turnTokensRow = addStatRowWithLabel(turnGrid, tRow++, turnTokensRowLabel, turnTokensValue);
+        turnCostRow = addStatRowWithLabel(turnGrid, tRow, turnCostRowLabel, turnCostValue);
 
         turnSection = new JPanel();
         turnSection.setLayout(new BoxLayout(turnSection, BoxLayout.Y_AXIS));
@@ -125,22 +128,22 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         JPanel statsGrid = new JPanel(new GridBagLayout());
         statsGrid.setOpaque(false);
         statsGrid.setBorder(BorderFactory.createEmptyBorder(
-                JBUI.scale(4), JBUI.scale(8), JBUI.scale(4), JBUI.scale(8)));
+            JBUI.scale(4), JBUI.scale(8), JBUI.scale(4), JBUI.scale(8)));
 
         int row = 0;
-        addStatRow(statsGrid, row++, "Time", timeValue, smallFont, dimColor);
-        addStatRow(statsGrid, row++, "Turns", turnsValue, smallFont, dimColor);
-        addStatRow(statsGrid, row++, "Tool calls", toolsValue, smallFont, dimColor);
-        addStatRow(statsGrid, row++, "Lines changed", linesValue, smallFont, dimColor);
+        addStatRow(statsGrid, row++, "Time", timeValue);
+        addStatRow(statsGrid, row++, "Turns", turnsValue);
+        addStatRow(statsGrid, row++, "Tool calls", toolsValue);
+        addStatRow(statsGrid, row++, "Lines changed", linesValue);
 
-        tokensRow = addStatRowWithLabel(statsGrid, row++, tokensRowLabel, tokensValue, smallFont, dimColor);
-        costRow = addStatRowWithLabel(statsGrid, row, costRowLabel, costValue, smallFont, dimColor);
+        tokensRow = addStatRowWithLabel(statsGrid, row++, tokensRowLabel, tokensValue);
+        costRow = addStatRowWithLabel(statsGrid, row, costRowLabel, costValue);
 
         // Usage graph — thin full-width sparkline
         JPanel graphSection = new JPanel(new BorderLayout());
         graphSection.setOpaque(false);
         graphSection.setBorder(BorderFactory.createEmptyBorder(
-                JBUI.scale(4), JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
+            JBUI.scale(4), JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
         int graphH = JBUI.scale(20);
         usageGraphPanel.setPreferredSize(new Dimension(0, graphH));
         usageGraphPanel.setMinimumSize(new Dimension(0, graphH));
@@ -151,20 +154,20 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         JPanel billingGrid = new JPanel(new GridBagLayout());
         billingGrid.setOpaque(false);
         billingGrid.setBorder(BorderFactory.createEmptyBorder(
-                JBUI.scale(2), JBUI.scale(8), JBUI.scale(8), JBUI.scale(8)));
+            JBUI.scale(2), JBUI.scale(8), JBUI.scale(8), JBUI.scale(8)));
 
-        billingHeader = createSectionHeader("Monthly quota", smallFont, dimColor);
+        billingHeader = createSectionHeader("Monthly quota");
         int brow = 0;
-        usageRow = addStatRow(billingGrid, brow++, "Used", usageValue, smallFont, dimColor);
-        remainingRow = addStatRow(billingGrid, brow++, "Remaining", remainingValue, smallFont, dimColor);
-        resetsRow = addStatRow(billingGrid, brow, "Resets", resetsValue, smallFont, dimColor);
+        usageRow = addStatRow(billingGrid, brow++, "Used", usageValue);
+        remainingRow = addStatRow(billingGrid, brow++, "Remaining", remainingValue);
+        resetsRow = addStatRow(billingGrid, brow, "Resets", resetsValue);
 
         // Assemble the content
         JPanel content = new JPanel();
         content.setLayout(new BoxLayout(content, BoxLayout.Y_AXIS));
         content.setOpaque(false);
         content.add(turnSection);
-        content.add(createSectionHeader("Session", smallFont, dimColor));
+        content.add(createSectionHeader("Session"));
         content.add(statsGrid);
         content.add(billingHeader);
         content.add(graphSection);
@@ -193,39 +196,34 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
 
     @Override
     public void dispose() {
-        timerPanel.setOnStatsChanged(() -> {
-        });
-        billing.setOnBillingChanged(() -> {
-        });
+        timerPanel.setOnStatsChanged(null);
+        billing.setOnBillingChanged(null);
         animationTimer.stop();
     }
 
-    private JPanel createSectionHeader(String title, Font font, Color color) {
-        return createSectionHeader(new JLabel(title), font, color);
+    private JPanel createSectionHeader(String title) {
+        return createSectionHeader(new JLabel(title));
     }
 
-    private JPanel createSectionHeader(JLabel label, Font font, Color color) {
-        label.setFont(font.deriveFont(Font.BOLD));
-        label.setForeground(color);
+    private JPanel createSectionHeader(JLabel label) {
+        label.setFont(smallFont.deriveFont(Font.BOLD));
+        label.setForeground(dimColor);
         JPanel header = new JPanel(new FlowLayout(FlowLayout.LEFT, JBUI.scale(8), 0));
         header.setOpaque(false);
         header.setBorder(BorderFactory.createEmptyBorder(
-                JBUI.scale(6), 0, JBUI.scale(2), 0));
+            JBUI.scale(6), 0, JBUI.scale(2), 0));
         header.add(label);
         return header;
     }
 
-    @SuppressWarnings("SameParameterValue")
-    private JPanel addStatRow(JPanel grid, int row, String labelText, JLabel value,
-                              Font font, Color dimColor) {
-        return addStatRowWithLabel(grid, row, new JLabel(labelText), value, font, dimColor);
+    private JPanel addStatRow(JPanel grid, int row, String labelText, JLabel value) {
+        return addStatRowWithLabel(grid, row, new JLabel(labelText), value);
     }
 
-    private JPanel addStatRowWithLabel(JPanel grid, int row, JLabel label, JLabel value,
-                                       Font font, Color dimColor) {
-        label.setFont(font);
+    private JPanel addStatRowWithLabel(JPanel grid, int row, JLabel label, JLabel value) {
+        label.setFont(smallFont);
         label.setForeground(dimColor);
-        value.setFont(font);
+        value.setFont(smallFont);
 
         JPanel rowPanel = new JPanel(new BorderLayout(JBUI.scale(8), 0));
         rowPanel.setOpaque(false);
@@ -287,10 +285,10 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
             if (hasTurnUsage) {
                 turnTokensRowLabel.setText(LABEL_TOKENS);
                 turnTokensValue.setText(
-                        TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getTurnInputTokens()) +
-                                " in / " +
-                                TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getTurnOutputTokens()) +
-                                " out");
+                    TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getTurnInputTokens()) +
+                        " in / " +
+                        TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getTurnOutputTokens()) +
+                        " out");
                 turnTokensRow.setVisible(true);
                 turnCostRowLabel.setText("Cost");
                 turnCostValue.setText(TimerDisplayFormatter.INSTANCE.formatCost(turnCost != null ? turnCost : 0.0));
@@ -317,10 +315,10 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
             if (totalTokens > 0 || snap.getSessionCostUsd() > 0.0) {
                 tokensRowLabel.setText(LABEL_TOKENS);
                 tokensValue.setText(
-                        TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getSessionInputTokens()) +
-                                " in / " +
-                                TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getSessionOutputTokens()) +
-                                " out");
+                    TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getSessionInputTokens()) +
+                        " in / " +
+                        TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getSessionOutputTokens()) +
+                        " out");
                 tokensRow.setVisible(true);
                 costRowLabel.setText("Cost");
                 costValue.setText(TimerDisplayFormatter.INSTANCE.formatCost(snap.getSessionCostUsd()));
@@ -338,13 +336,13 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
 
         SessionDiffAnimator.DiffCounts sCounts = sessionDiffAnimator.displayCounts(now);
         String sHtml = TimerDisplayFormatter.formatDiffCountHtml(
-                sCounts.added(), sCounts.removed(), addColor, delColor);
+            sCounts.added(), sCounts.removed(), addColor, delColor);
         linesValue.setText(sHtml.isEmpty() ? "—" : sHtml);
 
         if (turnSection.isVisible()) {
             SessionDiffAnimator.DiffCounts tCounts = turnDiffAnimator.displayCounts(now);
             String tHtml = TimerDisplayFormatter.formatDiffCountHtml(
-                    tCounts.added(), tCounts.removed(), addColor, delColor);
+                tCounts.added(), tCounts.removed(), addColor, delColor);
             turnLinesValue.setText(tHtml.isEmpty() ? "—" : tHtml);
         }
     }
@@ -387,7 +385,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
                 LocalDate reset = LocalDate.parse(bill.getResetDate(), DateTimeFormatter.ISO_LOCAL_DATE);
                 resetsValue.setText(reset.format(RESET_DATE_FMT));
                 resetsRow.setVisible(hasBilling);
-            } catch (Exception ignored) {
+            } catch (DateTimeParseException ignored) {
                 resetsRow.setVisible(false);
             }
         } else {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SidePanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SidePanel.java
@@ -38,6 +38,7 @@ public final class SidePanel extends JPanel implements Disposable {
         super(new BorderLayout());
         ReviewChangesPanel reviewPanel = new ReviewChangesPanel(project);
         Disposer.register(this, reviewPanel);
+        Disposer.register(this, sessionStatsPanel);
 
         ProjectFilesPanel projectFilesPanel = new ProjectFilesPanel(project);
         TodoPanel todoPanel = new TodoPanel(project);

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/TimerDisplayFormatterTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/TimerDisplayFormatterTest.java
@@ -243,4 +243,45 @@ class TimerDisplayFormatterTest {
     void formatLinesChanged_bothNonZero() {
         assertEquals("+42 / -7", TimerDisplayFormatter.INSTANCE.formatLinesChanged(42, 7));
     }
+
+    // ── formatDiffCountHtml ─────────────────────────────────────────────
+
+    private static final java.awt.Color GREEN = new java.awt.Color(0x00, 0xAA, 0x00);
+    private static final java.awt.Color RED = new java.awt.Color(0xCC, 0x00, 0x00);
+
+    @Test
+    void formatDiffCountHtml_bothZero_returnsEmpty() {
+        assertEquals("", TimerDisplayFormatter.formatDiffCountHtml(0, 0, GREEN, RED));
+    }
+
+    @Test
+    void formatDiffCountHtml_onlyAdded() {
+        String result = TimerDisplayFormatter.formatDiffCountHtml(5, 0, GREEN, RED);
+        assertTrue(result.startsWith("<html>"), "should be wrapped in html");
+        assertTrue(result.contains("+5"), "should contain +5");
+        assertFalse(result.contains("\u2212"), "should not contain minus sign");
+    }
+
+    @Test
+    void formatDiffCountHtml_onlyRemoved() {
+        String result = TimerDisplayFormatter.formatDiffCountHtml(0, 3, GREEN, RED);
+        assertTrue(result.startsWith("<html>"));
+        assertTrue(result.contains("\u22123"), "should contain −3");
+        assertFalse(result.contains("+"), "should not contain plus sign");
+    }
+
+    @Test
+    void formatDiffCountHtml_bothNonZero() {
+        String result = TimerDisplayFormatter.formatDiffCountHtml(10, 4, GREEN, RED);
+        assertTrue(result.startsWith("<html>"));
+        assertTrue(result.contains("+10"));
+        assertTrue(result.contains("\u22124"));
+        assertTrue(result.contains("#00aa00"), "should contain green hex color");
+        assertTrue(result.contains("#cc0000"), "should contain red hex color");
+    }
+
+    @Test
+    void formatDiffCountHtml_negativeValuesIgnored() {
+        assertEquals("", TimerDisplayFormatter.formatDiffCountHtml(-1, -1, GREEN, RED));
+    }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/side/SessionDiffAnimatorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/ui/side/SessionDiffAnimatorTest.java
@@ -1,0 +1,121 @@
+package com.github.catatafishen.agentbridge.ui.side;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SessionDiffAnimatorTest {
+
+    @Test
+    void initialStateReturnsZeros() {
+        SessionDiffAnimator animator = new SessionDiffAnimator();
+        SessionDiffAnimator.DiffCounts counts = animator.displayCounts(0L);
+        assertEquals(0, counts.added());
+        assertEquals(0, counts.removed());
+        assertFalse(animator.isAnimating(0L));
+    }
+
+    @Test
+    void updateTriggersAnimation() {
+        SessionDiffAnimator animator = new SessionDiffAnimator();
+        animator.update(20, 8, 100L);
+
+        // At start of animation, should be near 0 (interpolating from 0)
+        SessionDiffAnimator.DiffCounts atStart = animator.displayCounts(100L);
+        assertEquals(0, atStart.added());
+        assertEquals(0, atStart.removed());
+        assertTrue(animator.isAnimating(100L));
+    }
+
+    @Test
+    void midpointShowsIntermediateValues() {
+        SessionDiffAnimator animator = new SessionDiffAnimator();
+        animator.update(20, 10, 0L);
+
+        long midpoint = SessionDiffAnimator.ANIMATION_DURATION_MS / 2;
+        SessionDiffAnimator.DiffCounts mid = animator.displayCounts(midpoint);
+        assertTrue(mid.added() > 0 && mid.added() < 20,
+            "midpoint added should be between 0 and 20, was " + mid.added());
+        assertTrue(mid.removed() > 0 && mid.removed() < 10,
+            "midpoint removed should be between 0 and 10, was " + mid.removed());
+    }
+
+    @Test
+    void afterDurationReachesTarget() {
+        SessionDiffAnimator animator = new SessionDiffAnimator();
+        animator.update(42, 17, 0L);
+
+        long finished = SessionDiffAnimator.ANIMATION_DURATION_MS + 1L;
+        SessionDiffAnimator.DiffCounts end = animator.displayCounts(finished);
+        assertEquals(42, end.added());
+        assertEquals(17, end.removed());
+        assertFalse(animator.isAnimating(finished));
+    }
+
+    @Test
+    void retargetPreservesCurrentPosition() {
+        SessionDiffAnimator animator = new SessionDiffAnimator();
+        animator.update(20, 10, 0L);
+
+        // At midpoint, retarget to higher values
+        long midpoint = SessionDiffAnimator.ANIMATION_DURATION_MS / 2;
+        SessionDiffAnimator.DiffCounts midValues = animator.displayCounts(midpoint);
+        animator.update(40, 20, midpoint);
+
+        // The new animation should start from the midpoint values
+        SessionDiffAnimator.DiffCounts afterRetarget = animator.displayCounts(midpoint);
+        assertEquals(midValues.added(), afterRetarget.added());
+        assertEquals(midValues.removed(), afterRetarget.removed());
+        assertTrue(animator.isAnimating(midpoint));
+
+        // And eventually reach the new target
+        long finished = midpoint + SessionDiffAnimator.ANIMATION_DURATION_MS + 1L;
+        SessionDiffAnimator.DiffCounts finalCounts = animator.displayCounts(finished);
+        assertEquals(40, finalCounts.added());
+        assertEquals(20, finalCounts.removed());
+    }
+
+    @Test
+    void sameValuesDoNotRestartAnimation() {
+        SessionDiffAnimator animator = new SessionDiffAnimator();
+        animator.update(10, 5, 0L);
+
+        // Let it finish
+        long finished = SessionDiffAnimator.ANIMATION_DURATION_MS + 1L;
+        assertFalse(animator.isAnimating(finished));
+
+        // Update with same values — should not start animating
+        animator.update(10, 5, finished + 100L);
+        assertFalse(animator.isAnimating(finished + 100L));
+    }
+
+    @Test
+    void onlyAddedAnimates() {
+        SessionDiffAnimator animator = new SessionDiffAnimator();
+        animator.update(30, 0, 0L);
+
+        long midpoint = SessionDiffAnimator.ANIMATION_DURATION_MS / 2;
+        SessionDiffAnimator.DiffCounts mid = animator.displayCounts(midpoint);
+        assertTrue(mid.added() > 0 && mid.added() < 30);
+        assertEquals(0, mid.removed());
+
+        long finished = SessionDiffAnimator.ANIMATION_DURATION_MS + 1L;
+        assertEquals(30, animator.displayCounts(finished).added());
+    }
+
+    @Test
+    void onlyRemovedAnimates() {
+        SessionDiffAnimator animator = new SessionDiffAnimator();
+        animator.update(0, 15, 0L);
+
+        long midpoint = SessionDiffAnimator.ANIMATION_DURATION_MS / 2;
+        SessionDiffAnimator.DiffCounts mid = animator.displayCounts(midpoint);
+        assertEquals(0, mid.added());
+        assertTrue(mid.removed() > 0 && mid.removed() < 15);
+
+        long finished = SessionDiffAnimator.ANIMATION_DURATION_MS + 1L;
+        assertEquals(15, animator.displayCounts(finished).removed());
+    }
+}


### PR DESCRIPTION
## Summary

Adds colored (green/red) animated line-changed numbers to the **Session** tab, matching the style already used in the **Diff** tab. Also adds a "Current turn" section that shows turn-specific stats with a processing indicator while the agent is running.

## Changes

### New files
- **`SessionDiffAnimator.java`** — Simple pair animator with 600ms linear interpolation (mirrors `ReviewDiffCountAnimator` but for a single value pair)
- **`SessionDiffAnimatorTest.java`** — 8 unit tests covering initial state, midpoint interpolation, retargeting, and edge cases

### Modified files
- **`SessionStatsPanel.java`** — Major rewrite: colored HTML diff labels, animation timer (33ms), "Current turn" section with spinner + turn stats, implements `Disposable`
- **`SessionStatsSnapshot.kt`** — Extended with 6 turn-level fields (turnToolCalls, turnLinesAdded, turnLinesRemoved, turnInputTokens, turnOutputTokens, turnCostUsd)
- **`ProcessingTimerPanel.kt`** — Updated `getSessionSnapshot()` to populate turn-level fields
- **`TimerDisplayFormatter.kt`** — Added `formatDiffCountHtml()` for colored HTML rendering with theme-aware colors
- **`SidePanel.java`** — Register `SessionStatsPanel` as `Disposable`
- **`TimerDisplayFormatterTest.java`** — 5 new tests for `formatDiffCountHtml()`

## Visual behavior
- Lines changed in both session totals and current turn now show as `+N −M` with green/red colors
- Numbers animate smoothly (600ms linear interpolation) when values change
- "Current turn" section appears while agent is running and hides when complete