### PR TITLE
fix: replace dot separator with vertical rule in shortcut hint panel

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutHintPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutHintPanel.kt
@@ -1,10 +1,12 @@
 package com.github.catatafishen.agentbridge.ui
 
+import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPanel
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import java.awt.BorderLayout
+import java.awt.Dimension
 import java.awt.FlowLayout
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
@@ -40,7 +42,7 @@ class PromptShortcutHintPanel : JBPanel<JBPanel<*>>(BorderLayout()) {
             KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
             "Send"
         )
-        addDot(row1)
+        addVerticalSeparator(row1)
         addShortcutEntry(
             row1,
             PromptShortcutAction.NEW_LINE_ID,
@@ -55,7 +57,7 @@ class PromptShortcutHintPanel : JBPanel<JBPanel<*>>(BorderLayout()) {
             KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.CTRL_DOWN_MASK),
             "Stop && Send"
         )
-        addDot(row2)
+        addVerticalSeparator(row2)
         addShortcutEntry(
             row2,
             PromptShortcutAction.QUEUE_ID,
@@ -67,7 +69,7 @@ class PromptShortcutHintPanel : JBPanel<JBPanel<*>>(BorderLayout()) {
         )
 
         inner.add(row1)
-        inner.add(Box.createVerticalStrut(JBUI.scale(3)))
+        inner.add(Box.createVerticalStrut(JBUI.scale(6)))
         inner.add(row2)
 
         add(inner, BorderLayout.CENTER)
@@ -101,11 +103,18 @@ class PromptShortcutHintPanel : JBPanel<JBPanel<*>>(BorderLayout()) {
         return lbl
     }
 
-    private fun addDot(row: JPanel) {
-        row.add(JBLabel("\u00B7").apply {
-            font = JBUI.Fonts.smallFont()
-            foreground = UIUtil.getContextHelpForeground()
-            border = JBUI.Borders.empty(0, 2)
-        })
+    private fun addVerticalSeparator(row: JPanel) {
+        val line = JPanel().apply {
+            isOpaque = true
+            background = JBColor.namedColor("Separator.foreground", JBColor(0xcdcdcd, 0x3d3d3d))
+            preferredSize = Dimension(JBUI.scale(1), JBUI.scale(11))
+        }
+        // Wrap in an empty-bordered panel to add symmetric horizontal margins.
+        val wrapper = JPanel(BorderLayout()).apply {
+            isOpaque = false
+            border = JBUI.Borders.empty(0, JBUI.scale(6))
+            add(line, BorderLayout.CENTER)
+        }
+        row.add(wrapper)
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutHintPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutHintPanel.kt
@@ -1,17 +1,14 @@
 package com.github.catatafishen.agentbridge.ui
 
-import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPanel
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import java.awt.BorderLayout
-import java.awt.Dimension
 import java.awt.FlowLayout
+import java.awt.GridLayout
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
-import javax.swing.Box
-import javax.swing.BoxLayout
 import javax.swing.JPanel
 import javax.swing.KeyStroke
 
@@ -22,6 +19,9 @@ import javax.swing.KeyStroke
  *
  * Reads actual key bindings from the IntelliJ keymap so customized
  * shortcuts are reflected in the displayed hints.
+ *
+ * The four hints are arranged in a 2×2 grid so items in the same column
+ * are vertically aligned across rows.
  */
 class PromptShortcutHintPanel : JBPanel<JBPanel<*>>(BorderLayout()) {
 
@@ -31,35 +31,30 @@ class PromptShortcutHintPanel : JBPanel<JBPanel<*>>(BorderLayout()) {
         isOpaque = false
         border = JBUI.Borders.empty(4, 8, 4, 8)
 
-        val inner = JPanel()
-        inner.isOpaque = false
-        inner.layout = BoxLayout(inner, BoxLayout.Y_AXIS)
+        // 2×2 grid — equal-width columns keep entries vertically aligned.
+        val grid = JPanel(GridLayout(2, 2, JBUI.scale(16), JBUI.scale(6)))
+        grid.isOpaque = false
 
-        val row1 = createRow()
         sendLabel = addShortcutEntry(
-            row1,
+            grid,
             PromptShortcutAction.SEND_ID,
             KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
             "Send"
         )
-        addVerticalSeparator(row1)
         addShortcutEntry(
-            row1,
+            grid,
             PromptShortcutAction.NEW_LINE_ID,
             KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.SHIFT_DOWN_MASK),
             "New Line"
         )
-
-        val row2 = createRow()
         addShortcutEntry(
-            row2,
+            grid,
             PromptShortcutAction.STOP_AND_SEND_ID,
             KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.CTRL_DOWN_MASK),
             "Stop && Send"
         )
-        addVerticalSeparator(row2)
         addShortcutEntry(
-            row2,
+            grid,
             PromptShortcutAction.QUEUE_ID,
             KeyStroke.getKeyStroke(
                 KeyEvent.VK_ENTER,
@@ -68,11 +63,7 @@ class PromptShortcutHintPanel : JBPanel<JBPanel<*>>(BorderLayout()) {
             "Queue"
         )
 
-        inner.add(row1)
-        inner.add(Box.createVerticalStrut(JBUI.scale(6)))
-        inner.add(row2)
-
-        add(inner, BorderLayout.CENTER)
+        add(grid, BorderLayout.CENTER)
     }
 
     /** Toggle between "send" and "nudge" label when the agent is working. */
@@ -80,41 +71,22 @@ class PromptShortcutHintPanel : JBPanel<JBPanel<*>>(BorderLayout()) {
         sendLabel.text = if (nudge) "Nudge" else "Send"
     }
 
-    private fun createRow(): JPanel {
-        val row = JPanel(FlowLayout(FlowLayout.CENTER, JBUI.scale(4), 0))
-        row.isOpaque = false
-        row.alignmentX = CENTER_ALIGNMENT
-        return row
-    }
-
     private fun addShortcutEntry(
-        row: JPanel,
+        grid: JPanel,
         actionId: String,
         fallbackStroke: KeyStroke,
         label: String
     ): JBLabel {
+        val cell = JPanel(FlowLayout(FlowLayout.CENTER, JBUI.scale(4), 0))
+        cell.isOpaque = false
         val stroke = PromptShortcutAction.resolveKeystroke(actionId, fallbackStroke)
-        KeyBadge.keystrokeTokens(stroke).forEach { row.add(KeyBadge(it)) }
+        KeyBadge.keystrokeTokens(stroke).forEach { cell.add(KeyBadge(it)) }
         val lbl = JBLabel(label).apply {
             font = JBUI.Fonts.smallFont()
             foreground = UIUtil.getContextHelpForeground()
         }
-        row.add(lbl)
+        cell.add(lbl)
+        grid.add(cell)
         return lbl
-    }
-
-    private fun addVerticalSeparator(row: JPanel) {
-        val line = JPanel().apply {
-            isOpaque = true
-            background = JBColor.namedColor("Separator.foreground", JBColor(0xcdcdcd, 0x3d3d3d))
-            preferredSize = Dimension(JBUI.scale(1), JBUI.scale(11))
-        }
-        // Wrap in an empty-bordered panel to add symmetric horizontal margins.
-        val wrapper = JPanel(BorderLayout()).apply {
-            isOpaque = false
-            border = JBUI.Borders.empty(0, JBUI.scale(6))
-            add(line, BorderLayout.CENTER)
-        }
-        row.add(wrapper)
     }
 }


### PR DESCRIPTION
Replaces the middle dot `·` between shortcut hint entries with a proper 1px vertical rule, and increases row spacing.

## Changes
- `PromptShortcutHintPanel.kt`: vertical rule separator (1px wide, themed via `JBColor.namedColor("Separator.foreground")`), 6px horizontal margins on each side
- Row spacing increased from 3px → 6px
- Renamed `addDot` → `addVerticalSeparator`