### PR TITLE
fix(ui): scroll session tab as a whole; transparent file-tree background

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
@@ -8,9 +8,7 @@ import com.intellij.openapi.fileTypes.FileTypeManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.treeStructure.Tree;
-import com.intellij.util.ui.JBUI;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -51,10 +49,15 @@ final class ProjectFilesPanel extends JPanel {
     ProjectFilesPanel(@NotNull Project project) {
         super(new BorderLayout());
         this.project = project;
+        setOpaque(false);
 
         tree.setRootVisible(false);
         tree.setShowsRootHandles(true);
         tree.setCellRenderer(new FileNodeRenderer());
+        // Let the parent's background show through so dark mode doesn't
+        // paint a gray rectangle behind the file rows.
+        tree.setOpaque(false);
+        tree.setBackground(new Color(0, 0, 0, 0));
         tree.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
@@ -67,9 +70,9 @@ final class ProjectFilesPanel extends JPanel {
             }
         });
 
-        JBScrollPane scrollPane = new JBScrollPane(tree);
-        scrollPane.setBorder(JBUI.Borders.empty());
-        add(scrollPane, BorderLayout.CENTER);
+        // No internal scroll pane: the tree expands to its preferred height so the
+        // outer SessionStatsPanel scroll pane scrolls the whole side panel as one.
+        add(tree, BorderLayout.CENTER);
         refresh();
     }
 
@@ -306,14 +309,18 @@ final class ProjectFilesPanel extends JPanel {
     }
 
     private static final class FileNodeRenderer extends DefaultTreeCellRenderer {
+        FileNodeRenderer() {
+            // DefaultTreeCellRenderer.paint() fills the cell with this color even when
+            // setOpaque(false). Null it out so the tree (and parent) background shows through.
+            setBackgroundNonSelectionColor(null);
+        }
+
         @Override
         public Component getTreeCellRendererComponent(JTree tree, Object value, boolean sel,
                                                       boolean expanded, boolean leaf, int row,
                                                       boolean hasFocus) {
             Component c = super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
             if (!sel) {
-                // DefaultTreeCellRenderer can paint a non-transparent background in dark themes;
-                // clear it so the tree background shows through on non-selected rows.
                 setOpaque(false);
                 if (c instanceof JLabel label) {
                     label.setOpaque(false);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
@@ -316,6 +316,14 @@ final class ProjectFilesPanel extends JPanel {
         }
 
         @Override
+        public void updateUI() {
+            super.updateUI();
+            // L&F change can reset backgroundNonSelectionColor; re-apply the null so that
+            // the transparent background survives theme switches.
+            setBackgroundNonSelectionColor(null);
+        }
+
+        @Override
         public Component getTreeCellRendererComponent(JTree tree, Object value, boolean sel,
                                                       boolean expanded, boolean leaf, int row,
                                                       boolean hasFocus) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -12,10 +12,12 @@ import com.github.catatafishen.agentbridge.ui.UsageGraphPanel;
 import com.github.catatafishen.agentbridge.ui.renderers.ToolRenderers;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.project.Project;
+import com.intellij.ui.components.JBScrollPane;
 import com.intellij.util.ui.JBUI;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import javax.swing.ScrollPaneConstants;
 import java.awt.*;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -201,7 +203,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         // scroll pane (below) handles scrolling for the entire side panel.
         filesPanel = new ProjectFilesPanel(project);
 
-        JPanel wrapper = new JPanel();
+        JPanel wrapper = new ScrollablePanel();
         wrapper.setLayout(new BoxLayout(wrapper, BoxLayout.Y_AXIS));
         wrapper.setOpaque(false);
         // Each child sticks to its preferred height; together they grow the
@@ -211,15 +213,12 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         wrapper.add(content);
         wrapper.add(filesPanel);
 
-        com.intellij.ui.components.JBScrollPane scrollPane =
-            new com.intellij.ui.components.JBScrollPane(wrapper);
+        JBScrollPane scrollPane = new JBScrollPane(wrapper);
         scrollPane.setBorder(JBUI.Borders.empty());
         scrollPane.setOpaque(false);
         scrollPane.getViewport().setOpaque(false);
-        scrollPane.setHorizontalScrollBarPolicy(
-            javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        scrollPane.setVerticalScrollBarPolicy(
-            javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+        scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        scrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
 
         add(scrollPane, BorderLayout.CENTER);
 
@@ -451,6 +450,38 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
             }
         } else {
             resetsRow.setVisible(false);
+        }
+    }
+
+    /**
+     * A {@link JPanel} that implements {@link Scrollable} so that the containing
+     * {@link JBScrollPane} tracks the viewport width and never shows a horizontal
+     * scrollbar even when a child (e.g. the file tree) has a wide preferred width.
+     */
+    private static final class ScrollablePanel extends JPanel implements Scrollable {
+        @Override
+        public Dimension getPreferredScrollableViewportSize() {
+            return getPreferredSize();
+        }
+
+        @Override
+        public int getScrollableUnitIncrement(Rectangle visibleRect, int orientation, int direction) {
+            return 16;
+        }
+
+        @Override
+        public int getScrollableBlockIncrement(Rectangle visibleRect, int orientation, int direction) {
+            return visibleRect.height;
+        }
+
+        @Override
+        public boolean getScrollableTracksViewportWidth() {
+            return true;
+        }
+
+        @Override
+        public boolean getScrollableTracksViewportHeight() {
+            return false;
         }
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -197,15 +197,31 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         content.add(billingGrid);
         content.add(createSectionHeader("Project files"));
 
-        // Project files tree fills remaining height
+        // Project files tree expands to its full preferred height; the outer
+        // scroll pane (below) handles scrolling for the entire side panel.
         filesPanel = new ProjectFilesPanel(project);
 
-        JPanel wrapper = new JPanel(new BorderLayout());
+        JPanel wrapper = new JPanel();
+        wrapper.setLayout(new BoxLayout(wrapper, BoxLayout.Y_AXIS));
         wrapper.setOpaque(false);
-        wrapper.add(content, BorderLayout.NORTH);
-        wrapper.add(filesPanel, BorderLayout.CENTER);
+        // Each child sticks to its preferred height; together they grow the
+        // wrapper beyond the viewport so the outer scroll pane can scroll it.
+        content.setAlignmentX(Component.LEFT_ALIGNMENT);
+        filesPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        wrapper.add(content);
+        wrapper.add(filesPanel);
 
-        add(wrapper, BorderLayout.CENTER);
+        com.intellij.ui.components.JBScrollPane scrollPane =
+            new com.intellij.ui.components.JBScrollPane(wrapper);
+        scrollPane.setBorder(JBUI.Borders.empty());
+        scrollPane.setOpaque(false);
+        scrollPane.getViewport().setOpaque(false);
+        scrollPane.setHorizontalScrollBarPolicy(
+            javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        scrollPane.setVerticalScrollBarPolicy(
+            javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+
+        add(scrollPane, BorderLayout.CENTER);
 
         animationTimer = new Timer(33, e -> {
             long now = System.currentTimeMillis();


### PR DESCRIPTION
Addresses two UI issues in the Session tab.

## Behavior changes

### Session tab now scrolls as one
Previously the **Project files** tree had its own internal scrollbar, and the session statistics above it stayed pinned at the top. As soon as a project had more than a handful of tracked files, only the small inner area scrolled while the visible stat blocks ate most of the side panel.

Now the whole session panel scrolls as a single unit:
- `ProjectFilesPanel` drops its inner `JBScrollPane`; the tree expands to its preferred height.
- `SessionStatsPanel` stacks `content` and `filesPanel` in a `Y_AXIS` `BoxLayout` wrapper, hosted in a single outer `JBScrollPane` (vertical-only).

### Transparent background behind file rows in dark mode
The file-tree rows showed a gray rectangle behind the labels in dark themes because:
1. The tree itself was opaque and painted its own background.
2. `DefaultTreeCellRenderer.paint()` fills each cell with `backgroundNonSelectionColor` even when `setOpaque(false)` is set.

Fixed by:
- Making the tree non-opaque with a fully transparent background.
- Nulling `backgroundNonSelectionColor` in `FileNodeRenderer`.

## Verification
- `build_project plugin-core` clean (0 errors, 0 warnings).
- All 10 `ui.side` tests pass.

---

> **Disclaimer:** This pull request was prepared by GitHub Copilot on behalf of @catatafishen.