### PR TITLE
feat: multi-repo git support

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
@@ -547,12 +547,30 @@ public final class PlatformApiCompat {
      */
     public static @Nullable String runIdeGitCommand(@NotNull Project project, @NotNull String[] args) {
         if (args.length == 0) return null;
-
-        git4idea.commands.GitCommand command = IDE_GIT_COMMAND_MAP.get(args[0]);
-        if (command == null) return null;
-
         git4idea.repo.GitRepository repo = getRepository(project);
         if (repo == null) return null;
+        return runIdeGitCommandWithRepo(project, repo, args);
+    }
+
+    /**
+     * Runs a Git command using the repo rooted at {@code rootPath}.
+     * Falls back to {@link #runIdeGitCommand} if no repo is found at that path.
+     */
+    public static @Nullable String runIdeGitCommandIn(
+        @NotNull Project project, @NotNull String rootPath, @NotNull String[] args) {
+        if (args.length == 0) return null;
+        git4idea.repo.GitRepository repo = getRepositoryForRoot(project, rootPath);
+        if (repo == null) {
+            repo = getRepository(project);
+            if (repo == null) return null;
+        }
+        return runIdeGitCommandWithRepo(project, repo, args);
+    }
+
+    private static @Nullable String runIdeGitCommandWithRepo(
+        @NotNull Project project, @NotNull git4idea.repo.GitRepository repo, @NotNull String[] args) {
+        git4idea.commands.GitCommand command = IDE_GIT_COMMAND_MAP.get(args[0]);
+        if (command == null) return null;
 
         git4idea.commands.GitLineHandler handler =
             new git4idea.commands.GitLineHandler(project, repo.getRoot(), command);
@@ -580,8 +598,7 @@ public final class PlatformApiCompat {
      * Returns null if Git4Idea is unavailable or no repositories are registered.
      */
     public static @Nullable git4idea.repo.GitRepository getRepository(@NotNull Project project) {
-        java.util.List<git4idea.repo.GitRepository> repos =
-            git4idea.repo.GitRepositoryManager.getInstance(project).getRepositories();
+        java.util.List<git4idea.repo.GitRepository> repos = getRepositories(project);
         if (repos.isEmpty()) return null;
 
         git4idea.repo.GitRepository repo = repos.getFirst();
@@ -595,12 +612,43 @@ public final class PlatformApiCompat {
     }
 
     /**
+     * Returns all git repositories registered in this project.
+     * Returns an empty list if Git4Idea is unavailable or no repositories are registered.
+     */
+    public static @NotNull java.util.List<git4idea.repo.GitRepository> getRepositories(@NotNull Project project) {
+        try {
+            return git4idea.repo.GitRepositoryManager.getInstance(project).getRepositories();
+        } catch (NoClassDefFoundError e) {
+            return java.util.Collections.emptyList();
+        }
+    }
+
+    /**
+     * Returns the GitRepository whose root is exactly {@code rootPath}, or null if not found.
+     */
+    public static @Nullable git4idea.repo.GitRepository getRepositoryForRoot(
+        @NotNull Project project, @NotNull String rootPath) {
+        for (git4idea.repo.GitRepository r : getRepositories(project)) {
+            if (r.getRoot().getPath().equals(rootPath)) return r;
+        }
+        return null;
+    }
+
+    /**
      * Switches to an existing branch using Git4Idea's high-level checkout API.
      * Uses IntelliJ's configured git executable and properly refreshes the GitRepository state.
      * Returns null to signal that the caller should fall back to CLI.
      */
     public static @Nullable String ideCheckout(@NotNull Project project, @NotNull String branchName) {
-        git4idea.repo.GitRepository repo = getRepository(project);
+        return ideCheckout(project, null, branchName);
+    }
+
+    /** Root-aware variant of {@link #ideCheckout(Project, String)}. */
+    public static @Nullable String ideCheckout(
+            @NotNull Project project, @Nullable String rootPath, @NotNull String branchName) {
+        git4idea.repo.GitRepository repo = rootPath != null
+            ? getRepositoryForRoot(project, rootPath)
+            : getRepository(project);
         if (repo == null) return null;
         git4idea.commands.GitCommandResult result =
             git4idea.commands.Git.getInstance().checkout(repo, branchName, null, false, false);
@@ -617,7 +665,16 @@ public final class PlatformApiCompat {
     public static @Nullable String ideCheckoutNewBranch(@NotNull Project project,
                                                         @NotNull String branchName,
                                                         @Nullable String base) {
-        git4idea.repo.GitRepository repo = getRepository(project);
+        return ideCheckoutNewBranch(project, null, branchName, base);
+    }
+
+    /** Root-aware variant of {@link #ideCheckoutNewBranch(Project, String, String)}. */
+    public static @Nullable String ideCheckoutNewBranch(
+            @NotNull Project project, @Nullable String rootPath,
+            @NotNull String branchName, @Nullable String base) {
+        git4idea.repo.GitRepository repo = rootPath != null
+            ? getRepositoryForRoot(project, rootPath)
+            : getRepository(project);
         if (repo == null) return null;
         git4idea.commands.GitCommandResult result;
         if (base == null) {
@@ -641,7 +698,16 @@ public final class PlatformApiCompat {
     public static @Nullable String ideDeleteBranch(@NotNull Project project,
                                                    @NotNull String branchName,
                                                    boolean force) {
-        git4idea.repo.GitRepository repo = getRepository(project);
+        return ideDeleteBranch(project, null, branchName, force);
+    }
+
+    /** Root-aware variant of {@link #ideDeleteBranch(Project, String, boolean)}. */
+    public static @Nullable String ideDeleteBranch(
+            @NotNull Project project, @Nullable String rootPath,
+            @NotNull String branchName, boolean force) {
+        git4idea.repo.GitRepository repo = rootPath != null
+            ? getRepositoryForRoot(project, rootPath)
+            : getRepository(project);
         if (repo == null) return null;
         git4idea.commands.GitCommandResult result =
             git4idea.commands.Git.getInstance().branchDelete(repo, branchName, force);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
@@ -552,18 +552,11 @@ public final class PlatformApiCompat {
         return runIdeGitCommandWithRepo(project, repo, args);
     }
 
-    /**
-     * Runs a Git command using the repo rooted at {@code rootPath}.
-     * Falls back to {@link #runIdeGitCommand} if no repo is found at that path.
-     */
     public static @Nullable String runIdeGitCommandIn(
         @NotNull Project project, @NotNull String rootPath, @NotNull String[] args) {
         if (args.length == 0) return null;
         git4idea.repo.GitRepository repo = getRepositoryForRoot(project, rootPath);
-        if (repo == null) {
-            repo = getRepository(project);
-            if (repo == null) return null;
-        }
+        if (repo == null) return null;
         return runIdeGitCommandWithRepo(project, repo, args);
     }
 
@@ -643,9 +636,11 @@ public final class PlatformApiCompat {
         return ideCheckout(project, null, branchName);
     }
 
-    /** Root-aware variant of {@link #ideCheckout(Project, String)}. */
+    /**
+     * Root-aware variant of {@link #ideCheckout(Project, String)}.
+     */
     public static @Nullable String ideCheckout(
-            @NotNull Project project, @Nullable String rootPath, @NotNull String branchName) {
+        @NotNull Project project, @Nullable String rootPath, @NotNull String branchName) {
         git4idea.repo.GitRepository repo = rootPath != null
             ? getRepositoryForRoot(project, rootPath)
             : getRepository(project);
@@ -668,10 +663,12 @@ public final class PlatformApiCompat {
         return ideCheckoutNewBranch(project, null, branchName, base);
     }
 
-    /** Root-aware variant of {@link #ideCheckoutNewBranch(Project, String, String)}. */
+    /**
+     * Root-aware variant of {@link #ideCheckoutNewBranch(Project, String, String)}.
+     */
     public static @Nullable String ideCheckoutNewBranch(
-            @NotNull Project project, @Nullable String rootPath,
-            @NotNull String branchName, @Nullable String base) {
+        @NotNull Project project, @Nullable String rootPath,
+        @NotNull String branchName, @Nullable String base) {
         git4idea.repo.GitRepository repo = rootPath != null
             ? getRepositoryForRoot(project, rootPath)
             : getRepository(project);
@@ -701,10 +698,12 @@ public final class PlatformApiCompat {
         return ideDeleteBranch(project, null, branchName, force);
     }
 
-    /** Root-aware variant of {@link #ideDeleteBranch(Project, String, boolean)}. */
+    /**
+     * Root-aware variant of {@link #ideDeleteBranch(Project, String, boolean)}.
+     */
     public static @Nullable String ideDeleteBranch(
-            @NotNull Project project, @Nullable String rootPath,
-            @NotNull String branchName, boolean force) {
+        @NotNull Project project, @Nullable String rootPath,
+        @NotNull String branchName, boolean force) {
         git4idea.repo.GitRepository repo = rootPath != null
             ? getRepositoryForRoot(project, rootPath)
             : getRepository(project);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GetFileHistoryTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GetFileHistoryTool.java
@@ -44,7 +44,8 @@ public final class GetFileHistoryTool extends GitTool {
     public @NotNull JsonObject inputSchema() {
         return schema(
             Param.required("path", TYPE_STRING, "Path to the file to get history for (absolute or project-relative)"),
-            Param.optional(PARAM_MAX_COUNT, TYPE_INTEGER, "Maximum number of commits to show (default: 20)")
+            Param.optional(PARAM_MAX_COUNT, TYPE_INTEGER, "Maximum number of commits to show (default: 20)"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
@@ -55,12 +56,16 @@ public final class GetFileHistoryTool extends GitTool {
         }
         String path = args.get("path").getAsString();
 
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
         String maxCount = String.valueOf(
             args.has(PARAM_MAX_COUNT)
                 ? args.get(PARAM_MAX_COUNT).getAsInt()
                 : DEFAULT_MAX_COUNT);
 
-        return runGit("log", "--follow",
+        return runGitIn(root, "log", "--follow",
             "--format=%H %ai %an%n  %s",
             "-n", maxCount, "--", path);
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitBlameTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitBlameTool.java
@@ -49,7 +49,8 @@ public final class GitBlameTool extends GitTool {
         return schema(
             Param.required("path", TYPE_STRING, "File path to blame"),
             Param.optional(PARAM_LINE_START, TYPE_INTEGER, "Start line number for partial blame"),
-            Param.optional(PARAM_LINE_END, TYPE_INTEGER, "End line number for partial blame")
+            Param.optional(PARAM_LINE_END, TYPE_INTEGER, "End line number for partial blame"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
@@ -59,6 +60,10 @@ public final class GitBlameTool extends GitTool {
             return "Error: 'path' parameter is required";
         }
         String path = args.get("path").getAsString();
+
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
 
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add("blame");
@@ -73,7 +78,7 @@ public final class GitBlameTool extends GitTool {
         cmdArgs.add("--");
         cmdArgs.add(path);
 
-        return runGit(cmdArgs.toArray(String[]::new));
+        return runGitIn(root, cmdArgs.toArray(String[]::new));
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitBranchTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitBranchTool.java
@@ -56,51 +56,66 @@ public final class GitBranchTool extends GitTool {
             Param.optional(PARAM_NAME, TYPE_STRING, "Branch name (required for create/switch/delete)"),
             Param.optional(PARAM_BASE, TYPE_STRING, "Base ref for create (default: HEAD)"),
             Param.optional(PARAM_ALL, TYPE_BOOLEAN, "For list: include remote branches"),
-            Param.optional(PARAM_FORCE, TYPE_BOOLEAN, "For delete: force delete unmerged branches")
+            Param.optional(PARAM_FORCE, TYPE_BOOLEAN, "For delete: force delete unmerged branches"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
-        String action = args.has(PARAM_ACTION)
-            ? args.get(PARAM_ACTION).getAsString()
-            : "list";
+        String action = args.has(PARAM_ACTION) ? args.get(PARAM_ACTION).getAsString() : "list";
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
 
         return switch (action) {
             case "list" -> {
+                // List is read-only: no ambiguity guard, no repo required.
+                String root = resolveRepoRootOrError(repoParam);
+                if (root.startsWith("Error")) yield root;
                 boolean all = args.has(PARAM_ALL) && args.get(PARAM_ALL).getAsBoolean();
-                yield runGit(CMD_BRANCH, all ? "--all" : "--list", "-v");
+                yield runGitIn(root, CMD_BRANCH, all ? "--all" : "--list", "-v");
             }
             case "create" -> {
                 String name = requireName(args);
                 if (name == null) yield "Error: 'name' parameter is required for 'create'";
+                String ambiError = requireUnambiguousRepo(repoParam, "branch create");
+                if (ambiError != null) yield ambiError;
+                String root = resolveRepoRootOrError(repoParam);
+                if (root.startsWith("Error")) yield root;
                 String reviewError = AgentEditSession.getInstance(project)
                     .awaitReviewCompletion("branch create '" + name + "'");
                 if (reviewError != null) yield reviewError;
                 String base = args.has(PARAM_BASE) && !args.get(PARAM_BASE).getAsString().isEmpty()
                     ? args.get(PARAM_BASE).getAsString()
                     : null;
-                String result = ideCreate(name, base);
+                String result = ideCreate(root, name, base);
                 if (result.startsWith("Error")) yield result;
                 AgentEditSession.getInstance(project).invalidateOnWorktreeChange("branch create");
-                yield "Created and switched to branch '" + name + "'\n" + getBranchContext();
+                yield "Created and switched to branch '" + name + "'\n" + getBranchContextIn(root);
             }
             case "switch", CMD_CHECKOUT -> {
                 String name = requireName(args);
                 if (name == null) yield "Error: 'name' parameter is required for 'switch'";
+                String ambiError = requireUnambiguousRepo(repoParam, "branch switch");
+                if (ambiError != null) yield ambiError;
+                String root = resolveRepoRootOrError(repoParam);
+                if (root.startsWith("Error")) yield root;
                 String reviewError = AgentEditSession.getInstance(project)
                     .awaitReviewCompletion("branch switch '" + name + "'");
                 if (reviewError != null) yield reviewError;
-                String result = ideSwitch(name);
+                String result = ideSwitch(root, name);
                 if (result.startsWith("Error")) yield result;
                 AgentEditSession.getInstance(project).invalidateOnWorktreeChange("branch switch");
-                yield "Switched to branch '" + name + "'\n" + getBranchContext();
+                yield "Switched to branch '" + name + "'\n" + getBranchContextIn(root);
             }
             case "delete" -> {
                 String name = requireName(args);
                 if (name == null) yield "Error: 'name' parameter is required for 'delete'";
+                String ambiError = requireUnambiguousRepo(repoParam, "branch delete");
+                if (ambiError != null) yield ambiError;
+                String root = resolveRepoRootOrError(repoParam);
+                if (root.startsWith("Error")) yield root;
                 boolean force = args.has(PARAM_FORCE) && args.get(PARAM_FORCE).getAsBoolean();
-                yield ideDelete(name, force);
+                yield ideDelete(root, name, force);
             }
             default -> "Error: unknown action '" + action + "'. Use: list, create, switch, delete";
         };
@@ -109,9 +124,9 @@ public final class GitBranchTool extends GitTool {
     /**
      * Create a new branch and switch to it. Prefers Git4Idea high-level API; falls back to CLI.
      */
-    private String ideCreate(String name, @Nullable String base) throws Exception {
+    private String ideCreate(String root, String name, @Nullable String base) throws Exception {
         try {
-            String result = PlatformApiCompat.ideCheckoutNewBranch(project, name, base);
+            String result = PlatformApiCompat.ideCheckoutNewBranch(project, root, name, base);
             if (result != null) {
                 refreshVcsState();
                 return result;
@@ -119,18 +134,17 @@ public final class GitBranchTool extends GitTool {
         } catch (NoClassDefFoundError ignored) {
             // Git4Idea unavailable
         }
-        // CLI fallback
         return base != null
-            ? runGit(CMD_CHECKOUT, "-b", name, base)
-            : runGit(CMD_CHECKOUT, "-b", name);
+            ? runGitIn(root, CMD_CHECKOUT, "-b", name, base)
+            : runGitIn(root, CMD_CHECKOUT, "-b", name);
     }
 
     /**
      * Switch to an existing branch. Prefers Git4Idea high-level API; falls back to CLI.
      */
-    private String ideSwitch(String name) throws Exception {
+    private String ideSwitch(String root, String name) throws Exception {
         try {
-            String result = PlatformApiCompat.ideCheckout(project, name);
+            String result = PlatformApiCompat.ideCheckout(project, root, name);
             if (result != null) {
                 refreshVcsState();
                 return result;
@@ -138,15 +152,15 @@ public final class GitBranchTool extends GitTool {
         } catch (NoClassDefFoundError ignored) {
             // Git4Idea unavailable
         }
-        return runGit(CMD_CHECKOUT, name);
+        return runGitIn(root, CMD_CHECKOUT, name);
     }
 
     /**
      * Delete a branch. Prefers Git4Idea high-level API; falls back to CLI.
      */
-    private String ideDelete(String name, boolean force) throws Exception {
+    private String ideDelete(String root, String name, boolean force) throws Exception {
         try {
-            String result = PlatformApiCompat.ideDeleteBranch(project, name, force);
+            String result = PlatformApiCompat.ideDeleteBranch(project, root, name, force);
             if (result != null) {
                 refreshVcsState();
                 return result;
@@ -154,7 +168,7 @@ public final class GitBranchTool extends GitTool {
         } catch (NoClassDefFoundError ignored) {
             // Git4Idea unavailable
         }
-        return runGit(CMD_BRANCH, force ? "-D" : "-d", name);
+        return runGitIn(root, CMD_BRANCH, force ? "-D" : "-d", name);
     }
 
     private static @Nullable String requireName(JsonObject args) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCherryPickTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCherryPickTool.java
@@ -53,7 +53,8 @@ public final class GitCherryPickTool extends GitTool {
             Param.optional(PARAM_COMMITS, TYPE_ARRAY, "One or more commit SHAs to cherry-pick"),
             Param.optional(PARAM_NO_COMMIT, TYPE_BOOLEAN, "Apply changes without creating commits"),
             Param.optional(PARAM_ABORT, TYPE_BOOLEAN, "Abort an in-progress cherry-pick"),
-            Param.optional(PARAM_CONTINUE_PICK, TYPE_BOOLEAN, "Continue cherry-pick after resolving conflicts")
+            Param.optional(PARAM_CONTINUE_PICK, TYPE_BOOLEAN, "Continue cherry-pick after resolving conflicts"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
         addArrayItems(s, PARAM_COMMITS);
         return s;
@@ -63,13 +64,19 @@ public final class GitCherryPickTool extends GitTool {
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         flushAndSave();
 
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String ambiError = requireUnambiguousRepo(repoParam, "git_cherry_pick");
+        if (ambiError != null) return ambiError;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
         if (args.has(PARAM_ABORT) && args.get(PARAM_ABORT).getAsBoolean()) {
-            return runGit(CHERRY_PICK, "--abort");
+            return runGitIn(root, CHERRY_PICK, "--abort");
         }
 
         if (args.has(PARAM_CONTINUE_PICK) && args.get(PARAM_CONTINUE_PICK).getAsBoolean()) {
             // --no-edit prevents git from opening $EDITOR for the commit message.
-            return runGit(CHERRY_PICK, "--continue", "--no-edit");
+            return runGitIn(root, CHERRY_PICK, "--continue", "--no-edit");
         }
 
         if (!args.has(PARAM_COMMITS) || !args.get(PARAM_COMMITS).isJsonArray()) {
@@ -92,7 +99,7 @@ public final class GitCherryPickTool extends GitTool {
             cmdArgs.add(commit.getAsString());
         }
 
-        String result = runGit(cmdArgs.toArray(String[]::new));
+        String result = runGitIn(root, cmdArgs.toArray(String[]::new));
         if (!result.startsWith("Error")) {
             AgentEditSession.getInstance(project).invalidateOnWorktreeChange("cherry-pick");
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
@@ -65,13 +65,20 @@ public final class GitCommitTool extends GitTool {
             Param.required(PARAM_MESSAGE, TYPE_STRING, "Commit message (use conventional commit format)"),
             Param.optional(PARAM_AMEND, TYPE_BOOLEAN, "If true, amend the previous commit instead of creating a new one"),
             Param.optional(PARAM_AUTHOR, TYPE_STRING, "Override the commit author (e.g. 'Name <email@example.com>')"),
-            Param.optional("all", TYPE_BOOLEAN, "Stage all changes (modified, deleted, and new untracked files) before committing. Default: true. Set false to commit only already-staged changes.")
+            Param.optional("all", TYPE_BOOLEAN, "Stage all changes (modified, deleted, and new untracked files) before committing. Default: true. Set false to commit only already-staged changes."),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         flushAndSave();
+
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String ambiError = requireUnambiguousRepo(repoParam, "git_commit");
+        if (ambiError != null) return ambiError;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
 
         if (!args.has(PARAM_MESSAGE) || args.get(PARAM_MESSAGE).getAsString().isEmpty()) {
             return "Error: 'message' parameter is required";
@@ -81,23 +88,23 @@ public final class GitCommitTool extends GitTool {
 
         // Compute which files will be committed, then only gate on those paths.
         // This prevents unrelated PENDING review items from blocking the commit.
-        Collection<String> filesToCommit = resolveFilesToCommit(commitAll);
+        Collection<String> filesToCommit = resolveFilesToCommit(commitAll, root);
         String reviewError = AgentEditSession.getInstance(project)
             .awaitReviewForPaths("git commit", filesToCommit);
         if (reviewError != null) return reviewError;
 
         if (commitAll) {
             // Stage all changes including new untracked files (equivalent to git add -A)
-            runGit("add", "-A");
+            runGitIn(root, "add", "-A");
         }
 
         boolean isAmend = resolveAmend(args);
 
         // Pre-commit check: verify there are staged changes (skip for amend — message-only amends are valid)
         if (!isAmend) {
-            String staged = runGitQuiet("diff", "--cached", "--name-only");
+            String staged = runGitInQuiet(root, "diff", "--cached", "--name-only");
             if (staged != null && staged.isEmpty()) {
-                return buildNothingToCommitHint();
+                return buildNothingToCommitHint(root);
             }
         }
 
@@ -130,7 +137,7 @@ public final class GitCommitTool extends GitTool {
         cmdArgs.add("-m");
         cmdArgs.add(args.get(PARAM_MESSAGE).getAsString());
 
-        String result = runGit(cmdArgs.toArray(String[]::new));
+        String result = runGitIn(root, cmdArgs.toArray(String[]::new));
         showNewCommitInLog();
 
         if (result.startsWith("Error")) return result;
@@ -138,7 +145,7 @@ public final class GitCommitTool extends GitTool {
         // Prune approved review rows for files that are now part of this commit.
         // Run on EDT-safe pool: AgentEditSession mutations + listeners are EDT-safe.
         try {
-            String committedNames = runGitQuiet("show", "--name-only", "--format=", "HEAD");
+            String committedNames = runGitInQuiet(root, "show", "--name-only", "--format=", "HEAD");
             if (committedNames != null && !committedNames.isBlank()) {
                 java.util.List<String> paths = new java.util.ArrayList<>();
                 for (String line : committedNames.split("\\r?\\n")) {
@@ -156,19 +163,19 @@ public final class GitCommitTool extends GitTool {
         }
 
         // Append committed file list so agent can verify what was included
-        String fileStats = runGitQuiet("show", "--stat", "--format=", "HEAD");
+        String fileStats = runGitInQuiet(root, "show", "--stat", "--format=", "HEAD");
         if (fileStats != null && !fileStats.isBlank()) {
             result += "\n\nCommitted files:\n" + fileStats.trim();
         }
 
         // Warn if committing directly to default branch
-        String branch = runGitQuiet("rev-parse", "--abbrev-ref", "HEAD");
+        String branch = runGitInQuiet(root, "rev-parse", "--abbrev-ref", "HEAD");
         if ("main".equals(branch) || "master".equals(branch)) {
             result += "\n\n⚠️ Warning: you committed directly to " + branch
                 + ". Consider using a feature branch instead.";
         }
 
-        return result + getBranchContext();
+        return result + getBranchContextIn(root);
     }
 
     /**
@@ -184,11 +191,11 @@ public final class GitCommitTool extends GitTool {
      * {@code git status --porcelain}. For staged-only: files from
      * {@code git diff --cached --name-only}.
      */
-    private Collection<String> resolveFilesToCommit(boolean commitAll) {
+    private Collection<String> resolveFilesToCommit(boolean commitAll, String root) {
         String basePath = project.getBasePath();
         Set<String> paths = new java.util.HashSet<>();
         if (commitAll) {
-            String status = runGitQuiet("status", "--porcelain");
+            String status = runGitInQuiet(root, "status", "--porcelain");
             if (status != null) {
                 for (String line : status.split("\\r?\\n")) {
                     if (line.length() < 4) continue;
@@ -200,7 +207,7 @@ public final class GitCommitTool extends GitTool {
                 }
             }
         } else {
-            String staged = runGitQuiet("diff", "--cached", "--name-only");
+            String staged = runGitInQuiet(root, "diff", "--cached", "--name-only");
             if (staged != null) {
                 for (String line : staged.split("\\r?\\n")) {
                     String trimmed = line.trim();
@@ -222,10 +229,10 @@ public final class GitCommitTool extends GitTool {
      * Builds a detailed hint for the "nothing to commit" case, listing which paths are
      * unstaged/untracked/ignored so the agent knows exactly what to stage (or force-add).
      */
-    private String buildNothingToCommitHint() {
-        String unstaged = runGitQuiet("diff", "--name-only");
-        String untracked = runGitQuiet("ls-files", "--others", "--exclude-standard");
-        String ignored = runGitQuiet("ls-files", "--others", "--ignored", "--exclude-standard");
+    private String buildNothingToCommitHint(String root) {
+        String unstaged = runGitInQuiet(root, "diff", "--name-only");
+        String untracked = runGitInQuiet(root, "ls-files", "--others", "--exclude-standard");
+        String ignored = runGitInQuiet(root, "ls-files", "--others", "--ignored", "--exclude-standard");
 
         boolean hasUnstaged = unstaged != null && !unstaged.isEmpty();
         boolean hasUntracked = untracked != null && !untracked.isEmpty();

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitConfigTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitConfigTool.java
@@ -56,12 +56,17 @@ public final class GitConfigTool extends GitTool {
             Param.optional(PARAM_VALUE, TYPE_STRING, "The value to set. If omitted and unset/list are false, performs a get operation."),
             Param.optional(PARAM_GLOBAL, TYPE_BOOLEAN, "If true, uses --global flag"),
             Param.optional(PARAM_UNSET, TYPE_BOOLEAN, "If true, unsets the given key"),
-            Param.optional(PARAM_LIST, TYPE_BOOLEAN, "If true, lists all configuration options")
+            Param.optional(PARAM_LIST, TYPE_BOOLEAN, "If true, lists all configuration options"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add("config");
 
@@ -71,7 +76,7 @@ public final class GitConfigTool extends GitTool {
 
         if (args.has(PARAM_LIST) && args.get(PARAM_LIST).getAsBoolean()) {
             cmdArgs.add("--list");
-            return runGit(cmdArgs.toArray(new String[0]));
+            return runGitIn(root, cmdArgs.toArray(new String[0]));
         }
 
         if (!args.has(PARAM_KEY)) {
@@ -91,6 +96,6 @@ public final class GitConfigTool extends GitTool {
             cmdArgs.add(key);
         }
 
-        return runGit(cmdArgs.toArray(new String[0]));
+        return runGitIn(root, cmdArgs.toArray(new String[0]));
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitConfigTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitConfigTool.java
@@ -64,18 +64,19 @@ public final class GitConfigTool extends GitTool {
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
-        String root = resolveRepoRootOrError(repoParam);
-        if (root.startsWith("Error")) return root;
 
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add("config");
 
-        if (args.has(PARAM_GLOBAL) && args.get(PARAM_GLOBAL).getAsBoolean()) {
+        boolean isGlobal = args.has(PARAM_GLOBAL) && args.get(PARAM_GLOBAL).getAsBoolean();
+        if (isGlobal) {
             cmdArgs.add("--global");
         }
 
         if (args.has(PARAM_LIST) && args.get(PARAM_LIST).getAsBoolean()) {
             cmdArgs.add("--list");
+            String root = resolveRepoRootOrError(repoParam);
+            if (root.startsWith("Error")) return root;
             return runGitIn(root, cmdArgs.toArray(new String[0]));
         }
 
@@ -84,11 +85,23 @@ public final class GitConfigTool extends GitTool {
         }
 
         String key = args.get(PARAM_KEY).getAsString();
+        boolean isUnset = args.has(PARAM_UNSET) && args.get(PARAM_UNSET).getAsBoolean();
+        boolean isSet = args.has(PARAM_VALUE);
+        boolean isWrite = isUnset || isSet;
 
-        if (args.has(PARAM_UNSET) && args.get(PARAM_UNSET).getAsBoolean()) {
+        // Repo-scoped writes require an unambiguous repo target
+        if (!isGlobal && isWrite) {
+            String ambiError = requireUnambiguousRepo(repoParam, "git_config");
+            if (ambiError != null) return ambiError;
+        }
+
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
+        if (isUnset) {
             cmdArgs.add("--unset");
             cmdArgs.add(key);
-        } else if (args.has(PARAM_VALUE)) {
+        } else if (isSet) {
             cmdArgs.add(key);
             cmdArgs.add(args.get(PARAM_VALUE).getAsString());
         } else {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitDiffTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitDiffTool.java
@@ -54,7 +54,8 @@ public final class GitDiffTool extends GitTool {
             Param.optional(PARAM_STAGED, TYPE_BOOLEAN, "If true, show staged (cached) changes only"),
             Param.optional(PARAM_COMMIT, TYPE_STRING, "Compare against this commit (e.g., 'HEAD~1', branch name)"),
             Param.optional("path", TYPE_STRING, "Limit diff to this file path"),
-            Param.optional(PARAM_STAT_ONLY, TYPE_BOOLEAN, "If true, show only file stats (insertions/deletions), not full diff")
+            Param.optional(PARAM_STAT_ONLY, TYPE_BOOLEAN, "If true, show only file stats (insertions/deletions), not full diff"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
@@ -62,9 +63,13 @@ public final class GitDiffTool extends GitTool {
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         flushAndSave();
 
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
         // Auto-fetch when comparing against a remote ref
         String commitRef = args.has(PARAM_COMMIT) ? args.get(PARAM_COMMIT).getAsString() : null;
-        String fetchNote = autoFetchForRemoteRef(commitRef);
+        String fetchNote = autoFetchForRemoteRefIn(commitRef, root);
 
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add("diff");
@@ -90,7 +95,7 @@ public final class GitDiffTool extends GitTool {
             cmdArgs.add(args.get("path").getAsString());
         }
 
-        return fetchNote + runGit(cmdArgs.toArray(String[]::new));
+        return fetchNote + runGitIn(root, cmdArgs.toArray(String[]::new));
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitFetchTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitFetchTool.java
@@ -71,12 +71,19 @@ public final class GitFetchTool extends GitTool {
             Param.optional(PARAM_REMOTE, TYPE_STRING, "Remote name (default: origin)"),
             Param.optional(PARAM_BRANCH, TYPE_STRING, "Specific branch to fetch"),
             Param.optional(PARAM_PRUNE, TYPE_BOOLEAN, "Remove remote-tracking refs that no longer exist on the remote"),
-            Param.optional("tags", TYPE_BOOLEAN, "Fetch all tags from the remote")
+            Param.optional("tags", TYPE_BOOLEAN, "Fetch all tags from the remote"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String ambiError = requireUnambiguousRepo(repoParam, "git_fetch");
+        if (ambiError != null) return ambiError;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add("fetch");
 
@@ -96,12 +103,9 @@ public final class GitFetchTool extends GitTool {
             cmdArgs.add(args.get(PARAM_BRANCH).getAsString());
         }
 
-        String result = runGit(cmdArgs.toArray(String[]::new));
+        String result = runGitIn(root, cmdArgs.toArray(String[]::new));
         String output = result.isBlank() ? "Fetch completed successfully." : result;
 
-        // Reset throttle so subsequent tools see the fresh state
-        lastFetchTime.set(System.currentTimeMillis());
-
-        return output + getBranchContext();
+        return output + getBranchContextIn(root);
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitFetchTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitFetchTool.java
@@ -105,6 +105,7 @@ public final class GitFetchTool extends GitTool {
 
         String result = runGitIn(root, cmdArgs.toArray(String[]::new));
         String output = result.isBlank() ? "Fetch completed successfully." : result;
+        markFetchCompleted(root);
 
         return output + getBranchContextIn(root);
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitLogTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitLogTool.java
@@ -58,12 +58,17 @@ public final class GitLogTool extends GitTool {
             Param.optional(PARAM_SINCE, TYPE_STRING, "Show commits after this date (e.g., '2024-01-01', '2 weeks ago')"),
             Param.optional(PARAM_UNTIL, TYPE_STRING, "Show commits before this date (e.g., '2024-12-31', '1 week ago')"),
             Param.optional("path", TYPE_STRING, "Show only commits touching this file"),
-            Param.optional(PARAM_BRANCH, TYPE_STRING, "Show commits from this branch (default: current)")
+            Param.optional(PARAM_BRANCH, TYPE_STRING, "Show commits from this branch (default: current)"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add("log");
 
@@ -107,7 +112,7 @@ public final class GitLogTool extends GitTool {
             cmdArgs.add(args.get("path").getAsString());
         }
 
-        String result = runGit(cmdArgs.toArray(String[]::new));
+        String result = runGitIn(root, cmdArgs.toArray(String[]::new));
         showFirstCommitInLog(result);
         return result;
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitMergeTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitMergeTool.java
@@ -59,7 +59,8 @@ public final class GitMergeTool extends GitTool {
             Param.optional(PARAM_NO_FF, TYPE_BOOLEAN, "Create a merge commit even for fast-forward merges"),
             Param.optional(PARAM_FF_ONLY, TYPE_BOOLEAN, "Only merge if fast-forward is possible"),
             Param.optional(PARAM_SQUASH, TYPE_BOOLEAN, "Squash all commits into a single commit (requires manual commit after)"),
-            Param.optional(PARAM_ABORT, TYPE_BOOLEAN, "Abort an in-progress merge")
+            Param.optional(PARAM_ABORT, TYPE_BOOLEAN, "Abort an in-progress merge"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
@@ -72,16 +73,22 @@ public final class GitMergeTool extends GitTool {
             return "Error: 'branch' parameter is required (or use 'abort' to abort an in-progress merge)";
         }
 
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String ambiError = requireUnambiguousRepo(repoParam, "git_merge");
+        if (ambiError != null) return ambiError;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
         flushAndSave();
 
         if (hasAbort) {
-            return runGit("merge", "--abort");
+            return runGitIn(root, "merge", "--abort");
         }
 
         String branchArg = args.get(PARAM_BRANCH).getAsString();
 
         // Auto-fetch when merging a remote branch
-        String fetchNote = autoFetchForRemoteRef(branchArg);
+        String fetchNote = autoFetchForRemoteRefIn(branchArg, root);
 
         String reviewError = AgentEditSession.getInstance(project)
             .awaitReviewCompletion("git merge '" + branchArg + "'");
@@ -109,10 +116,10 @@ public final class GitMergeTool extends GitTool {
 
         cmdArgs.add(branchArg);
 
-        String result = runGit(cmdArgs.toArray(String[]::new));
+        String result = runGitIn(root, cmdArgs.toArray(String[]::new));
         if (result.startsWith("Error")) return fetchNote + result;
 
         AgentEditSession.getInstance(project).invalidateOnWorktreeChange("git merge");
-        return fetchNote + result + getBranchSummary();
+        return fetchNote + result + getBranchSummaryIn(root);
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitPullTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitPullTool.java
@@ -83,13 +83,20 @@ public final class GitPullTool extends GitTool {
             Param.optional(PARAM_REMOTE, TYPE_STRING, "Remote name (default: origin)"),
             Param.optional(PARAM_BRANCH, TYPE_STRING, "Branch to pull (default: current tracking branch)"),
             Param.optional(PARAM_REBASE, TYPE_BOOLEAN, "If true, rebase instead of merge when pulling"),
-            Param.optional(PARAM_FF_ONLY, TYPE_BOOLEAN, "If true, only fast-forward (abort if not possible)")
+            Param.optional(PARAM_FF_ONLY, TYPE_BOOLEAN, "If true, only fast-forward (abort if not possible)"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         flushAndSave();
+
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String ambiError = requireUnambiguousRepo(repoParam, "git_pull");
+        if (ambiError != null) return ambiError;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
 
         String reviewError = AgentEditSession.getInstance(project)
             .awaitReviewCompletion("git pull");
@@ -114,10 +121,10 @@ public final class GitPullTool extends GitTool {
             cmdArgs.add(args.get(PARAM_BRANCH).getAsString());
         }
 
-        String result = runGit(cmdArgs.toArray(String[]::new));
+        String result = runGitIn(root, cmdArgs.toArray(String[]::new));
         if (result.startsWith("Error")) return result;
 
         AgentEditSession.getInstance(project).invalidateOnWorktreeChange("git pull");
-        return result + getBranchContext();
+        return result + getBranchContextIn(root);
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitPushTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitPushTool.java
@@ -88,21 +88,28 @@ public final class GitPushTool extends GitTool {
             Param.optional(PARAM_BRANCH, TYPE_STRING, "Branch to push (default: current)"),
             Param.optional(PARAM_FORCE, TYPE_BOOLEAN, "Force push"),
             Param.optional(PARAM_SET_UPSTREAM, TYPE_BOOLEAN, "Set upstream tracking reference"),
-            Param.optional("tags", TYPE_BOOLEAN, "Push all tags")
+            Param.optional("tags", TYPE_BOOLEAN, "Push all tags"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String ambiError = requireUnambiguousRepo(repoParam, "git_push");
+        if (ambiError != null) return ambiError;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
         boolean forceFlag = args.has(PARAM_FORCE) && args.get(PARAM_FORCE).getAsBoolean();
 
         // Auto-fetch to detect remote divergence before pushing
-        String fetchNote = autoFetchIfStale();
+        String fetchNote = autoFetchIfStaleIn(root);
 
         // Pre-push divergence check (skip for force-push)
         String divergenceWarning = "";
         if (!forceFlag) {
-            String behind = runGitQuiet("rev-list", "--count", "HEAD..@{upstream}");
+            String behind = runGitInQuiet(root, "rev-list", "--count", "HEAD..@{upstream}");
             if (behind != null && !"0".equals(behind)) {
                 divergenceWarning = "\n⚠️ Remote is " + behind
                     + " commit(s) ahead of local. Consider pulling first, or use force: true.";
@@ -129,7 +136,7 @@ public final class GitPushTool extends GitTool {
                 remote = "origin";
             }
             if (branch == null) {
-                branch = runGit("rev-parse", "--abbrev-ref", "HEAD").trim();
+                branch = runGitIn(root, "rev-parse", "--abbrev-ref", "HEAD").trim();
             }
         }
 
@@ -143,7 +150,7 @@ public final class GitPushTool extends GitTool {
             cmdArgs.add("--tags");
         }
 
-        String result = runGit(cmdArgs.toArray(String[]::new));
+        String result = runGitIn(root, cmdArgs.toArray(String[]::new));
 
         if (result.startsWith("Error")) return fetchNote + result + divergenceWarning;
 
@@ -154,12 +161,12 @@ public final class GitPushTool extends GitTool {
 
         ctx.append("\n\n--- Context ---\n");
         String actualBranch = branch != null ? branch
-            : runGitQuiet("rev-parse", "--abbrev-ref", "HEAD");
+            : runGitInQuiet(root, "rev-parse", "--abbrev-ref", "HEAD");
         String actualRemote = remote != null ? remote : "origin";
         ctx.append("Pushed ").append(actualBranch).append(" → ")
             .append(actualRemote).append('/').append(actualBranch).append('\n');
 
-        String remoteUrl = runGitQuiet("remote", "get-url", actualRemote);
+        String remoteUrl = runGitInQuiet(root, "remote", "get-url", actualRemote);
         if (remoteUrl != null) {
             ctx.append("Remote: ").append(remoteUrl).append('\n');
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitRebaseTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitRebaseTool.java
@@ -65,7 +65,8 @@ public final class GitRebaseTool extends GitTool {
             Param.optional(PARAM_EXEC, TYPE_STRING, "Shell command to run after each rebase step (e.g. 'make test')"),
             Param.optional(PARAM_ABORT, TYPE_BOOLEAN, "Abort an in-progress rebase"),
             Param.optional(PARAM_CONTINUE_REBASE, TYPE_BOOLEAN, "Continue a paused rebase after resolving conflicts"),
-            Param.optional("skip", TYPE_BOOLEAN, "Skip the current patch and continue rebase")
+            Param.optional("skip", TYPE_BOOLEAN, "Skip the current patch and continue rebase"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
@@ -73,35 +74,41 @@ public final class GitRebaseTool extends GitTool {
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         flushAndSave();
 
-        String controlResult = handleControlArgs(args);
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String ambiError = requireUnambiguousRepo(repoParam, "git_rebase");
+        if (ambiError != null) return ambiError;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
+        String controlResult = handleControlArgs(args, root);
         if (controlResult != null) return controlResult;
 
         // Auto-fetch when rebasing onto a remote branch
         String branchArg = args.has(PARAM_BRANCH) ? args.get(PARAM_BRANCH).getAsString() : null;
         String ontoArg = args.has("onto") ? args.get("onto").getAsString() : null;
-        String fetchNote = autoFetchForRemoteRef(branchArg);
-        if (fetchNote.isEmpty()) fetchNote = autoFetchForRemoteRef(ontoArg);
+        String fetchNote = autoFetchForRemoteRefIn(branchArg, root);
+        if (fetchNote.isEmpty()) fetchNote = autoFetchForRemoteRefIn(ontoArg, root);
 
         String reviewError = AgentEditSession.getInstance(project)
             .awaitReviewCompletion("git rebase");
         if (reviewError != null) return reviewError;
 
-        String result = runGit(buildRebaseArgs(args).toArray(String[]::new));
+        String result = runGitIn(root, buildRebaseArgs(args).toArray(String[]::new));
         if (result.startsWith("Error")) return fetchNote + result;
 
         AgentEditSession.getInstance(project).invalidateOnWorktreeChange("git rebase");
-        return fetchNote + result + getBranchContext();
+        return fetchNote + result + getBranchContextIn(root);
     }
 
-    private @Nullable String handleControlArgs(@NotNull JsonObject args) throws Exception {
+    private @Nullable String handleControlArgs(@NotNull JsonObject args, @NotNull String root) throws Exception {
         if (args.has(PARAM_ABORT) && args.get(PARAM_ABORT).getAsBoolean()) {
-            return runGit(CMD_REBASE, "--abort");
+            return runGitIn(root, CMD_REBASE, "--abort");
         }
         if (args.has(PARAM_CONTINUE_REBASE) && args.get(PARAM_CONTINUE_REBASE).getAsBoolean()) {
-            return runGit(CMD_REBASE, "--continue");
+            return runGitIn(root, CMD_REBASE, "--continue");
         }
         if (args.has("skip") && args.get("skip").getAsBoolean()) {
-            return runGit(CMD_REBASE, "--skip");
+            return runGitIn(root, CMD_REBASE, "--skip");
         }
         if (args.has(PARAM_INTERACTIVE) && args.get(PARAM_INTERACTIVE).getAsBoolean()) {
             return "Error: interactive rebase requires a terminal text editor and cannot run in the plugin context. " +

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitRemoteTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitRemoteTool.java
@@ -48,41 +48,46 @@ public final class GitRemoteTool extends GitTool {
         return schema(
             Param.optional(PARAM_ACTION, TYPE_STRING, "Action: 'list' (default), 'add', 'remove', 'set_url', 'get_url'"),
             Param.optional("name", TYPE_STRING, "Remote name (required for add/remove/set_url/get_url)"),
-            Param.optional("url", TYPE_STRING, "Remote URL (required for add/set_url)")
+            Param.optional("url", TYPE_STRING, "Remote URL (required for add/set_url)"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
         String action = args.has(PARAM_ACTION)
             ? args.get(PARAM_ACTION).getAsString()
             : "list";
 
         return switch (action) {
-            case "list" -> runGit(GIT_REMOTE, "-v");
+            case "list" -> runGitIn(root, GIT_REMOTE, "-v");
             case "add" -> {
                 String name = requireString(args, "name");
                 String url = requireString(args, "url");
                 if (name == null) yield "Error: 'name' parameter is required for 'add'";
                 if (url == null) yield "Error: 'url' parameter is required for 'add'";
-                yield runGit(GIT_REMOTE, "add", name, url);
+                yield runGitIn(root, GIT_REMOTE, "add", name, url);
             }
             case "remove" -> {
                 String name = requireString(args, "name");
                 if (name == null) yield "Error: 'name' parameter is required for 'remove'";
-                yield runGit(GIT_REMOTE, "remove", name);
+                yield runGitIn(root, GIT_REMOTE, "remove", name);
             }
             case "set_url" -> {
                 String name = requireString(args, "name");
                 String url = requireString(args, "url");
                 if (name == null) yield "Error: 'name' parameter is required for 'set_url'";
                 if (url == null) yield "Error: 'url' parameter is required for 'set_url'";
-                yield runGit(GIT_REMOTE, "set-url", name, url);
+                yield runGitIn(root, GIT_REMOTE, "set-url", name, url);
             }
             case "get_url" -> {
                 String name = requireString(args, "name");
                 if (name == null) yield "Error: 'name' parameter is required for 'get_url'";
-                yield runGit(GIT_REMOTE, "get-url", name);
+                yield runGitIn(root, GIT_REMOTE, "get-url", name);
             }
             default -> "Error: unknown action '" + action + "'. Use: list, add, remove, set_url, get_url";
         };

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitRemoteTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitRemoteTool.java
@@ -56,12 +56,19 @@ public final class GitRemoteTool extends GitTool {
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
-        String root = resolveRepoRootOrError(repoParam);
-        if (root.startsWith("Error")) return root;
 
         String action = args.has(PARAM_ACTION)
             ? args.get(PARAM_ACTION).getAsString()
             : "list";
+
+        // Write actions require an unambiguous repo
+        if (action.equals("add") || action.equals("remove") || action.equals("set_url")) {
+            String ambiError = requireUnambiguousRepo(repoParam, "git_remote " + action);
+            if (ambiError != null) return ambiError;
+        }
+
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
 
         return switch (action) {
             case "list" -> runGitIn(root, GIT_REMOTE, "-v");

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitResetTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitResetTool.java
@@ -57,13 +57,21 @@ public final class GitResetTool extends GitTool {
         return schema(
             Param.optional(PARAM_COMMIT, TYPE_STRING, "Target commit (default: HEAD)"),
             Param.optional("mode", TYPE_STRING, "Reset mode: 'soft' (keep staged), 'mixed' (default, unstage), 'hard' (discard all changes)"),
-            Param.optional("path", TYPE_STRING, "Reset a specific file path (unstages it)")
+            Param.optional("path", TYPE_STRING, "Reset a specific file path (unstages it)"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         flushAndSave();
+
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String ambiError = requireUnambiguousRepo(repoParam, "git_reset");
+        if (ambiError != null) return ambiError;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add("reset");
 
@@ -80,7 +88,7 @@ public final class GitResetTool extends GitTool {
             }
         }
 
-        String result = runGit(cmdArgs.toArray(String[]::new));
+        String result = runGitIn(root, cmdArgs.toArray(String[]::new));
         if (!result.isBlank() && result.startsWith("Error")) return result;
         // Invalidate after hard reset (worktree changed)
         String mode = args.has("mode") ? args.get("mode").getAsString() : "mixed";

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitRevertTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitRevertTool.java
@@ -45,7 +45,8 @@ public final class GitRevertTool extends GitTool {
         return schema(
             Param.required(PARAM_COMMIT, TYPE_STRING, "Commit SHA to revert"),
             Param.optional(PARAM_NO_COMMIT, TYPE_BOOLEAN, "If true, revert changes to working tree without creating a commit"),
-            Param.optional(PARAM_NO_EDIT, TYPE_BOOLEAN, "If true, use the default commit message without editing")
+            Param.optional(PARAM_NO_EDIT, TYPE_BOOLEAN, "If true, use the default commit message without editing"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
@@ -54,6 +55,12 @@ public final class GitRevertTool extends GitTool {
         if (!args.has(PARAM_COMMIT) || args.get(PARAM_COMMIT).getAsString().isEmpty()) {
             return "Error: 'commit' parameter is required";
         }
+
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String ambiError = requireUnambiguousRepo(repoParam, "git_revert");
+        if (ambiError != null) return ambiError;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
 
         String reviewError = AgentEditSession.getInstance(project)
             .awaitReviewCompletion("git revert");
@@ -75,7 +82,7 @@ public final class GitRevertTool extends GitTool {
 
         cmdArgs.add(args.get(PARAM_COMMIT).getAsString());
 
-        String result = runGit(cmdArgs.toArray(String[]::new));
+        String result = runGitIn(root, cmdArgs.toArray(String[]::new));
         if (!result.startsWith("Error")) {
             AgentEditSession.getInstance(project).invalidateOnWorktreeChange("git revert");
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitShowTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitShowTool.java
@@ -48,12 +48,17 @@ public final class GitShowTool extends GitTool {
         return schema(
             Param.optional("ref", TYPE_STRING, "Commit SHA, branch, tag, or ref (default: HEAD)"),
             Param.optional(PARAM_STAT_ONLY, TYPE_BOOLEAN, "If true, show only file stats, not full diff content"),
-            Param.optional("path", TYPE_STRING, "Limit output to this file path")
+            Param.optional("path", TYPE_STRING, "Limit output to this file path"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add("show");
 
@@ -73,7 +78,7 @@ public final class GitShowTool extends GitTool {
             cmdArgs.add(args.get("path").getAsString());
         }
 
-        String result = runGit(cmdArgs.toArray(String[]::new));
+        String result = runGitIn(root, cmdArgs.toArray(String[]::new));
         showFirstCommitInLog(result);
         return result;
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStageTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStageTool.java
@@ -56,7 +56,8 @@ public final class GitStageTool extends GitTool {
         JsonObject s = schema(
             Param.optional("path", TYPE_STRING, "Single file path to stage"),
             Param.optional(PARAM_PATHS, TYPE_ARRAY, "Multiple file paths to stage"),
-            Param.optional("all", TYPE_BOOLEAN, "If true, stage all changes (including untracked files)")
+            Param.optional("all", TYPE_BOOLEAN, "If true, stage all changes (including untracked files)"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
         addArrayItems(s, PARAM_PATHS);
         return s;
@@ -66,6 +67,12 @@ public final class GitStageTool extends GitTool {
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         flushAndSave();
 
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String ambiError = requireUnambiguousRepo(repoParam, "git_stage");
+        if (ambiError != null) return ambiError;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add("add");
 
@@ -74,7 +81,7 @@ public final class GitStageTool extends GitTool {
             return "Error: provide 'path', 'paths', or 'all' parameter";
         }
 
-        String result = runGit(cmdArgs.toArray(String[]::new));
+        String result = runGitIn(root, cmdArgs.toArray(String[]::new));
 
         refreshAndActivateCommitPanel();
 
@@ -87,7 +94,7 @@ public final class GitStageTool extends GitTool {
 
         if (base.startsWith("Error")) return base;
 
-        return base + getBranchSummary();
+        return base + getBranchSummaryIn(root);
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStashTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStashTool.java
@@ -56,18 +56,25 @@ public final class GitStashTool extends GitTool {
             Param.optional(PARAM_ACTION, TYPE_STRING, "Action: 'list' (default), 'push', 'pop', 'apply', 'drop'"),
             Param.optional(PARAM_MESSAGE, TYPE_STRING, "Stash message (for push action)"),
             Param.optional(PARAM_INDEX, TYPE_STRING, "Stash index (for pop/apply/drop, e.g., 'stash@{0}')"),
-            Param.optional(PARAM_INCLUDE_UNTRACKED, TYPE_BOOLEAN, "For push: include untracked files")
+            Param.optional(PARAM_INCLUDE_UNTRACKED, TYPE_BOOLEAN, "For push: include untracked files"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String ambiError = requireUnambiguousRepo(repoParam, "git_stash");
+        if (ambiError != null) return ambiError;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
         String action = args.has(PARAM_ACTION)
             ? args.get(PARAM_ACTION).getAsString()
             : "list";
 
         return switch (action) {
-            case "list" -> runGit(CMD_STASH, "list");
+            case "list" -> runGitIn(root, CMD_STASH, "list");
             case "push", "save" -> {
                 List<String> cmdArgs = new ArrayList<>();
                 cmdArgs.add(CMD_STASH);
@@ -82,7 +89,7 @@ public final class GitStashTool extends GitTool {
                     cmdArgs.add("--include-untracked");
                 }
 
-                yield runGit(cmdArgs.toArray(String[]::new));
+                yield runGitIn(root, cmdArgs.toArray(String[]::new));
             }
             case "pop" -> {
                 String reviewError = AgentEditSession.getInstance(project)
@@ -90,8 +97,8 @@ public final class GitStashTool extends GitTool {
                 if (reviewError != null) yield reviewError;
                 String index = stashRef(args);
                 String result = index != null
-                    ? runGit(CMD_STASH, "pop", index)
-                    : runGit(CMD_STASH, "pop");
+                    ? runGitIn(root, CMD_STASH, "pop", index)
+                    : runGitIn(root, CMD_STASH, "pop");
                 AgentEditSession.getInstance(project).invalidateOnWorktreeChange("stash pop");
                 yield result;
             }
@@ -101,16 +108,16 @@ public final class GitStashTool extends GitTool {
                 if (reviewError != null) yield reviewError;
                 String index = stashRef(args);
                 String result = index != null
-                    ? runGit(CMD_STASH, ACTION_APPLY, index)
-                    : runGit(CMD_STASH, ACTION_APPLY);
+                    ? runGitIn(root, CMD_STASH, ACTION_APPLY, index)
+                    : runGitIn(root, CMD_STASH, ACTION_APPLY);
                 AgentEditSession.getInstance(project).invalidateOnWorktreeChange("stash apply");
                 yield result;
             }
             case "drop" -> {
                 String index = stashRef(args);
                 yield index != null
-                    ? runGit(CMD_STASH, "drop", index)
-                    : runGit(CMD_STASH, "drop");
+                    ? runGitIn(root, CMD_STASH, "drop", index)
+                    : runGitIn(root, CMD_STASH, "drop");
             }
             default -> "Error: unknown action '" + action + "'. Use: list, push, pop, apply, drop";
         };

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStashTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStashTool.java
@@ -64,8 +64,6 @@ public final class GitStashTool extends GitTool {
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
-        String ambiError = requireUnambiguousRepo(repoParam, "git_stash");
-        if (ambiError != null) return ambiError;
         String root = resolveRepoRootOrError(repoParam);
         if (root.startsWith("Error")) return root;
 
@@ -76,6 +74,9 @@ public final class GitStashTool extends GitTool {
         return switch (action) {
             case "list" -> runGitIn(root, CMD_STASH, "list");
             case "push", "save" -> {
+                String ambiError = requireUnambiguousRepo(repoParam, "git_stash push");
+                if (ambiError != null) yield ambiError;
+
                 List<String> cmdArgs = new ArrayList<>();
                 cmdArgs.add(CMD_STASH);
                 cmdArgs.add("push");
@@ -92,6 +93,9 @@ public final class GitStashTool extends GitTool {
                 yield runGitIn(root, cmdArgs.toArray(String[]::new));
             }
             case "pop" -> {
+                String ambiError = requireUnambiguousRepo(repoParam, "git_stash pop");
+                if (ambiError != null) yield ambiError;
+
                 String reviewError = AgentEditSession.getInstance(project)
                     .awaitReviewCompletion("stash pop");
                 if (reviewError != null) yield reviewError;
@@ -103,6 +107,9 @@ public final class GitStashTool extends GitTool {
                 yield result;
             }
             case ACTION_APPLY -> {
+                String ambiError = requireUnambiguousRepo(repoParam, "git_stash apply");
+                if (ambiError != null) yield ambiError;
+
                 String reviewError = AgentEditSession.getInstance(project)
                     .awaitReviewCompletion("stash apply");
                 if (reviewError != null) yield reviewError;
@@ -114,6 +121,9 @@ public final class GitStashTool extends GitTool {
                 yield result;
             }
             case "drop" -> {
+                String ambiError = requireUnambiguousRepo(repoParam, "git_stash drop");
+                if (ambiError != null) yield ambiError;
+
                 String index = stashRef(args);
                 yield index != null
                     ? runGitIn(root, CMD_STASH, "drop", index)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStatusTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStatusTool.java
@@ -27,7 +27,9 @@ public final class GitStatusTool extends GitTool {
     @Override
     public @NotNull String description() {
         return "Show working tree status including branch tracking info and stash count. "
-            + "Use verbose: true for full output including untracked files.";
+            + "Use verbose: true for full output including untracked files. "
+            + "When the project has multiple git repositories, returns an aggregate summary "
+            + "for all repos unless a specific 'repo' path is provided.";
     }
 
     @Override
@@ -43,7 +45,8 @@ public final class GitStatusTool extends GitTool {
     @Override
     public @NotNull JsonObject inputSchema() {
         return schema(
-            Param.optional(PARAM_VERBOSE, TYPE_BOOLEAN, "If true, show full 'git status' output including untracked files")
+            Param.optional(PARAM_VERBOSE, TYPE_BOOLEAN, "If true, show full 'git status' output including untracked files"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
@@ -51,18 +54,28 @@ public final class GitStatusTool extends GitTool {
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         flushAndSave();
 
-        boolean verbose = args.has(PARAM_VERBOSE)
-            && args.get(PARAM_VERBOSE).getAsBoolean();
+        boolean verbose = args.has(PARAM_VERBOSE) && args.get(PARAM_VERBOSE).getAsBoolean();
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
 
-        String result;
-        if (verbose) {
-            result = runGit("status");
-        } else {
-            result = runGit("status", "--short", "--branch");
+        if (isMultiRepo() && repoParam == null) {
+            return aggregateMultiRepoStatus(verbose);
         }
 
-        // Append stash count if any
-        String stashList = runGitQuiet("stash", "list");
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
+        return statusForRoot(root, verbose);
+    }
+
+    private String statusForRoot(String root, boolean verbose) throws Exception {
+        String result;
+        if (verbose) {
+            result = runGitIn(root, "status");
+        } else {
+            result = runGitIn(root, "status", "--short", "--branch");
+        }
+
+        String stashList = runGitInQuiet(root, "stash", "list");
         if (stashList != null && !stashList.isEmpty()) {
             long count = stashList.chars().filter(c -> c == '\n').count();
             if (!stashList.endsWith("\n")) count++;
@@ -72,6 +85,16 @@ public final class GitStatusTool extends GitTool {
         }
 
         return result;
+    }
+
+    private String aggregateMultiRepoStatus(boolean verbose) throws Exception {
+        StringBuilder sb = new StringBuilder();
+        for (String root : listRepoRoots()) {
+            String relRoot = toRelativePath(root, project.getBasePath() != null ? project.getBasePath() : root);
+            sb.append("=== ").append(relRoot).append(" ===\n");
+            sb.append(statusForRoot(root, verbose)).append('\n');
+        }
+        return sb.toString().stripTrailing();
     }
 
     @Override

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStatusTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStatusTool.java
@@ -88,11 +88,19 @@ public final class GitStatusTool extends GitTool {
     }
 
     private String aggregateMultiRepoStatus(boolean verbose) throws Exception {
+        java.util.List<git4idea.repo.GitRepository> repos;
+        try {
+            repos = com.github.catatafishen.agentbridge.psi.PlatformApiCompat.getRepositories(project);
+        } catch (NoClassDefFoundError e) {
+            repos = java.util.Collections.emptyList();
+        }
+        String basePath = project.getBasePath();
         StringBuilder sb = new StringBuilder();
-        for (String root : listRepoRoots()) {
-            String relRoot = toRelativePath(root, project.getBasePath() != null ? project.getBasePath() : root);
+        for (git4idea.repo.GitRepository repo : repos) {
+            String absRoot = repo.getRoot().getPath();
+            String relRoot = toRelativePath(absRoot, basePath);
             sb.append("=== ").append(relRoot).append(" ===\n");
-            sb.append(statusForRoot(root, verbose)).append('\n');
+            sb.append(statusForRoot(absRoot, verbose)).append('\n');
         }
         return sb.toString().stripTrailing();
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTagTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTagTool.java
@@ -59,12 +59,19 @@ public final class GitTagTool extends GitTool {
             Param.optional(PARAM_MESSAGE, TYPE_STRING, "Tag message (for annotated tags)"),
             Param.optional(PARAM_ANNOTATE, TYPE_BOOLEAN, "Create an annotated tag (requires message)"),
             Param.optional(PARAM_PATTERN, TYPE_STRING, "Glob pattern to filter tags (for list)"),
-            Param.optional("sort", TYPE_STRING, "Sort field for list (e.g., '-creatordate' for newest first)")
+            Param.optional("sort", TYPE_STRING, "Sort field for list (e.g., '-creatordate' for newest first)"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
     }
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String ambiError = requireUnambiguousRepo(repoParam, "git_tag");
+        if (ambiError != null) return ambiError;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
         String action = args.has(PARAM_ACTION)
             ? args.get(PARAM_ACTION).getAsString()
             : "list";
@@ -83,7 +90,7 @@ public final class GitTagTool extends GitTool {
                     cmdArgs.add("--sort=" + args.get("sort").getAsString());
                 }
 
-                yield runGit(cmdArgs.toArray(String[]::new));
+                yield runGitIn(root, cmdArgs.toArray(String[]::new));
             }
             case "create" -> {
                 String name = requireName(args);
@@ -114,12 +121,12 @@ public final class GitTagTool extends GitTool {
                     cmdArgs.add(message);
                 }
 
-                yield runGit(cmdArgs.toArray(String[]::new));
+                yield runGitIn(root, cmdArgs.toArray(String[]::new));
             }
             case "delete" -> {
                 String name = requireName(args);
                 if (name == null) yield "Error: 'name' parameter is required for 'delete'";
-                yield runGit("tag", "-d", name);
+                yield runGitIn(root, "tag", "-d", name);
             }
             default -> "Error: unknown action '" + action + "'. Use: list, create, delete";
         };

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTagTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTagTool.java
@@ -67,8 +67,6 @@ public final class GitTagTool extends GitTool {
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
         String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
-        String ambiError = requireUnambiguousRepo(repoParam, "git_tag");
-        if (ambiError != null) return ambiError;
         String root = resolveRepoRootOrError(repoParam);
         if (root.startsWith("Error")) return root;
 
@@ -93,6 +91,9 @@ public final class GitTagTool extends GitTool {
                 yield runGitIn(root, cmdArgs.toArray(String[]::new));
             }
             case "create" -> {
+                String ambiError = requireUnambiguousRepo(repoParam, "git_tag create");
+                if (ambiError != null) yield ambiError;
+
                 String name = requireName(args);
                 if (name == null) yield "Error: 'name' parameter is required for 'create'";
 
@@ -124,6 +125,9 @@ public final class GitTagTool extends GitTool {
                 yield runGitIn(root, cmdArgs.toArray(String[]::new));
             }
             case "delete" -> {
+                String ambiError = requireUnambiguousRepo(repoParam, "git_tag delete");
+                if (ambiError != null) yield ambiError;
+
                 String name = requireName(args);
                 if (name == null) yield "Error: 'name' parameter is required for 'delete'";
                 yield runGitIn(root, "tag", "-d", name);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
@@ -23,15 +23,24 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Abstract base for git tools. Provides git process execution, VCS refresh,
  * branch context enrichment, auto-fetch throttling, and IDE follow-along helpers.
+ *
+ * <p>Multi-repo support: when a project contains more than one git repository,
+ * tools accept an optional {@code repo} parameter (relative path from the project root,
+ * e.g. {@code "backend"}) to select the target repository. Read operations default to
+ * the primary repository when no selector is given; write operations require an explicit
+ * selector and return an actionable error when the project is ambiguous.
  */
 @SuppressWarnings("java:S112") // generic exceptions caught at JSON-RPC dispatch level
 public abstract class GitTool extends Tool {
@@ -47,8 +56,31 @@ public abstract class GitTool extends Tool {
     static final Pattern COMMIT_LINE_PATTERN =
         Pattern.compile("^commit ([0-9a-f]{40})$", Pattern.MULTILINE);
 
+    // ── Multi-repo selectors ─────────────────────────────────
+
+    /**
+     * Shared parameter name for the optional repository selector.
+     */
+    protected static final String PARAM_REPO = "repo";
+
+    /**
+     * Description for the optional {@code repo} parameter in tool schemas.
+     * Only shown/needed for multi-repo projects; benign extra field for single-repo.
+     */
+    static final String REPO_PARAM_DESCRIPTION =
+        "Optional: relative path of the git repository root to target (e.g. 'backend'). "
+            + "Only needed when the project contains multiple git repositories. "
+            + "Use git_status with no parameters to discover available repositories.";
+
+    // ── Auto-fetch throttling (per-repo) ─────────────────────
+
     protected static final long FETCH_THROTTLE_MS = 60_000;
-    protected static final AtomicLong lastFetchTime = new AtomicLong(0);
+
+    /**
+     * Per-repo auto-fetch timestamps, keyed by absolute repository root path.
+     */
+    private static final ConcurrentHashMap<String, AtomicLong> lastFetchTimes =
+        new ConcurrentHashMap<>();
 
     protected GitTool(Project project) {
         super(project);
@@ -74,6 +106,116 @@ public abstract class GitTool extends Tool {
         return !isReadOnly();
     }
 
+    // ── Multi-repo helpers ───────────────────────────────────
+
+    /**
+     * Returns true when the project contains more than one registered git repository.
+     */
+    protected boolean isMultiRepo() {
+        try {
+            return PlatformApiCompat.getRepositories(project).size() > 1;
+        } catch (NoClassDefFoundError e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the relative paths (from the project root) of all registered git repositories.
+     * Returns {@code ["."]} for a project root repo, {@code ["backend", "frontend"]} for
+     * side-by-side repos, etc. Used for error messages and status summaries.
+     */
+    protected List<String> listRepoRoots() {
+        try {
+            List<git4idea.repo.GitRepository> repos = PlatformApiCompat.getRepositories(project);
+            String basePath = project.getBasePath();
+            return repos.stream()
+                .map(r -> toRelativePath(r.getRoot().getPath(), basePath))
+                .collect(Collectors.toList());
+        } catch (NoClassDefFoundError e) {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Resolves the absolute repository root to use for a git command.
+     *
+     * <ul>
+     *   <li>If {@code repoParam} is non-null: finds the repo matching that relative path and
+     *       returns its absolute root, or an {@code "Error: ..."} string if not found.</li>
+     *   <li>If single repo: returns that repo's root (possibly a subdirectory of basePath).</li>
+     *   <li>If zero repos (git not initialised): returns {@code project.getBasePath()}.</li>
+     *   <li>If multiple repos and no param: returns the primary root (basePath-matching or first)
+     *       — callers that perform writes should call {@link #requireUnambiguousRepo} first.</li>
+     * </ul>
+     *
+     * @return absolute root path, or a string starting with {@code "Error:"} on failure
+     */
+    @NotNull
+    protected String resolveRepoRootOrError(@Nullable String repoParam) {
+        List<git4idea.repo.GitRepository> repos;
+        try {
+            repos = PlatformApiCompat.getRepositories(project);
+        } catch (NoClassDefFoundError e) {
+            repos = Collections.emptyList();
+        }
+
+        if (repoParam != null && !repoParam.isEmpty()) {
+            String basePath = project.getBasePath();
+            // Accept both relative (e.g. "backend") and absolute paths
+            String absParam = (basePath != null && !new File(repoParam).isAbsolute())
+                ? new File(basePath, repoParam).getAbsolutePath().replace("\\", "/")
+                : repoParam.replace("\\", "/");
+
+            for (git4idea.repo.GitRepository r : repos) {
+                if (r.getRoot().getPath().equals(absParam)) return r.getRoot().getPath();
+            }
+            String available = repos.isEmpty() ? "none"
+                : repos.stream()
+                  .map(r -> "'" + toRelativePath(r.getRoot().getPath(), project.getBasePath()) + "'")
+                  .collect(Collectors.joining(", "));
+            return "Error: repository '" + repoParam + "' not found. Available: " + available
+                + ". Use git_status to list repositories.";
+        }
+
+        if (repos.isEmpty()) {
+            String basePath = project.getBasePath();
+            return basePath != null ? basePath : "Error: no project base path";
+        }
+
+        if (repos.size() == 1) {
+            return repos.getFirst().getRoot().getPath();
+        }
+
+        // Multiple repos: prefer the one rooted at basePath, otherwise use first.
+        String basePath = project.getBasePath();
+        if (basePath != null) {
+            for (git4idea.repo.GitRepository r : repos) {
+                if (r.getRoot().getPath().equals(basePath)) return r.getRoot().getPath();
+            }
+        }
+        return repos.getFirst().getRoot().getPath();
+    }
+
+    /**
+     * For write operations: returns an error string when the project has multiple repositories
+     * and no {@code repo} selector was given; returns null when it is safe to proceed.
+     *
+     * @param repoParam the value of the {@code repo} parameter (may be null)
+     * @param action    human-readable action name for the error message
+     */
+    @Nullable
+    protected String requireUnambiguousRepo(@Nullable String repoParam, @NotNull String action) {
+        if (repoParam != null && !repoParam.isEmpty()) return null;
+        if (!isMultiRepo()) return null;
+
+        String repoList = listRepoRoots().stream()
+            .map(r -> "'" + r + "'")
+            .collect(Collectors.joining(", "));
+        return "Error: project has multiple git repositories (" + repoList + "). "
+            + "Specify which repository to use with the 'repo' parameter for '"
+            + action + "'. Use git_status to see all repositories.";
+    }
+
     // ── Branch context enrichment ────────────────────────────
 
     /**
@@ -84,26 +226,60 @@ public abstract class GitTool extends Tool {
      * @return formatted context block, or empty string if branch detection fails
      */
     protected String getBranchContext() {
+        return getBranchContextIn(resolveRepoRootOrError(null));
+    }
+
+    /**
+     * Root-aware variant of {@link #getBranchContext()}.
+     * Use when the repo root has already been resolved for the current tool call.
+     */
+    protected String getBranchContextIn(@NotNull String rootDir) {
+        if (rootDir.startsWith("Error")) return "";
         StringBuilder ctx = new StringBuilder();
 
-        String branch = runGitQuiet("rev-parse", "--abbrev-ref", "HEAD");
+        String branch = runGitInQuiet(rootDir, "rev-parse", "--abbrev-ref", "HEAD");
         if (branch == null) return "";
 
         ctx.append("\n\n--- Context ---\n");
         ctx.append("On branch: ").append(branch).append('\n');
 
-        String tracking = runGitQuiet("rev-parse", "--abbrev-ref", "@{upstream}");
+        String tracking = runGitInQuiet(rootDir, "rev-parse", "--abbrev-ref", "@{upstream}");
         if (tracking != null) {
             ctx.append("Tracking: ").append(tracking);
-            appendAheadBehind(ctx, tracking);
+            appendAheadBehindIn(ctx, rootDir, tracking);
             ctx.append('\n');
         } else {
             ctx.append("Tracking: none (no upstream set — use git_push with set_upstream: true)\n");
         }
 
-        appendDivergenceFromDefault(ctx, branch);
-        appendWorkingTreeStatus(ctx);
-        appendStashCount(ctx);
+        // Divergence from default branch
+        String defaultBranch = detectDefaultBranchIn(rootDir);
+        if (defaultBranch != null && !defaultBranch.equals(branch)) {
+            String count = runGitInQuiet(rootDir, "rev-list", "--count", defaultBranch + "..HEAD");
+            if (count != null && !"0".equals(count)) {
+                ctx.append("Branch has ").append(count)
+                    .append(" commit(s) since ").append(defaultBranch).append('\n');
+            }
+        }
+
+        // Working tree status
+        String porcelain = runGitInQuiet(rootDir, "status", "--porcelain");
+        if (porcelain != null) {
+            if (porcelain.isEmpty()) {
+                ctx.append("Working tree: clean\n");
+            } else {
+                ctx.append("Working tree: ").append(formatPorcelainStatus(porcelain)).append('\n');
+            }
+        }
+
+        // Stash count
+        String stashList = runGitInQuiet(rootDir, "stash", "list");
+        if (stashList != null && !stashList.isEmpty()) {
+            long count = countStashEntries(stashList);
+            if (count > 0) {
+                ctx.append("Stash: ").append(count).append(" entr").append(count == 1 ? "y" : "ies").append('\n');
+            }
+        }
 
         return ctx.toString();
     }
@@ -112,48 +288,33 @@ public abstract class GitTool extends Tool {
      * Returns a compact one-line branch summary (for tools that want less verbosity).
      */
     protected String getBranchSummary() {
-        String branch = runGitQuiet("rev-parse", "--abbrev-ref", "HEAD");
+        return getBranchSummaryIn(resolveRepoRootOrError(null));
+    }
+
+    /**
+     * Root-aware variant of {@link #getBranchSummary()}.
+     */
+    protected String getBranchSummaryIn(@NotNull String rootDir) {
+        if (rootDir.startsWith("Error")) return "";
+        String branch = runGitInQuiet(rootDir, "rev-parse", "--abbrev-ref", "HEAD");
         if (branch == null) return "";
 
         StringBuilder sb = new StringBuilder();
         sb.append("\nBranch: ").append(branch);
 
-        String tracking = runGitQuiet("rev-parse", "--abbrev-ref", "@{upstream}");
+        String tracking = runGitInQuiet(rootDir, "rev-parse", "--abbrev-ref", "@{upstream}");
         if (tracking != null) {
-            appendAheadBehind(sb, tracking);
+            appendAheadBehindIn(sb, rootDir, tracking);
         }
         return sb.toString();
     }
 
-    private void appendAheadBehind(StringBuilder ctx, String tracking) {
-        String ahead = runGitQuiet("rev-list", "--count", tracking + "..HEAD");
-        String behind = runGitQuiet("rev-list", "--count", "HEAD.." + tracking);
+    private void appendAheadBehindIn(@NotNull StringBuilder sb, @NotNull String rootDir, @NotNull String tracking) {
+        String ahead = runGitInQuiet(rootDir, "rev-list", "--count", tracking + "..HEAD");
+        String behind = runGitInQuiet(rootDir, "rev-list", "--count", "HEAD.." + tracking);
         if (ahead != null && behind != null) {
-            ctx.append(" (ahead ").append(ahead).append(", behind ").append(behind).append(')');
+            sb.append(" (ahead ").append(ahead).append(", behind ").append(behind).append(')');
         }
-    }
-
-    private void appendDivergenceFromDefault(StringBuilder ctx, String currentBranch) {
-        String defaultBranch = detectDefaultBranch();
-        if (defaultBranch == null || defaultBranch.equals(currentBranch)) return;
-
-        String count = runGitQuiet("rev-list", "--count", defaultBranch + "..HEAD");
-        if (count != null && !"0".equals(count)) {
-            ctx.append("Branch has ").append(count)
-                .append(" commit(s) since ").append(defaultBranch).append('\n');
-        }
-    }
-
-    private void appendWorkingTreeStatus(StringBuilder ctx) {
-        String porcelain = runGitQuiet("status", "--porcelain");
-        if (porcelain == null) return;
-
-        if (porcelain.isEmpty()) {
-            ctx.append("Working tree: clean\n");
-            return;
-        }
-
-        ctx.append("Working tree: ").append(formatPorcelainStatus(porcelain)).append('\n');
     }
 
     /**
@@ -183,15 +344,6 @@ public abstract class GitTool extends Tool {
         return String.join(", ", parts);
     }
 
-    private void appendStashCount(StringBuilder ctx) {
-        String stashList = runGitQuiet("stash", "list");
-        if (stashList == null || stashList.isEmpty()) return;
-        long count = countStashEntries(stashList);
-        if (count > 0) {
-            ctx.append("Stash: ").append(count).append(" entr").append(count == 1 ? "y" : "ies").append('\n');
-        }
-    }
-
     /**
      * Counts the number of stash entries from {@code git stash list} output. Pure function.
      */
@@ -218,16 +370,20 @@ public abstract class GitTool extends Tool {
     }
 
     /**
-     * Detects the default branch (origin/main or origin/master).
+     * Detects the default branch (origin/main or origin/master) in the primary repo.
      */
     @Nullable
     protected String detectDefaultBranch() {
-        String symbolic = runGitQuiet("symbolic-ref", "refs/remotes/origin/HEAD");
+        return detectDefaultBranchIn(resolveRepoRootOrError(null));
+    }
+
+    @Nullable
+    private String detectDefaultBranchIn(@NotNull String rootDir) {
+        String symbolic = runGitInQuiet(rootDir, "symbolic-ref", "refs/remotes/origin/HEAD");
         if (symbolic != null) {
             return symbolic.replace("refs/remotes/", "");
         }
-        // Fallback: check common names
-        String branches = runGitQuiet("branch", "-r", "--list", "origin/main", "origin/master");
+        String branches = runGitInQuiet(rootDir, "branch", "-r", "--list", "origin/main", "origin/master");
         if (branches == null) return null;
         if (branches.contains("origin/main")) return "origin/main";
         if (branches.contains("origin/master")) return "origin/master";
@@ -237,19 +393,27 @@ public abstract class GitTool extends Tool {
     // ── Auto-fetch throttling ────────────────────────────────
 
     /**
-     * Fetches from origin if the last fetch was more than 60 seconds ago.
+     * Fetches from origin in the primary repo if the last fetch was more than 60 seconds ago.
      * Returns a note about what was fetched, or empty string if throttled/failed.
-     * This prevents agents from working with stale remote refs.
      */
     protected String autoFetchIfStale() {
-        long now = System.currentTimeMillis();
-        long last = lastFetchTime.get();
-        if (now - last < FETCH_THROTTLE_MS) return "";
+        String root = resolveRepoRootOrError(null);
+        return root.startsWith("Error") ? "" : autoFetchIfStaleIn(root);
+    }
 
-        if (!lastFetchTime.compareAndSet(last, now)) return "";
+    /**
+     * Root-aware variant of {@link #autoFetchIfStale()}.
+     * Throttle is tracked per repository root to avoid cross-repo interference.
+     */
+    protected String autoFetchIfStaleIn(@NotNull String rootDir) {
+        AtomicLong timer = lastFetchTimes.computeIfAbsent(rootDir, k -> new AtomicLong(0));
+        long now = System.currentTimeMillis();
+        long last = timer.get();
+        if (now - last < FETCH_THROTTLE_MS) return "";
+        if (!timer.compareAndSet(last, now)) return "";
 
         try {
-            String result = runGit("fetch", "--quiet", "origin");
+            String result = runGitIn(rootDir, "fetch", "--quiet", "origin");
             if (result != null && !result.isBlank() && !result.startsWith("Error")) {
                 return "(auto-fetched latest from origin)\n";
             }
@@ -273,16 +437,41 @@ public abstract class GitTool extends Tool {
         return "";
     }
 
+    /**
+     * Root-aware variant of {@link #autoFetchForRemoteRef(String)}.
+     */
+    protected String autoFetchForRemoteRefIn(@Nullable String ref, @NotNull String rootDir) {
+        if (ref == null) return "";
+        if (ref.startsWith("origin/") || ref.startsWith("remotes/")) {
+            return autoFetchIfStaleIn(rootDir);
+        }
+        return "";
+    }
+
     // ── Run git (quiet variant for metadata) ─────────────────
 
     /**
-     * Runs a git command and returns trimmed stdout, or null on any error.
+     * Runs a git command in the primary repository and returns trimmed stdout, or null on error.
      * Used for lightweight metadata queries that must not fail loudly.
      */
     @Nullable
     protected String runGitQuiet(String... args) {
         try {
             String result = runGit(args);
+            if (result == null || result.startsWith("Error")) return null;
+            return result.trim();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Runs a git command in {@code rootDir} and returns trimmed stdout, or null on any error.
+     */
+    @Nullable
+    protected String runGitInQuiet(@NotNull String rootDir, String... args) {
+        try {
+            String result = runGitIn(rootDir, args);
             if (result == null || result.startsWith("Error")) return null;
             return result.trim();
         } catch (Exception e) {
@@ -302,7 +491,7 @@ public abstract class GitTool extends Tool {
     }
 
     /**
-     * Run a git command, preferring IntelliJ's Git4Idea infrastructure.
+     * Run a git command in the primary repository, preferring IntelliJ's Git4Idea infrastructure.
      * Falls back to ProcessBuilder if Git4Idea is unavailable.
      */
     protected String runGit(String... args) throws Exception {
@@ -312,10 +501,16 @@ public abstract class GitTool extends Tool {
         try {
             result = PlatformApiCompat.runIdeGitCommand(project, args);
             if (result == null) {
-                result = runGitProcess(args);
+                String basePath = project.getBasePath();
+                result = basePath != null
+                    ? runGitProcess(basePath, args)
+                    : "Error: no project base path";
             }
         } catch (NoClassDefFoundError e) {
-            result = runGitProcess(args);
+            String basePath = project.getBasePath();
+            result = basePath != null
+                ? runGitProcess(basePath, args)
+                : "Error: no project base path";
         }
 
         if (WRITE_COMMANDS.contains(args[0])) {
@@ -325,17 +520,38 @@ public abstract class GitTool extends Tool {
         return result;
     }
 
-    private String runGitProcess(String... args) throws Exception {
-        String basePath = project.getBasePath();
-        if (basePath == null) return "Error: no project base path";
+    /**
+     * Run a git command in the specified repository root directory.
+     * Prefers Git4Idea infrastructure; falls back to ProcessBuilder.
+     */
+    protected String runGitIn(@NotNull String rootDir, String... args) throws Exception {
+        if (args.length == 0) return "Error: no git command";
 
+        String result;
+        try {
+            result = PlatformApiCompat.runIdeGitCommandIn(project, rootDir, args);
+            if (result == null) {
+                result = runGitProcess(rootDir, args);
+            }
+        } catch (NoClassDefFoundError e) {
+            result = runGitProcess(rootDir, args);
+        }
+
+        if (WRITE_COMMANDS.contains(args[0])) {
+            refreshVcsState();
+        }
+
+        return result;
+    }
+
+    private String runGitProcess(@NotNull String rootDir, String... args) throws Exception {
         List<String> cmd = new ArrayList<>();
         cmd.add("git");
         cmd.add("--no-pager");
         cmd.addAll(Arrays.asList(args));
 
         ProcessBuilder pb = new ProcessBuilder(cmd);
-        pb.directory(new File(basePath));
+        pb.directory(new File(rootDir));
         pb.redirectErrorStream(false);
         // Prevent git from opening a text editor (e.g. for revert/commit without --no-edit).
         // "true" is a POSIX no-op that exits 0, causing git to use the default message.
@@ -424,13 +640,26 @@ public abstract class GitTool extends Tool {
         if (gitOutput == null || gitOutput.isEmpty()) return;
         String hash = extractFirstCommitHash(gitOutput);
         if (hash == null) return;
-        String finalHash = hash;
         EdtUtil.invokeLater(() -> {
             try {
-                PlatformApiCompat.showRevisionInLogAfterRefresh(project, finalHash);
+                PlatformApiCompat.showRevisionInLogAfterRefresh(project, hash);
             } catch (Exception ignored) {
                 // best-effort UI follow-along
             }
         });
+    }
+
+    // ── Utility ──────────────────────────────────────────────
+
+    /**
+     * Converts an absolute path to a path relative to {@code basePath}.
+     * Returns {@code "."} when they are equal, preserves absolute path when
+     * {@code basePath} is null or {@code absPath} is not under it.
+     */
+    static String toRelativePath(@NotNull String absPath, @Nullable String basePath) {
+        if (basePath == null) return absPath;
+        if (absPath.equals(basePath)) return ".";
+        if (absPath.startsWith(basePath + "/")) return absPath.substring(basePath.length() + 1);
+        return absPath;
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
@@ -424,6 +424,16 @@ public abstract class GitTool extends Tool {
     }
 
     /**
+     * Records a completed explicit fetch so the auto-fetch throttle skips the next window.
+     * Call this after a successful explicit {@code git fetch} to prevent a redundant
+     * auto-fetch within the next {@value #FETCH_THROTTLE_MS} ms.
+     */
+    protected void markFetchCompleted(@NotNull String rootDir) {
+        lastFetchTimes.computeIfAbsent(rootDir, k -> new AtomicLong(0))
+            .set(System.currentTimeMillis());
+    }
+
+    /**
      * Checks if a branch/ref argument references a remote and fetches if stale.
      *
      * @param ref the branch or ref name from tool arguments

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitUnstageTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitUnstageTool.java
@@ -49,7 +49,8 @@ public final class GitUnstageTool extends GitTool {
     public @NotNull JsonObject inputSchema() {
         JsonObject s = schema(
             Param.optional("path", TYPE_STRING, "Single file path to unstage"),
-            Param.optional(PARAM_PATHS, TYPE_ARRAY, "Multiple file paths to unstage")
+            Param.optional(PARAM_PATHS, TYPE_ARRAY, "Multiple file paths to unstage"),
+            Param.optional(PARAM_REPO, TYPE_STRING, REPO_PARAM_DESCRIPTION)
         );
         addArrayItems(s, PARAM_PATHS);
         return s;
@@ -57,6 +58,12 @@ public final class GitUnstageTool extends GitTool {
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
+        String repoParam = args.has(PARAM_REPO) ? args.get(PARAM_REPO).getAsString() : null;
+        String ambiError = requireUnambiguousRepo(repoParam, "git_unstage");
+        if (ambiError != null) return ambiError;
+        String root = resolveRepoRootOrError(repoParam);
+        if (root.startsWith("Error")) return root;
+
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add("restore");
         cmdArgs.add("--staged");
@@ -72,9 +79,9 @@ public final class GitUnstageTool extends GitTool {
             return "Error: provide 'path' or 'paths' parameter";
         }
 
-        String result = runGit(cmdArgs.toArray(String[]::new));
+        String result = runGitIn(root, cmdArgs.toArray(String[]::new));
         if (result.startsWith("Error")) return result;
 
-        return result + getBranchSummary();
+        return result + getBranchSummaryIn(root);
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitToolStaticMethodsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitToolStaticMethodsTest.java
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.regex.Matcher;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GitToolStaticMethodsTest {
 
@@ -160,6 +163,44 @@ class GitToolStaticMethodsTest {
     }
 
     // ── Pattern fields ──────────────────────────────────────
+
+// ── toRelativePath ──────────────────────────────────────
+
+    @Nested
+    class ToRelativePath {
+
+        @Test
+        void samePathReturnsDot() {
+            assertEquals(".", GitTool.toRelativePath("/project/root", "/project/root"));
+        }
+
+        @Test
+        void childPathReturnsRelative() {
+            assertEquals("backend", GitTool.toRelativePath("/project/root/backend", "/project/root"));
+        }
+
+        @Test
+        void deepChildReturnsFullRelative() {
+            assertEquals("a/b/c", GitTool.toRelativePath("/project/root/a/b/c", "/project/root"));
+        }
+
+        @Test
+        void nullBasePathReturnsAbsolute() {
+            assertEquals("/some/absolute/path", GitTool.toRelativePath("/some/absolute/path", null));
+        }
+
+        @Test
+        void pathOutsideBaseReturnsAbsolute() {
+            assertEquals("/other/repo", GitTool.toRelativePath("/other/repo", "/project/root"));
+        }
+
+        @Test
+        void pathWithCommonPrefixButNotChildReturnsAbsolute() {
+            // "/project/rootother" must NOT match base "/project/root"
+            assertEquals("/project/rootother",
+                GitTool.toRelativePath("/project/rootother", "/project/root"));
+        }
+    }
 
     @Nested
     class Patterns {


### PR DESCRIPTION
## Summary

Adds support for projects with multiple git repositories (side-by-side or nested), while keeping the single-repo case completely unchanged.

## Changes

### Infrastructure (GitTool + PlatformApiCompat)
- **GitTool**: new multi-repo helpers — `resolveRepoRootOrError`, `requireUnambiguousRepo`, `runGitIn`, `getBranchContextIn`, `listRepoRoots`, `isMultiRepo`, per-repo fetch throttle, `toRelativePath`
- **PlatformApiCompat**: `getRepositories`, `getRepositoryForRoot`, `runIdeGitCommandIn`; root-aware overloads for `ideCheckout`, `ideCheckoutNewBranch`, `ideDeleteBranch`

### Tool changes (all 22 git tools)
- Optional `repo` param added to all tools (relative path from project root)
- **Write tools**: `requireUnambiguousRepo` guards prevent silently targeting the wrong repo
- **GitStatusTool**: aggregates all repos when no `repo` param given in a multi-repo project
- **GitBranchTool**: root-aware IDE API for create/switch/delete; ambiguity guard for writes
- **All other tools**: route git calls through `runGitIn(root, ...)` using resolved root

## Behavior

| Scenario | Behavior |
|---|---|
| Single-repo project | Identical to before — no `repo` param needed |
| Multi-repo, read operation, no `repo` param | Uses primary repo (basePath-rooted or first) |
| Multi-repo, `git_status`, no `repo` param | Returns aggregate status for all repos |
| Multi-repo, write operation, no `repo` param | Returns actionable error listing available repos |
| Any project, explicit `repo` param | Routes to that specific repo |

Closes #303 (partial — adds repo routing; symbol search scope was addressed separately)