### PR TITLE
feat(search): support library/JDK scope in search_symbols and find_references

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/FindReferencesTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/FindReferencesTool.java
@@ -113,9 +113,7 @@ public final class FindReferencesTool extends NavigationTool {
             (element, offsetInElement) -> {
                 com.intellij.psi.PsiFile file = element.getContainingFile();
                 if (file == null || file.getVirtualFile() == null) return true;
-                String relPath = basePath != null
-                    ? relativize(basePath, file.getVirtualFile().getPath())
-                    : file.getVirtualFile().getPath();
+                String relPath = safeRelativize(basePath, file.getVirtualFile().getPath());
                 if (!filePattern.isEmpty() && ToolUtils.doesNotMatchGlob(relPath, filePattern, compiledGlob))
                     return true;
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/FindReferencesTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/FindReferencesTool.java
@@ -39,7 +39,9 @@ public final class FindReferencesTool extends NavigationTool {
     @Override
     public @NotNull String description() {
         return "Find all usages of a symbol throughout the project. Semantic — finds references even through renames and imports. " +
-            "Returns file paths and line numbers. For textual search, use search_text. For finding symbol definitions, use search_symbols.";
+            "Returns file paths and line numbers. Use the 'scope' parameter to also search inside library / JDK sources " +
+            "(after running download_sources). " +
+            "For textual search, use search_text. For finding symbol definitions, use search_symbols.";
     }
 
     @Override
@@ -56,7 +58,8 @@ public final class FindReferencesTool extends NavigationTool {
     public @NotNull JsonObject inputSchema() {
         return schema(
             Param.required("symbol", TYPE_STRING, "The exact symbol name to search for"),
-            Param.optional("file_pattern", TYPE_STRING, "Optional glob pattern to filter files (e.g., '*.java')", "")
+            Param.optional("file_pattern", TYPE_STRING, "Optional glob pattern to filter files (e.g., '*.java')", ""),
+            Param.optional(PARAM_SCOPE, TYPE_STRING, SCOPE_DESCRIPTION, SCOPE_PROJECT)
         );
     }
 
@@ -71,12 +74,13 @@ public final class FindReferencesTool extends NavigationTool {
             return "Error: 'symbol' parameter is required";
         String symbol = args.get(PARAM_SYMBOL).getAsString();
         String filePattern = args.has(PARAM_FILE_PATTERN) ? args.get(PARAM_FILE_PATTERN).getAsString() : "";
+        String scopeName = readScopeParam(args);
 
         showSearchFeedback("🔍 Finding references: " + symbol);
         String result = ApplicationManager.getApplication().runReadAction((Computable<String>) () -> {
             List<String> results = new ArrayList<>();
             String basePath = project.getBasePath();
-            GlobalSearchScope scope = GlobalSearchScope.projectScope(project);
+            GlobalSearchScope scope = resolveScope(scopeName);
 
             PsiElement definition = findDefinition(symbol, scope);
             if (definition != null) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
@@ -146,4 +146,50 @@ public abstract class NavigationTool extends Tool {
             results.add(String.format(FORMAT_LOCATION, relPath, line, type, lineText));
         }
     }
+
+    protected List<String> collectOutlineEntries(PsiFile psiFile, Document document) {
+        List<String> outline = new java.util.ArrayList<>();
+        psiFile.accept(new com.intellij.psi.PsiRecursiveElementWalkingVisitor() {
+            @Override
+            public void visitElement(@NotNull PsiElement element) {
+                if (element instanceof PsiNamedElement named) {
+                    String name = named.getName();
+                    if (name != null && !name.isEmpty()) {
+                        String type = ToolUtils.classifyElement(element);
+                        if (type != null) {
+                            int line = document.getLineNumber(element.getTextOffset()) + 1;
+                            outline.add(String.format("  %d: %s %s", line, type, name));
+                        }
+                    }
+                }
+                super.visitElement(element);
+            }
+        });
+        return outline;
+    }
+
+    protected void collectSymbolsFromFile(PsiFile psiFile, Document doc, com.intellij.openapi.vfs.VirtualFile vf,
+                                          String typeFilter, String basePath,
+                                          java.util.Set<String> seen, List<String> results) {
+        String relPath = safeRelativize(basePath, vf.getPath());
+        psiFile.accept(new com.intellij.psi.PsiRecursiveElementWalkingVisitor() {
+            @Override
+            public void visitElement(@NotNull PsiElement element) {
+                if (results.size() >= 200) return;
+                if (!(element instanceof PsiNamedElement named)) {
+                    super.visitElement(element);
+                    return;
+                }
+                String name = named.getName();
+                String type = ToolUtils.classifyElement(element);
+                if (name != null && type != null && type.equals(typeFilter)) {
+                    int line = doc.getLineNumber(element.getTextOffset()) + 1;
+                    if (seen.add(relPath + ":" + line)) {
+                        results.add(String.format(FORMAT_LOCATION, relPath, line, type, name));
+                    }
+                }
+                super.visitElement(element);
+            }
+        });
+    }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
@@ -32,9 +32,36 @@ public abstract class NavigationTool extends Tool {
     protected static final String FORMAT_LOCATION = "%s:%d [%s] %s";
     protected static final String FORMAT_LINE_REF = "%s:%d: %s";
     protected static final String PARAM_QUERY = "query";
+    protected static final String PARAM_SCOPE = "scope";
+    protected static final String SCOPE_PROJECT = "project";
+    protected static final String SCOPE_LIBRARIES = "libraries";
+    protected static final String SCOPE_ALL = "all";
+    protected static final String SCOPE_DESCRIPTION =
+        "Search scope: 'project' (default — only project sources, fastest), 'libraries' (only library/JDK sources — "
+            + "use after download_sources to look up symbols in dependencies), or 'all' (project + libraries). "
+            + "Default 'project' keeps result counts small; switch when you need symbols declared in dependency JARs.";
 
     protected NavigationTool(Project project) {
         super(project);
+    }
+
+    /**
+     * Resolves a user-supplied scope name to a {@link GlobalSearchScope}. Falls back to project scope
+     * when the value is missing or unrecognised so existing callers keep their current behaviour.
+     */
+    protected GlobalSearchScope resolveScope(String scopeName) {
+        if (scopeName == null) return GlobalSearchScope.projectScope(project);
+        return switch (scopeName.toLowerCase(java.util.Locale.ROOT)) {
+            case SCOPE_LIBRARIES -> com.intellij.psi.search.ProjectScope.getLibrariesScope(project);
+            case SCOPE_ALL -> GlobalSearchScope.allScope(project);
+            default -> GlobalSearchScope.projectScope(project);
+        };
+    }
+
+    protected String readScopeParam(com.google.gson.JsonObject args) {
+        return args.has(PARAM_SCOPE) && !args.get(PARAM_SCOPE).isJsonNull()
+            ? args.get(PARAM_SCOPE).getAsString()
+            : SCOPE_PROJECT;
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationTool.java
@@ -8,11 +8,9 @@ import com.github.catatafishen.agentbridge.services.ToolRegistry;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiNamedElement;
-import com.intellij.psi.PsiRecursiveElementWalkingVisitor;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.PsiSearchHelper;
 import com.intellij.psi.search.UsageSearchContext;
@@ -98,19 +96,40 @@ public abstract class NavigationTool extends Tool {
         return result[0];
     }
 
-    protected String buildReferenceEntry(com.intellij.psi.PsiReference ref, String filePattern, java.util.regex.Pattern compiledGlob, String basePath) {
+    protected String buildReferenceEntry(com.intellij.psi.PsiReference ref, String filePattern,
+                                         java.util.regex.Pattern compiledGlob, String basePath) {
         PsiElement refEl = ref.getElement();
         PsiFile file = refEl.getContainingFile();
         if (file == null || file.getVirtualFile() == null) return null;
-        String relPath = basePath != null
-            ? relativize(basePath, file.getVirtualFile().getPath())
-            : file.getVirtualFile().getPath();
+        String relPath = safeRelativize(basePath, file.getVirtualFile().getPath());
         if (!filePattern.isEmpty() && ToolUtils.doesNotMatchGlob(relPath, filePattern, compiledGlob)) return null;
         Document doc = FileDocumentManager.getInstance().getDocument(file.getVirtualFile());
         if (doc == null) return null;
         int line = doc.getLineNumber(refEl.getTextOffset()) + 1;
         String lineText = ToolUtils.getLineText(doc, line - 1);
         return String.format(FORMAT_LINE_REF, relPath, line, lineText);
+    }
+
+    /**
+     * Returns a safe, non-sensitive relative path for display:
+     * <ul>
+     *   <li>Files inside the project → project-relative path (normal behaviour)</li>
+     *   <li>JAR-internal paths ({@code .jar!/}) → the in-JAR portion only (e.g. {@code com/example/SomeClass.java})</li>
+     *   <li>Other external paths → just the filename, to avoid leaking user-specific home-directory paths</li>
+     * </ul>
+     */
+    protected static String safeRelativize(String basePath, String absolutePath) {
+        String p = absolutePath.replace('\\', '/');
+        if (basePath != null) {
+            String base = basePath.replace('\\', '/');
+            if (p.startsWith(base + "/")) return p.substring(base.length() + 1);
+        }
+        // JAR-internal source: strip the on-disk path, keep the in-JAR relative path
+        int jarSep = p.lastIndexOf(".jar!/");
+        if (jarSep >= 0) return p.substring(jarSep + ".jar!/".length());
+        // Unknown external path: emit only the filename to avoid leaking home-dir paths
+        int lastSlash = p.lastIndexOf('/');
+        return lastSlash >= 0 ? p.substring(lastSlash + 1) : p;
     }
 
     protected void addSymbolResult(PsiElement element, String basePath,
@@ -120,59 +139,11 @@ public abstract class NavigationTool extends Tool {
         Document doc = FileDocumentManager.getInstance().getDocument(file.getVirtualFile());
         if (doc == null) return;
         int line = doc.getLineNumber(element.getTextOffset()) + 1;
-        String relPath = basePath != null
-            ? relativize(basePath, file.getVirtualFile().getPath())
-            : file.getVirtualFile().getPath();
+        String relPath = safeRelativize(basePath, file.getVirtualFile().getPath());
         if (seen.add(relPath + ":" + line)) {
             String lineText = ToolUtils.getLineText(doc, line - 1);
             String type = ToolUtils.classifyElement(element);
             results.add(String.format(FORMAT_LOCATION, relPath, line, type, lineText));
         }
-    }
-
-    protected List<String> collectOutlineEntries(PsiFile psiFile, Document document) {
-        List<String> outline = new java.util.ArrayList<>();
-        psiFile.accept(new PsiRecursiveElementWalkingVisitor() {
-            @Override
-            public void visitElement(@NotNull PsiElement element) {
-                if (element instanceof PsiNamedElement named) {
-                    String name = named.getName();
-                    if (name != null && !name.isEmpty()) {
-                        String type = ToolUtils.classifyElement(element);
-                        if (type != null) {
-                            int line = document.getLineNumber(element.getTextOffset()) + 1;
-                            outline.add(String.format("  %d: %s %s", line, type, name));
-                        }
-                    }
-                }
-                super.visitElement(element);
-            }
-        });
-        return outline;
-    }
-
-    protected void collectSymbolsFromFile(PsiFile psiFile, Document doc, VirtualFile vf,
-                                          String typeFilter, String basePath,
-                                          java.util.Set<String> seen, List<String> results) {
-        String relPath = basePath != null ? relativize(basePath, vf.getPath()) : vf.getPath();
-        psiFile.accept(new PsiRecursiveElementWalkingVisitor() {
-            @Override
-            public void visitElement(@NotNull PsiElement element) {
-                if (results.size() >= 200) return;
-                if (!(element instanceof PsiNamedElement named)) {
-                    super.visitElement(element);
-                    return;
-                }
-                String name = named.getName();
-                String type = ToolUtils.classifyElement(element);
-                if (name != null && type != null && type.equals(typeFilter)) {
-                    int line = doc.getLineNumber(element.getTextOffset()) + 1;
-                    if (seen.add(relPath + ":" + line)) {
-                        results.add(String.format(FORMAT_LOCATION, relPath, line, type, name));
-                    }
-                }
-                super.visitElement(element);
-            }
-        });
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchSymbolsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchSymbolsTool.java
@@ -86,7 +86,7 @@ public final class SearchSymbolsTool extends NavigationTool {
         String result = ApplicationManager.getApplication().runReadAction((Computable<String>) () -> {
             if (query.isEmpty() || "*".equals(query)) {
                 if (!SCOPE_PROJECT.equalsIgnoreCase(scopeName)) {
-                    return "Wildcard symbol listing is only supported with scope='project'. "
+                    return "Error: Wildcard symbol listing is only supported with scope='project'. "
                         + "Use an exact query name when searching scope='libraries' or scope='all'.";
                 }
                 return searchWildcard(typeFilter);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchSymbolsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchSymbolsTool.java
@@ -46,7 +46,10 @@ public final class SearchSymbolsTool extends NavigationTool {
     public @NotNull String description() {
         return "Search for classes, methods, or fields by name using IntelliJ's symbol index. " +
             "Semantic search — finds symbols even if the text doesn't appear literally (e.g. inherited members). " +
-            "For textual/regex search across file contents, use search_text. For all usages of a specific symbol, use find_references.";
+            "Use the 'scope' parameter to look up symbols inside library / JDK sources " +
+            "(after running download_sources). " +
+            "For textual/regex search across file contents, use search_text. " +
+            "For all usages of a specific symbol, use find_references.";
     }
 
     @Override
@@ -63,7 +66,8 @@ public final class SearchSymbolsTool extends NavigationTool {
     public @NotNull JsonObject inputSchema() {
         return schema(
             Param.required("query", TYPE_STRING, "Symbol name to search for, or '*' to list all symbols in the project"),
-            Param.optional("type", TYPE_STRING, "Optional: filter by type (class, method, field, property). Default: all types", "")
+            Param.optional("type", TYPE_STRING, "Optional: filter by type (class, method, field, property). Default: all types", ""),
+            Param.optional(PARAM_SCOPE, TYPE_STRING, SCOPE_DESCRIPTION, SCOPE_PROJECT)
         );
     }
 
@@ -76,13 +80,18 @@ public final class SearchSymbolsTool extends NavigationTool {
     public @NotNull String execute(@NotNull JsonObject args) {
         String query = args.has(PARAM_QUERY) ? args.get(PARAM_QUERY).getAsString() : "";
         String typeFilter = args.has("type") ? args.get("type").getAsString() : "";
+        String scopeName = readScopeParam(args);
 
         showSearchFeedback("🔍 Searching symbols: " + query);
         String result = ApplicationManager.getApplication().runReadAction((Computable<String>) () -> {
             if (query.isEmpty() || "*".equals(query)) {
+                if (!SCOPE_PROJECT.equalsIgnoreCase(scopeName)) {
+                    return "Wildcard symbol listing is only supported with scope='project'. "
+                        + "Use an exact query name when searching scope='libraries' or scope='all'.";
+                }
                 return searchWildcard(typeFilter);
             }
-            return searchExact(query, typeFilter);
+            return searchExact(query, typeFilter, resolveScope(scopeName));
         });
         showSearchFeedback("✓ Symbol search complete: " + query);
         return result;
@@ -117,11 +126,10 @@ public final class SearchSymbolsTool extends NavigationTool {
         return results.size() + " " + typeFilter + " symbols:\n" + String.join("\n", results);
     }
 
-    private String searchExact(String query, String typeFilter) {
+    private String searchExact(String query, String typeFilter, GlobalSearchScope scope) {
         List<String> results = new ArrayList<>();
         Set<String> seen = new HashSet<>();
         String basePath = project.getBasePath();
-        GlobalSearchScope scope = GlobalSearchScope.projectScope(project);
 
         PsiSearchHelper.getInstance(project).processElementsWithWord(
             (element, offsetInElement) -> {

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationToolsExtendedTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationToolsExtendedTest.java
@@ -43,6 +43,7 @@ public class NavigationToolsExtendedTest extends BasePlatformTestCase {
 
     private GetFileOutlineTool getFileOutlineTool;
     private SearchSymbolsTool searchSymbolsTool;
+    private FindReferencesTool findReferencesTool;
     /**
      * Real temp directory for tests that need {@code LocalFileSystem#findFileByPath}.
      */
@@ -57,6 +58,7 @@ public class NavigationToolsExtendedTest extends BasePlatformTestCase {
             .setValue(ToolLayerSettings.FOLLOW_AGENT_FILES_KEY, "false");
         getFileOutlineTool = new GetFileOutlineTool(getProject());
         searchSymbolsTool = new SearchSymbolsTool(getProject());
+        findReferencesTool = new FindReferencesTool(getProject());
         tempDir = Files.createTempDirectory("nav-tools-test");
     }
 
@@ -71,8 +73,13 @@ public class NavigationToolsExtendedTest extends BasePlatformTestCase {
             // Remove temp files created during this test.
             try (var paths = Files.walk(tempDir)) {
                 paths.sorted(java.util.Comparator.reverseOrder())
-                    .map(Path::toFile)
-                    .forEach(java.io.File::delete);
+                    .forEach(p -> {
+                        try {
+                            Files.deleteIfExists(p);
+                        } catch (IOException ignored) {
+                            // Best-effort cleanup — not a test failure
+                        }
+                    });
             }
         } finally {
             super.tearDown();
@@ -80,18 +87,6 @@ public class NavigationToolsExtendedTest extends BasePlatformTestCase {
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
-
-    /**
-     * Creates a real file on disk and registers it in the VFS so that
-     * {@code LocalFileSystem#findFileByPath} can find it during {@code execute()}.
-     */
-    private String createTestFile(String name, String content) throws IOException {
-        Path file = tempDir.resolve(name);
-        Files.writeString(file, content);
-        VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByPath(file.toString());
-        assertNotNull("Failed to register test file in VFS: " + file, vf);
-        return file.toString();
-    }
 
     /**
      * Builds a {@link JsonObject} from alternating key/value String pairs.
@@ -114,13 +109,18 @@ public class NavigationToolsExtendedTest extends BasePlatformTestCase {
      * via {@code LocalFileSystem#findFileByPath}.
      */
     public void testGetFileOutlineWithJavaFile() throws Exception {
-        String path = createTestFile("OutlineClass.java", """
+        // Create a real disk file and register it in the VFS so LocalFileSystem can find it.
+        Path filePath = tempDir.resolve("OutlineClass.java");
+        Files.writeString(filePath, """
             public class OutlineClass {
                 public String greet() {
                     return "hello";
                 }
             }
             """);
+        VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath.toString());
+        assertNotNull("Failed to register test file in VFS: " + filePath, vf);
+        String path = filePath.toString();
 
         String result = getFileOutlineTool.execute(args("path", path));
 
@@ -280,5 +280,50 @@ public class NavigationToolsExtendedTest extends BasePlatformTestCase {
         // The wildcard path without a type filter returns a guidance message.
         assertTrue("Expected guidance about 'type' filter, got: " + result,
             result.contains("type"));
+    }
+
+    // ── FindReferencesTool ────────────────────────────────────────────────────
+
+    /**
+     * The tool schema must declare the {@code scope} parameter so MCP clients
+     * can advertise it to agents.
+     */
+    public void testFindReferencesToolSchemaDeclaresScopeParameter() {
+        JsonObject schema = findReferencesTool.inputSchema();
+        JsonObject properties = schema.getAsJsonObject("properties");
+
+        assertTrue("Schema must include 'scope' property", properties.has("scope"));
+        assertEquals("string",
+            properties.getAsJsonObject("scope").get("type").getAsString());
+    }
+
+    /**
+     * When {@code scope=libraries} is requested, the search must skip project
+     * sources entirely. A symbol declared in the project must therefore NOT
+     * appear in the results — proves the scope plumbing is honoured.
+     */
+    public void testFindReferencesLibraryScopeExcludesProjectSymbols() {
+        myFixture.addFileToProject(
+            "RefTarget_5522.java",
+            """
+                public class RefTarget_5522 {
+                    public void projectMethod() {}
+                }
+                """);
+        myFixture.addFileToProject(
+            "RefCaller_5522.java",
+            """
+                public class RefCaller_5522 {
+                    public void call() {
+                        new RefTarget_5522().projectMethod();
+                    }
+                }
+                """);
+
+        String result = findReferencesTool.execute(
+            args("symbol", "projectMethod", "scope", "libraries"));
+
+        assertFalse("Project symbol must not appear in libraries scope results, got: " + result,
+            result.contains("RefCaller_5522.java") || result.contains("projectMethod"));
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationToolsExtendedTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationToolsExtendedTest.java
@@ -323,7 +323,11 @@ public class NavigationToolsExtendedTest extends BasePlatformTestCase {
         String result = findReferencesTool.execute(
             args("symbol", "projectMethod", "scope", "libraries"));
 
-        assertFalse("Project symbol must not appear in libraries scope results, got: " + result,
-            result.contains("RefCaller_5522.java") || result.contains("projectMethod"));
+        // The "no references found" message naturally echoes the symbol name —
+        // assert only that no project file reference leaked through.
+        assertFalse("Project file must not appear in libraries scope results, got: " + result,
+            result.contains("RefCaller_5522.java") || result.contains("RefTarget_5522.java"));
+        assertTrue("Expected a 'no references' message, got: " + result,
+            result.contains("No references found"));
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationToolsExtendedTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/navigation/NavigationToolsExtendedTest.java
@@ -195,6 +195,77 @@ public class NavigationToolsExtendedTest extends BasePlatformTestCase {
     }
 
     /**
+     * Explicit {@code scope=project} must behave the same as the default and find
+     * a class declared in the project — guards backward compatibility for callers
+     * that always pass the parameter.
+     */
+    public void testSearchSymbolsExplicitProjectScopeFindsProjectSymbol() {
+        myFixture.addFileToProject(
+            "ScopedSymbol_4451.java",
+            """
+                public class ScopedSymbol_4451 {
+                }
+                """);
+
+        String result = searchSymbolsTool.execute(
+            args("query", "ScopedSymbol_4451", "scope", "project"));
+
+        assertFalse("Expected non-error result, got: " + result,
+            result.startsWith(ToolUtils.ERROR_PREFIX));
+        assertTrue("Expected class name in search result, got: " + result,
+            result.contains("ScopedSymbol_4451"));
+    }
+
+    /**
+     * When {@code scope=libraries} is requested, the search must skip project
+     * sources entirely. A class declared in the project must therefore NOT
+     * appear in the results — this proves the scope plumbing is honoured even
+     * if no library sources happen to be attached to the test fixture.
+     */
+    public void testSearchSymbolsLibraryScopeExcludesProjectSymbols() {
+        myFixture.addFileToProject(
+            "ProjectOnlyClass_8812.java",
+            """
+                public class ProjectOnlyClass_8812 {
+                }
+                """);
+
+        String result = searchSymbolsTool.execute(
+            args("query", "ProjectOnlyClass_8812", "scope", "libraries"));
+
+        assertFalse("Project symbol must not leak into libraries scope, got: " + result,
+            result.contains("ProjectOnlyClass_8812.java"));
+    }
+
+    /**
+     * Wildcard listing combined with a non-project scope is rejected with an
+     * actionable message instead of silently scanning every library file.
+     */
+    public void testSearchSymbolsWildcardWithLibraryScopeReturnsError() {
+        String result = searchSymbolsTool.execute(
+            args("query", "*", "type", "class", "scope", "libraries"));
+
+        assertTrue("Expected wildcard-scope error, got: " + result,
+            result.contains("Wildcard symbol listing is only supported with scope='project'"));
+    }
+
+    /**
+     * The tool schema must declare the new {@code scope} parameter so MCP clients
+     * can advertise it to agents.
+     */
+    public void testSearchSymbolsSchemaDeclaresScopeParameter() {
+        JsonObject schema = searchSymbolsTool.inputSchema();
+        JsonObject properties = schema.getAsJsonObject("properties");
+
+        assertTrue("Schema must include 'scope' property",
+            properties.has("scope"));
+        assertEquals("string",
+            properties.getAsJsonObject("scope").get("type").getAsString());
+        assertEquals("project",
+            properties.getAsJsonObject("scope").get("default").getAsString());
+    }
+
+    /**
      * When the {@code query} parameter is absent, the tool defaults to an empty
      * query which triggers the wildcard path. Without a {@code type} filter, the
      * tool returns guidance asking for a type filter rather than an empty result.


### PR DESCRIPTION
Closes #303

## Problem

`search_symbols` and `find_references` were hard-coded to
`GlobalSearchScope.projectScope(project)`, so they could never find
symbols declared in library or JDK sources — even when the user had
successfully run `download_sources`. The agent then had to fall back to
manually grepping the downloaded sources jars.

`get_class_outline` and `get_documentation` already use `allScope` and
worked fine for library lookups, but the symbol/reference search tools
didn't.

## Fix

Add an optional **`scope`** parameter (`project` | `libraries` | `all`)
to both tools, plumbed through a shared helper on `NavigationTool`.

- **Default stays `project`** — existing callers see no change in result
  counts or token usage.
- Agents opt in to `libraries` (only dependency sources) or `all` (project
  + libraries) when they need to resolve symbols from JDK/dependency JARs.
- Tool descriptions updated so the agent knows when to switch and that
  `download_sources` should be run first.

Wildcard listing (`query: '*'`) stays project-only — cross-library
wildcard would explode token budgets. Using a non-project scope with `*`
returns an actionable error message instead of silently scanning
thousands of files.

## Backward compatibility

Fully backward compatible — `scope` defaults to `project`.

---

> ⚠️ This PR was opened by GitHub Copilot on behalf of @catatafishen.