### PR TITLE
fix(ui): unify diff and todo placeholder padding

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/DiffPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/DiffPanel.java
@@ -5,6 +5,7 @@ import com.github.catatafishen.agentbridge.psi.review.RevertReasonDialog;
 import com.github.catatafishen.agentbridge.psi.review.ReviewItem;
 import com.github.catatafishen.agentbridge.psi.review.ReviewSessionTopic;
 import com.github.catatafishen.agentbridge.settings.McpServerSettings;
+import com.github.catatafishen.agentbridge.ui.util.EmptyStateStyles;
 import com.github.catatafishen.agentbridge.ui.util.TimestampDisplayFormatter;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.Disposable;
@@ -112,6 +113,7 @@ public final class DiffPanel extends JPanel implements Disposable {
 
         emptyLabel = new JBLabel("", SwingConstants.CENTER);
         emptyLabel.setForeground(JBColor.GRAY);
+        emptyLabel.setBorder(EmptyStateStyles.PLACEHOLDER_PADDING);
         JPanel emptyStatePanel = new JPanel(new GridBagLayout());
         JPanel column = new JPanel();
         column.setLayout(new BoxLayout(column, BoxLayout.Y_AXIS));

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/TodoPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/TodoPanel.java
@@ -2,6 +2,7 @@ package com.github.catatafishen.agentbridge.ui.side;
 
 import com.github.catatafishen.agentbridge.services.ActiveAgentManager;
 import com.github.catatafishen.agentbridge.ui.MarkdownRenderer;
+import com.github.catatafishen.agentbridge.ui.util.EmptyStateStyles;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
@@ -82,6 +83,7 @@ final class TodoPanel extends JPanel implements Disposable {
         );
         emptyLabel.setVerticalAlignment(SwingConstants.CENTER);
         emptyLabel.setHorizontalAlignment(SwingConstants.CENTER);
+        emptyLabel.setBorder(EmptyStateStyles.PLACEHOLDER_PADDING);
 
         contentPanel = new JPanel(new BorderLayout());
         contentPanel.add(emptyLabel, BorderLayout.CENTER);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/util/EmptyStateStyles.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/util/EmptyStateStyles.java
@@ -1,0 +1,16 @@
+package com.github.catatafishen.agentbridge.ui.util;
+
+import com.intellij.util.ui.JBUI;
+
+import javax.swing.border.Border;
+
+/**
+ * Shared spacing for centered empty-state labels across side-panel tabs.
+ */
+public final class EmptyStateStyles {
+
+    public static final Border PLACEHOLDER_PADDING = JBUI.Borders.empty(6, 8, 8, 8);
+
+    private EmptyStateStyles() {
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared empty-state padding constant
- use it for the Diff tab placeholder label
- use it for the Todo tab placeholder label so both tabs match

## Notes
The Todo tab spacing was the better baseline, so this change makes the Diff empty state follow the same padding instead of relying on slightly different container layout behavior.

## Verification
- plugin-core module build passes cleanly

---

> **Disclaimer:** This pull request was prepared by GitHub Copilot on behalf of @catatafishen.
