### PR TITLE
fix(review): make pending review explicit to agents

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProvider.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProvider.java
@@ -80,8 +80,7 @@ public final class AgentEditNotificationProvider implements EditorNotificationPr
 
     /**
      * Builds the banner text with file and change counters.
-     * Example:
-     * "REVIEW PENDING — user has not reviewed this file yet. Do not commit or push. File 3/7 · 5 changes"
+     * Example: "Review pending: File 3/7 · 5 changes"
      */
     private static @NotNull String buildStatusText(@NotNull Project project,
                                                    @NotNull VirtualFile file) {
@@ -105,10 +104,9 @@ public final class AgentEditNotificationProvider implements EditorNotificationPr
     }
 
     static @NotNull String formatBannerText(int fileIndex, int fileTotal, int changeCount) {
-        StringBuilder sb = new StringBuilder(
-            "REVIEW PENDING — user has not reviewed this file yet. Do not commit or push.");
+        StringBuilder sb = new StringBuilder("Review pending: ");
         if (fileTotal > 0 || changeCount > 0) {
-            sb.append(' ');
+            // keep the short summary on the same line for the human-facing editor banner
         }
         if (fileTotal > 0) {
             sb.append("File ").append(Math.max(fileIndex, 1)).append('/').append(fileTotal);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProvider.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProvider.java
@@ -80,7 +80,8 @@ public final class AgentEditNotificationProvider implements EditorNotificationPr
 
     /**
      * Builds the banner text with file and change counters.
-     * Example: "Review: File 3/7 · 5 changes"
+     * Example:
+     * "REVIEW PENDING — user has not reviewed this file yet. Do not commit or push. File 3/7 · 5 changes"
      */
     private static @NotNull String buildStatusText(@NotNull Project project,
                                                    @NotNull VirtualFile file) {
@@ -100,7 +101,15 @@ public final class AgentEditNotificationProvider implements EditorNotificationPr
         List<ChangeRange> ranges = session.computeRanges(file);
         int changeCount = ranges.size();
 
-        StringBuilder sb = new StringBuilder("Review: ");
+        return formatBannerText(fileIndex, fileTotal, changeCount);
+    }
+
+    static @NotNull String formatBannerText(int fileIndex, int fileTotal, int changeCount) {
+        StringBuilder sb = new StringBuilder(
+            "REVIEW PENDING — user has not reviewed this file yet. Do not commit or push.");
+        if (fileTotal > 0 || changeCount > 0) {
+            sb.append(' ');
+        }
         if (fileTotal > 0) {
             sb.append("File ").append(Math.max(fileIndex, 1)).append('/').append(fileTotal);
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProvider.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProvider.java
@@ -105,9 +105,6 @@ public final class AgentEditNotificationProvider implements EditorNotificationPr
 
     static @NotNull String formatBannerText(int fileIndex, int fileTotal, int changeCount) {
         StringBuilder sb = new StringBuilder("Review pending: ");
-        if (fileTotal > 0 || changeCount > 0) {
-            // keep the short summary on the same line for the human-facing editor banner
-        }
         if (fileTotal > 0) {
             sb.append("File ").append(Math.max(fileIndex, 1)).append('/').append(fileTotal);
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSession.java
@@ -970,7 +970,14 @@ public final class AgentEditSession implements Disposable, PersistentStateCompon
         return n;
     }
 
-    private boolean hasPendingIn(@NotNull Collection<String> scopedPaths) {
+    /**
+     * Whether any PENDING tracked path lies inside {@code scopedPaths}. Used by
+     * {@link #awaitReviewForPaths} for scope-limited gating.
+     * <p>Package-private so regression tests can assert the contract that
+     * git-amend must rely on (an empty {@code scopedPaths} never reports pending,
+     * even when the unscoped session has pending changes).
+     */
+    boolean hasPendingIn(@NotNull Collection<String> scopedPaths) {
         Set<String> scope = scopedPaths instanceof Set ? (Set<String>) scopedPaths : new HashSet<>(scopedPaths);
         for (Map.Entry<String, ApprovalState> e : approvals.entrySet()) {
             if (e.getValue() == ApprovalState.PENDING && pathIsTracked(e.getKey()) && scope.contains(e.getKey())) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
@@ -85,20 +85,27 @@ public final class GitCommitTool extends GitTool {
         }
 
         boolean commitAll = resolveCommitAll(args);
+        boolean isAmend = resolveAmend(args);
 
         // Compute which files will be committed, then only gate on those paths.
         // This prevents unrelated PENDING review items from blocking the commit.
-        Collection<String> filesToCommit = resolveFilesToCommit(commitAll, root);
-        String reviewError = AgentEditSession.getInstance(project)
-            .awaitReviewForPaths("git commit", filesToCommit);
+        // For --amend we don't compute filesToCommit (it's not used for gating) — we
+        // gate unconditionally via awaitReviewCompletion to keep amends safe even when
+        // the staged file set looks empty/irrelevant.
+        AgentEditSession session = AgentEditSession.getInstance(project);
+        String reviewError;
+        if (isAmend) {
+            reviewError = session.awaitReviewCompletion("git commit --amend");
+        } else {
+            Collection<String> filesToCommit = resolveFilesToCommit(commitAll, root);
+            reviewError = session.awaitReviewForPaths("git commit", filesToCommit);
+        }
         if (reviewError != null) return reviewError;
 
         if (commitAll) {
             // Stage all changes including new untracked files (equivalent to git add -A)
             runGitIn(root, "add", "-A");
         }
-
-        boolean isAmend = resolveAmend(args);
 
         // Pre-commit check: verify there are staged changes (skip for amend — message-only amends are valid)
         if (!isAmend) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
@@ -160,9 +160,9 @@ public final class GitCommitTool extends GitTool {
                     if (!trimmed.isEmpty()) paths.add(trimmed);
                 }
                 if (!paths.isEmpty()) {
-                    var session = com.github.catatafishen.agentbridge.psi.PlatformApiCompat
+                    var pruneSession = com.github.catatafishen.agentbridge.psi.PlatformApiCompat
                         .getService(project, com.github.catatafishen.agentbridge.psi.review.AgentEditSession.class);
-                    if (session != null) session.removeApprovedForCommit(paths);
+                    if (pruneSession != null) pruneSession.removeApprovedForCommit(paths);
                 }
             }
         } catch (Throwable ignored) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetHighlightsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetHighlightsTool.java
@@ -29,6 +29,9 @@ import java.util.concurrent.TimeoutException;
 public final class GetHighlightsTool extends QualityTool {
 
     private static final Logger LOG = Logger.getInstance(GetHighlightsTool.class);
+    static final String REVIEW_PENDING_AGENT_NOTE =
+        "[REVIEW_PENDING] User review is still pending for this file. "
+            + "Agent git commit/push/amend must wait for approval or rejection in the Review panel.";
 
     private static final String PARAM_INCLUDE_UNINDEXED = "include_unindexed";
 
@@ -295,7 +298,10 @@ public final class GetHighlightsTool extends QualityTool {
                 }
 
                 var editor = editors[0];
-                List<String> notifications = PlatformApiCompat.collectEditorNotificationTexts(project, vf, editor);
+                List<String> notifications = PlatformApiCompat.collectEditorNotificationTexts(project, vf, editor)
+                    .stream()
+                    .map(GetHighlightsTool::formatEditorNotificationForAgent)
+                    .toList();
 
                 future.complete(notifications);
             } catch (Exception e) {
@@ -303,5 +309,12 @@ public final class GetHighlightsTool extends QualityTool {
             }
         });
         return future.get(10, TimeUnit.SECONDS);
+    }
+
+    static @NotNull String formatEditorNotificationForAgent(@NotNull String notification) {
+        if (!notification.startsWith("[BANNER] Review pending:")) {
+            return notification;
+        }
+        return notification + "\n" + REVIEW_PENDING_AGENT_NOTE;
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetHighlightsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetHighlightsTool.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeoutException;
 public final class GetHighlightsTool extends QualityTool {
 
     private static final Logger LOG = Logger.getInstance(GetHighlightsTool.class);
-    static final String REVIEW_PENDING_AGENT_NOTE =
+    private static final String REVIEW_PENDING_AGENT_NOTE =
         "[REVIEW_PENDING] User review is still pending for this file. "
             + "Agent git commit/push/amend must wait for approval or rejection in the Review panel.";
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProviderTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProviderTest.java
@@ -8,15 +8,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class AgentEditNotificationProviderTest {
 
     @Test
-    void bannerTextExplicitlyBlocksCommitAndPush() {
+    void bannerTextLeadsWithReviewPendingState() {
         String msg = AgentEditNotificationProvider.formatBannerText(1, 3, 2);
 
-        assertTrue(msg.startsWith("REVIEW PENDING"),
+        assertTrue(msg.startsWith("Review pending:"),
             "Banner should lead with the pending-review state: " + msg);
-        assertTrue(msg.contains("user has not reviewed this file yet"),
-            "Banner should say the user has not reviewed the file yet: " + msg);
-        assertTrue(msg.contains("Do not commit or push"),
-            "Banner should explicitly block commit/push: " + msg);
         assertTrue(msg.contains("File 1/3"),
             "Banner should still include the file counter: " + msg);
         assertTrue(msg.contains("2 changes"),

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProviderTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProviderTest.java
@@ -1,0 +1,41 @@
+package com.github.catatafishen.agentbridge.psi.review;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AgentEditNotificationProviderTest {
+
+    @Test
+    void bannerTextExplicitlyBlocksCommitAndPush() {
+        String msg = AgentEditNotificationProvider.formatBannerText(1, 3, 2);
+
+        assertTrue(msg.startsWith("REVIEW PENDING"),
+            "Banner should lead with the pending-review state: " + msg);
+        assertTrue(msg.contains("user has not reviewed this file yet"),
+            "Banner should say the user has not reviewed the file yet: " + msg);
+        assertTrue(msg.contains("Do not commit or push"),
+            "Banner should explicitly block commit/push: " + msg);
+        assertTrue(msg.contains("File 1/3"),
+            "Banner should still include the file counter: " + msg);
+        assertTrue(msg.contains("2 changes"),
+            "Banner should still include the change counter: " + msg);
+    }
+
+    @Test
+    void bannerTextFallsBackWhenCountersAreEmpty() {
+        String msg = AgentEditNotificationProvider.formatBannerText(0, 0, 0);
+
+        assertTrue(msg.contains("No outstanding changes"),
+            "Banner should remain readable when counters are unavailable: " + msg);
+    }
+
+    @Test
+    void bannerTextIsDeterministic() {
+        assertEquals(
+            AgentEditNotificationProvider.formatBannerText(2, 5, 4),
+            AgentEditNotificationProvider.formatBannerText(2, 5, 4)
+        );
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSessionAmendGateContractTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/AgentEditSessionAmendGateContractTest.java
@@ -1,0 +1,67 @@
+package com.github.catatafishen.agentbridge.psi.review;
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Regression test for the contract that {@link com.github.catatafishen.agentbridge.psi.tools.git.GitCommitTool}
+ * relies on for {@code --amend}.
+ *
+ * <p>{@code git_commit --amend} cannot be scoped to a known set of paths because the amend
+ * rewrites a previous commit in its entirety, including paths that no longer appear in
+ * {@code resolveFilesToCommit(...)}. If amend used the scoped gate
+ * ({@link AgentEditSession#awaitReviewForPaths}) with an empty path collection, the gate would
+ * report no pending review and let the amend proceed — silently overwriting an in-progress
+ * agent edit that the user has not yet approved.
+ *
+ * <p>This test pins down the contract:
+ * <ul>
+ *   <li>{@link AgentEditSession#hasPendingChanges()} reports true once a tracked path is
+ *       registered as new.</li>
+ *   <li>{@link AgentEditSession#hasPendingIn(java.util.Collection)} returns {@code false} for
+ *       an empty scope, even when the unscoped session has pending changes.</li>
+ *   <li>{@link AgentEditSession#hasPendingIn(java.util.Collection)} only returns {@code true}
+ *       when the pending path itself appears in the scope.</li>
+ * </ul>
+ *
+ * <p>If anyone accidentally swaps {@code awaitReviewCompletion} back to
+ * {@code awaitReviewForPaths(...)} on the amend branch, this test still passes — but a
+ * companion test in {@code GitToolsTest} would then visibly fail because the amend gate would
+ * stop blocking. Together they document the invariant.
+ */
+public class AgentEditSessionAmendGateContractTest extends BasePlatformTestCase {
+
+    public void testEmptyScopeNeverReportsPending_evenWhenSessionHasPendingChanges() {
+        AgentEditSession session = AgentEditSession.getInstance(getProject());
+        String basePath = getProject().getBasePath();
+        assertNotNull("Test project must have a base path", basePath);
+
+        String trackedPath = basePath + "/amend-gate-contract.txt";
+        session.registerNewFile(trackedPath);
+
+        try {
+            assertTrue(
+                "registerNewFile must mark the path PENDING so the unscoped gate would block",
+                session.hasPendingChanges());
+
+            assertFalse(
+                "Empty scope must NOT report pending — this is exactly why git_commit --amend "
+                    + "uses the unscoped awaitReviewCompletion gate.",
+                session.hasPendingIn(Collections.emptyList()));
+
+            assertTrue(
+                "Sanity: scoping to the actual pending path must report pending.",
+                session.hasPendingIn(List.of(trackedPath)));
+
+            assertFalse(
+                "Sanity: scoping to an unrelated path must not report pending.",
+                session.hasPendingIn(List.of(basePath + "/some-other-file.txt")));
+        } finally {
+            // Approve so subsequent tests don't see leftover PENDING state.
+            session.acceptAll();
+            session.removeAllApproved();
+        }
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetHighlightsToolNotificationFormatTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetHighlightsToolNotificationFormatTest.java
@@ -1,0 +1,27 @@
+package com.github.catatafishen.agentbridge.psi.tools.quality;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GetHighlightsToolNotificationFormatTest {
+
+    @Test
+    void reviewBannerGetsAgentOnlyReviewNote() {
+        String formatted = GetHighlightsTool.formatEditorNotificationForAgent(
+            "[BANNER] Review pending: File 1/2 · 3 changes");
+
+        assertTrue(formatted.contains("[REVIEW_PENDING]"),
+            "Review banners should be expanded with an agent-only review note: " + formatted);
+        assertTrue(formatted.contains("must wait for approval or rejection"),
+            "The note should explicitly block agent-side git operations: " + formatted);
+    }
+
+    @Test
+    void nonReviewNotificationsPassThroughUnchanged() {
+        String notification = "[BANNER] SDK mismatch";
+
+        assertEquals(notification, GetHighlightsTool.formatEditorNotificationForAgent(notification));
+    }
+}


### PR DESCRIPTION
## Summary
- keep the human-facing editor banner concise as `Review pending: ...`
- append an explicit `[REVIEW_PENDING]` guidance line in `get_highlights` output for agents
- gate `git_commit --amend` on the full pending-review set so amend cannot bypass review with an empty file set

## Why
The important instruction is agent-specific, not human-specific: a human can choose to commit, but the agent should be told clearly that review is still pending and that git commit/push/amend must wait. Separately, the git tool itself should enforce that rule for amend.

## Verification
- plugin-core module build passes cleanly
- review, quality, and git test suites pass

---

> **Disclaimer:** This pull request was prepared by GitHub Copilot on behalf of @catatafishen.
