### PR TITLE
fix: detect Claude auth from macOS Keychain

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/claude/ClaudeCliCredentials.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/agent/claude/ClaudeCliCredentials.java
@@ -7,20 +7,28 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 
 /**
- * Reads the Claude CLI credential file ({@code ~/.claude/.credentials.json}) written by
- * {@code claude auth login} to determine whether the user is logged in.
+ * Reads the Claude CLI credentials written by {@code claude auth login} to determine whether the
+ * user is logged in.
  *
- * <p>The file contains an {@code oauthAccount} section and a {@code claudeAiOauth} section
- * with {@code accessToken} and {@code expiresAt} (Unix ms). The access token authenticates
- * the {@code claude} subprocess — it is NOT sent to any external API by this plugin.</p>
+ * <p>Older Claude Code versions store credentials in {@code ~/.claude/.credentials.json}. Claude
+ * Code 2.x on macOS stores the same JSON blob in the macOS Keychain under the service name
+ * {@code "Claude Code-credentials"}. The access token authenticates the {@code claude}
+ * subprocess — it is NOT sent to any external API by this plugin.</p>
  */
 public final class ClaudeCliCredentials {
 
     private static final Logger LOG = Logger.getInstance(ClaudeCliCredentials.class);
+    private static final String KEYCHAIN_SERVICE_NAME = "Claude Code-credentials";
+    private static final String MACOS_SECURITY_BINARY = "/usr/bin/security";
+    private static final int SECURITY_COMMAND_TIMEOUT_SECONDS = 3;
 
     private final boolean loggedIn;
     @Nullable
@@ -32,21 +40,79 @@ public final class ClaudeCliCredentials {
     }
 
     /**
-     * Reads credentials from disk and returns a snapshot.
+     * Reads credentials from disk (or from the macOS Keychain on macOS) and returns a snapshot.
      * Never throws — returns a "not logged in" instance on any error.
+     *
+     * <p>Claude Code 2.x stores OAuth credentials in the macOS Keychain under the service name
+     * {@code "Claude Code-credentials"} instead of the credentials file. On macOS we therefore
+     * try the Keychain as a fallback when the file is absent or contains no valid token.</p>
      */
     @NotNull
     public static ClaudeCliCredentials read() {
+        return read(ClaudeCliCredentials::runSecurityCommand);
+    }
+
+    @NotNull
+    static ClaudeCliCredentials read(@NotNull SecurityCommandRunner securityCommandRunner) {
+        // Always try the file first — covers non-macOS platforms and older Claude Code versions.
         Path path = credentialsPath();
         try {
-            if (!Files.exists(path)) {
-                return new ClaudeCliCredentials(false, null);
+            if (Files.exists(path)) {
+                ClaudeCliCredentials fromFile = parseCredentials(Files.readString(path));
+                if (fromFile.isLoggedIn()) return fromFile;
             }
-            return parseCredentials(Files.readString(path));
         } catch (IOException | RuntimeException e) {
-            LOG.warn("Failed to read Claude CLI credentials: " + e.getMessage());
-            return new ClaudeCliCredentials(false, null);
+            LOG.warn("Failed to read Claude CLI credentials file: " + e.getMessage());
         }
+
+        // On macOS, Claude Code 2.x stores tokens in the Keychain instead of the file.
+        if (isMac()) {
+            return readFromMacOsKeychain(securityCommandRunner);
+        }
+
+        return new ClaudeCliCredentials(false, null);
+    }
+
+    private static boolean isMac() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("mac");
+    }
+
+    /**
+     * Reads the credential JSON blob stored by Claude Code 2.x in the macOS Keychain
+     * (service name {@code "Claude Code-credentials"}) via the {@code security} CLI.
+     * Returns a "not logged in" instance if the entry is absent or unreadable.
+     */
+    @NotNull
+    private static ClaudeCliCredentials readFromMacOsKeychain(@NotNull SecurityCommandRunner securityCommandRunner) {
+        try {
+            String json = securityCommandRunner.run(List.of(
+                MACOS_SECURITY_BINARY, "find-generic-password", "-s", KEYCHAIN_SERVICE_NAME, "-w"));
+            if (json != null && !json.isBlank()) {
+                ClaudeCliCredentials creds = parseCredentials(json);
+                if (creds.isLoggedIn()) return creds;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.debug("Interrupted while reading Claude credentials from macOS Keychain");
+        } catch (IOException e) {
+            LOG.debug("Could not read Claude credentials from macOS Keychain: " + e.getMessage());
+        }
+        return new ClaudeCliCredentials(false, null);
+    }
+
+    @Nullable
+    private static String runSecurityCommand(@NotNull List<String> command) throws IOException, InterruptedException {
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+        Process process = pb.start();
+        if (!process.waitFor(SECURITY_COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly();
+            return null;
+        }
+        if (process.exitValue() != 0) {
+            return null;
+        }
+        return new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
     }
 
     /**
@@ -98,20 +164,43 @@ public final class ClaudeCliCredentials {
     }
 
     /**
-     * Deletes the credentials file, effectively logging the user out of the Claude CLI.
+     * Deletes the credentials file and, on macOS, the Keychain entry used by Claude Code 2.x.
      *
-     * @return true if the file was deleted, false if it did not exist or deletion failed
+     * @return true if any credential storage was deleted, false if nothing was removed
      */
     public static boolean logout() {
+        return logout(ClaudeCliCredentials::runSecurityCommand);
+    }
+
+    static boolean logout(@NotNull SecurityCommandRunner securityCommandRunner) {
+        boolean deletedFile = false;
         try {
-            return Files.deleteIfExists(credentialsPath());
+            deletedFile = Files.deleteIfExists(credentialsPath());
         } catch (IOException e) {
             LOG.warn("Failed to delete Claude CLI credentials: " + e.getMessage());
-            return false;
         }
+        return deletedFile || (isMac() && deleteMacOsKeychainCredentials(securityCommandRunner));
+    }
+
+    private static boolean deleteMacOsKeychainCredentials(@NotNull SecurityCommandRunner securityCommandRunner) {
+        try {
+            return securityCommandRunner.run(List.of(
+                MACOS_SECURITY_BINARY, "delete-generic-password", "-s", KEYCHAIN_SERVICE_NAME)) != null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.debug("Interrupted while deleting Claude credentials from macOS Keychain");
+        } catch (IOException e) {
+            LOG.debug("Could not delete Claude credentials from macOS Keychain: " + e.getMessage());
+        }
+        return false;
     }
 
     static Path credentialsPath() {
         return Path.of(System.getProperty("user.home"), ".claude", ".credentials.json");
+    }
+
+    @FunctionalInterface
+    interface SecurityCommandRunner {
+        @Nullable String run(@NotNull List<String> command) throws IOException, InterruptedException;
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/AuthLoginService.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/AuthLoginService.kt
@@ -253,7 +253,8 @@ class AuthLoginService(private val project: Project) {
      * Logs out the active agent by cleaning up its authentication data.
      * Always clears pending auth errors.
      *
-     * - **Claude CLI**: deletes `~/.claude/.credentials.json`
+     * - **Claude CLI**: deletes `~/.claude/.credentials.json` and the macOS Keychain entry used
+     *   by newer Claude Code versions
      * - **Kiro CLI**: delegates to `kiro-cli logout`
      * - **Copilot CLI**: runs `gh auth logout` because Copilot CLI authenticates
      *   via the `gh` token stored in the system keyring — there is no
@@ -269,7 +270,7 @@ class AuthLoginService(private val project: Project) {
             val profile = agentManager.getActiveProfile()
             val agentId = profile.id
 
-            // Claude CLI stores credentials at ~/.claude/.credentials.json, not in .agent-work/
+            // Claude CLI stores credentials outside .agent-work/ (file on most platforms, Keychain on macOS)
             if (agentId == ClaudeCliClient.PROFILE_ID) {
                 val deleted = ClaudeCliCredentials.logout()
                 LOG.info("Claude CLI logout: credentials deleted=$deleted")

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/agent/claude/ClaudeCliCredentialsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/agent/claude/ClaudeCliCredentialsTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -24,16 +25,23 @@ class ClaudeCliCredentialsTest {
     Path tempDir;
 
     private String originalUserHome;
+    private String originalOsName;
 
     @BeforeEach
     void redirectUserHome() {
         originalUserHome = System.getProperty("user.home");
+        originalOsName = System.getProperty("os.name");
         System.setProperty("user.home", tempDir.toString());
     }
 
     @AfterEach
     void restoreUserHome() {
         System.setProperty("user.home", originalUserHome);
+        if (originalOsName == null) {
+            System.clearProperty("os.name");
+        } else {
+            System.setProperty("os.name", originalOsName);
+        }
     }
 
     private void createCredentialsFile(String json) throws IOException {
@@ -50,6 +58,25 @@ class ClaudeCliCredentialsTest {
         ClaudeCliCredentials creds = ClaudeCliCredentials.read();
         assertFalse(creds.isLoggedIn());
         assertNull(creds.getDisplayName());
+    }
+
+    @Test
+    void fallsBackToMacOsKeychainWhenFileDoesNotExist() {
+        System.setProperty("os.name", "Mac OS X");
+
+        ClaudeCliCredentials creds = ClaudeCliCredentials.read(command -> {
+            assertEquals(List.of("/usr/bin/security", "find-generic-password", "-s",
+                "Claude Code-credentials", "-w"), command);
+            return """
+                {
+                  "oauthAccount": { "displayName": "Alice" },
+                  "claudeAiOauth": { "accessToken": "tok-keychain" }
+                }
+                """;
+        });
+
+        assertTrue(creds.isLoggedIn());
+        assertEquals("Alice", creds.getDisplayName());
     }
 
     // ── valid credentials ─────────────────────────────────────────────────────
@@ -95,6 +122,24 @@ class ClaudeCliCredentialsTest {
         assertEquals("alice@example.com", creds.getDisplayName());
     }
 
+    @Test
+    void prefersCredentialsFileOverMacOsKeychain() throws IOException {
+        System.setProperty("os.name", "Mac OS X");
+        createCredentialsFile("""
+            {
+              "oauthAccount": { "displayName": "File Alice" },
+              "claudeAiOauth": { "accessToken": "tok-file" }
+            }
+            """);
+
+        ClaudeCliCredentials creds = ClaudeCliCredentials.read(command -> {
+            throw new AssertionError("Keychain must not be queried when the credentials file is valid");
+        });
+
+        assertTrue(creds.isLoggedIn());
+        assertEquals("File Alice", creds.getDisplayName());
+    }
+
     // ── invalid / incomplete credentials ─────────────────────────────────────
 
     @Test
@@ -127,6 +172,22 @@ class ClaudeCliCredentialsTest {
         assertFalse(creds.isLoggedIn());
     }
 
+    @Test
+    void fallsBackToMacOsKeychainWhenFileIsMalformed() throws IOException {
+        System.setProperty("os.name", "Mac OS X");
+        createCredentialsFile("not-valid-json{{{");
+
+        ClaudeCliCredentials creds = ClaudeCliCredentials.read(command -> """
+            {
+              "oauthAccount": { "emailAddress": "alice@example.com" },
+              "claudeAiOauth": { "accessToken": "tok-keychain" }
+            }
+            """);
+
+        assertTrue(creds.isLoggedIn());
+        assertEquals("alice@example.com", creds.getDisplayName());
+    }
+
     // ── logout ────────────────────────────────────────────────────────────────
 
     @Test
@@ -141,6 +202,17 @@ class ClaudeCliCredentialsTest {
         assertTrue(ClaudeCliCredentials.logout(), "logout must return true when file existed");
         assertFalse(Files.exists(ClaudeCliCredentials.credentialsPath()),
             "credentials file must be deleted after logout");
+    }
+
+    @Test
+    void logoutDeletesMacOsKeychainCredential() {
+        System.setProperty("os.name", "Mac OS X");
+
+        assertTrue(ClaudeCliCredentials.logout(command -> {
+            assertEquals(List.of("/usr/bin/security", "delete-generic-password", "-s",
+                "Claude Code-credentials"), command);
+            return "";
+        }));
     }
 
     // ── parseCredentials (pure parsing, no filesystem) ─────────────────────


### PR DESCRIPTION
## Summary
- read Claude CLI credentials from the macOS Keychain when the file-based credentials are absent
- remove the Keychain credential on logout so plugin and CLI auth state stay in sync
- add coverage for Keychain-backed auth and logout behavior

## Testing
- ./gradlew :plugin-core:test --tests '*ClaudeCliCredentialsTest'