### PR TITLE
feat: tool readiness pre-flight checks (indexing, modal, build)

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -442,7 +442,11 @@ public final class PsiBridgeService implements Disposable {
                 success = false;
                 errorMessage = readinessError;
                 outputSize = readinessError.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
-                ToolChipRegistry.getInstance(project).storeMcpResult(req.toolName(), req.arguments(), readinessError);
+                // Register the chip first so the result is correlated with a real chip,
+                // matching the normal execution path in executeWithSyncLock().
+                ToolChipRegistry registry = ToolChipRegistry.getInstance(project);
+                registry.registerMcp(req.toolName(), req.arguments(), req.def().kind().value(), req.toolUseId());
+                registry.storeMcpResult(req.toolName(), req.arguments(), readinessError);
                 return readinessError;
             }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -436,6 +436,16 @@ public final class PsiBridgeService implements Disposable {
         try (DaemonWaiter daemonWaiter = filePathForHighlights != null
             ? new DaemonWaiter(project, vfForHighlights, preWriteStamp) : null) {
 
+            String readinessError = ToolReadinessGate.checkReady(project, req.def());
+            if (readinessError != null) {
+                if (writeRegistered.getAndSet(false)) writeBatchCoordinator.unregisterWrite();
+                success = false;
+                errorMessage = readinessError;
+                outputSize = readinessError.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+                ToolChipRegistry.getInstance(project).storeMcpResult(req.toolName(), req.arguments(), readinessError);
+                return readinessError;
+            }
+
             String result = executeWithSyncLock(req.def(), req.arguments(), req.toolName(), req.toolUseId(), requiresSync);
             if (writeRegistered.getAndSet(false)) writeBatchCoordinator.unregisterWrite();
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolReadinessGate.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolReadinessGate.java
@@ -5,7 +5,6 @@ import com.intellij.openapi.compiler.CompilerManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.startup.StartupManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,6 +34,9 @@ public final class ToolReadinessGate {
     /** How long we opportunistically wait for project initialisation. */
     static final long PROJECT_INIT_WAIT_MS = 2_000L;
 
+    /** Polling interval while waiting for project initialisation. */
+    private static final long PROJECT_INIT_POLL_MS = 50L;
+
     private ToolReadinessGate() { }
 
     /**
@@ -60,34 +62,65 @@ public final class ToolReadinessGate {
         return null;
     }
 
+    // ── Message builders ───────────────────────────────────────────────────────
+    // Public so unit tests assert against the real production messages instead
+    // of duplicating hard-coded strings that would silently drift.
+
+    @NotNull
+    public static String projectInitErrorMessage(@NotNull String toolName) {
+        return "Error: Project is still initialising. Tool '" + toolName
+            + "' depends on the project being fully opened. Retry shortly.";
+    }
+
+    @NotNull
+    public static String indexingErrorMessage(@NotNull String toolName) {
+        return "Error: IDE is indexing. Tool '" + toolName
+            + "' depends on the symbol index, which is not yet ready. "
+            + "Call get_indexing_status with wait=true to be notified when indexing finishes, then retry.";
+    }
+
+    @NotNull
+    public static String modalErrorMessage(@NotNull String toolName, @NotNull String detail) {
+        return "Error: A modal dialog is open and blocks tool '" + toolName + "'."
+            + detail
+            + " Use the interact_with_modal tool to inspect or dismiss the dialog, then retry.";
+    }
+
+    @NotNull
+    public static String buildInProgressErrorMessage(@NotNull String toolName) {
+        return "Error: A project build is already in progress. Tool '" + toolName
+            + "' cannot run concurrently. Wait for the current build to finish and retry.";
+    }
+
     /**
      * Returns null if the project is already initialised, or once it becomes
      * initialised within the timeout. Otherwise returns an error message.
+     * <p>
+     * Uses simple polling instead of {@code StartupManager.runAfterOpened()},
+     * which is marked {@code @ApiStatus.Internal} and flagged by the plugin
+     * verifier.
      */
     @Nullable
     static String awaitProjectInitialised(@NotNull Project project, @NotNull String toolName, long timeoutMs) {
         if (project.isDisposed()) {
             return "Error: Project is disposed. Tool '" + toolName + "' cannot run.";
         }
-        if (project.isInitialized()) return null;
-
-        StartupManager startup = StartupManager.getInstance(project);
-        CompletableFuture<Void> ready = new CompletableFuture<>();
-        startup.runAfterOpened(() -> ready.complete(null));
-
-        try {
-            ready.get(timeoutMs, TimeUnit.MILLISECONDS);
-            return null;
-        } catch (TimeoutException e) {
-            return "Error: Project is still initialising. Tool '" + toolName
-                + "' depends on the project being fully opened. Retry shortly.";
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            return "Error: Interrupted while waiting for project initialisation.";
-        } catch (Exception e) {
-            LOG.debug("Project init wait failed", e);
-            return null; // be permissive on unexpected failure
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (!project.isInitialized()) {
+            if (project.isDisposed()) {
+                return "Error: Project is disposed. Tool '" + toolName + "' cannot run.";
+            }
+            if (System.currentTimeMillis() >= deadline) {
+                return projectInitErrorMessage(toolName);
+            }
+            try {
+                Thread.sleep(PROJECT_INIT_POLL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return "Error: Interrupted while waiting for project initialisation.";
+            }
         }
+        return null;
     }
 
     /**
@@ -108,9 +141,7 @@ public final class ToolReadinessGate {
             smart.get(timeoutMs, TimeUnit.MILLISECONDS);
             return null;
         } catch (TimeoutException e) {
-            return "Error: IDE is indexing. Tool '" + toolName
-                + "' depends on the symbol index, which is not yet ready. "
-                + "Call get_indexing_status with wait=true to be notified when indexing finishes, then retry.";
+            return indexingErrorMessage(toolName);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             return "Error: Interrupted while waiting for indexing to finish.";
@@ -128,9 +159,7 @@ public final class ToolReadinessGate {
     static String checkNoModal(@NotNull String toolName) {
         String detail = EdtUtil.describeModalBlocker();
         if (detail == null || detail.isEmpty()) return null;
-        return "Error: A modal dialog is open and blocks tool '" + toolName + "'."
-            + detail
-            + " Use the interact_with_modal tool to inspect or dismiss the dialog, then retry.";
+        return modalErrorMessage(toolName, detail);
     }
 
     /**
@@ -143,8 +172,7 @@ public final class ToolReadinessGate {
         try {
             CompilerManager cm = CompilerManager.getInstance(project);
             if (cm != null && cm.isCompilationActive()) {
-                return "Error: A project build is already in progress. Tool '" + toolName
-                    + "' cannot run concurrently. Wait for the current build to finish and retry.";
+                return buildInProgressErrorMessage(toolName);
             }
         } catch (Exception e) {
             LOG.debug("Build-in-progress check failed", e);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolReadinessGate.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/ToolReadinessGate.java
@@ -1,0 +1,154 @@
+package com.github.catatafishen.agentbridge.psi;
+
+import com.github.catatafishen.agentbridge.services.ToolDefinition;
+import com.intellij.openapi.compiler.CompilerManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupManager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Centralised pre-flight readiness checks for MCP tool execution.
+ * <p>
+ * Tools declare their requirements via {@link ToolDefinition#requiresIndex()},
+ * {@link ToolDefinition#requiresSmartProject()}, and
+ * {@link ToolDefinition#requiresInteractiveEdt()}. This gate enforces them with
+ * a short opportunistic wait so transient pauses don't surface as errors, but
+ * surfaces a clear, actionable nudge when the IDE is genuinely not ready.
+ * <p>
+ * The intent is to give the agent focused context — a single descriptive error
+ * instead of a cryptic exception or empty result that wastes follow-up turns.
+ */
+public final class ToolReadinessGate {
+
+    private static final Logger LOG = Logger.getInstance(ToolReadinessGate.class);
+
+    /** How long we opportunistically wait for indexing to finish. */
+    static final long INDEX_WAIT_MS = 2_000L;
+
+    /** How long we opportunistically wait for project initialisation. */
+    static final long PROJECT_INIT_WAIT_MS = 2_000L;
+
+    private ToolReadinessGate() { }
+
+    /**
+     * Checks every applicable readiness gate for the given tool and project.
+     *
+     * @return null when all gates pass; otherwise an error string suitable to
+     *         return directly to the MCP client (already prefixed with {@code "Error: "}).
+     */
+    @Nullable
+    public static String checkReady(@NotNull Project project, @NotNull ToolDefinition def) {
+        if (def.requiresSmartProject() || def.requiresIndex()) {
+            String startupErr = awaitProjectInitialised(project, def.id(), PROJECT_INIT_WAIT_MS);
+            if (startupErr != null) return startupErr;
+        }
+        if (def.requiresIndex()) {
+            String indexErr = awaitSmartMode(project, def.id(), INDEX_WAIT_MS);
+            if (indexErr != null) return indexErr;
+        }
+        if (def.requiresInteractiveEdt()) {
+            String modalErr = checkNoModal(def.id());
+            if (modalErr != null) return modalErr;
+        }
+        return null;
+    }
+
+    /**
+     * Returns null if the project is already initialised, or once it becomes
+     * initialised within the timeout. Otherwise returns an error message.
+     */
+    @Nullable
+    static String awaitProjectInitialised(@NotNull Project project, @NotNull String toolName, long timeoutMs) {
+        if (project.isDisposed()) {
+            return "Error: Project is disposed. Tool '" + toolName + "' cannot run.";
+        }
+        if (project.isInitialized()) return null;
+
+        StartupManager startup = StartupManager.getInstance(project);
+        CompletableFuture<Void> ready = new CompletableFuture<>();
+        startup.runAfterOpened(() -> ready.complete(null));
+
+        try {
+            ready.get(timeoutMs, TimeUnit.MILLISECONDS);
+            return null;
+        } catch (TimeoutException e) {
+            return "Error: Project is still initialising. Tool '" + toolName
+                + "' depends on the project being fully opened. Retry shortly.";
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "Error: Interrupted while waiting for project initialisation.";
+        } catch (Exception e) {
+            LOG.debug("Project init wait failed", e);
+            return null; // be permissive on unexpected failure
+        }
+    }
+
+    /**
+     * Returns null if the project is in smart mode (indexing complete) or
+     * becomes smart within the timeout. Otherwise returns an error message
+     * that nudges the agent to call {@code get_indexing_status}.
+     */
+    @Nullable
+    static String awaitSmartMode(@NotNull Project project, @NotNull String toolName, long timeoutMs) {
+        if (project.isDisposed()) return null; // covered by initialisation check
+        DumbService dumb = DumbService.getInstance(project);
+        if (!dumb.isDumb()) return null;
+
+        CompletableFuture<Void> smart = new CompletableFuture<>();
+        dumb.runWhenSmart(() -> smart.complete(null));
+
+        try {
+            smart.get(timeoutMs, TimeUnit.MILLISECONDS);
+            return null;
+        } catch (TimeoutException e) {
+            return "Error: IDE is indexing. Tool '" + toolName
+                + "' depends on the symbol index, which is not yet ready. "
+                + "Call get_indexing_status with wait=true to be notified when indexing finishes, then retry.";
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "Error: Interrupted while waiting for indexing to finish.";
+        } catch (Exception e) {
+            LOG.debug("Smart-mode wait failed", e);
+            return null; // be permissive on unexpected failure
+        }
+    }
+
+    /**
+     * Returns null when no modal dialog is blocking the EDT, otherwise an
+     * error nudging the agent to call {@code interact_with_modal}.
+     */
+    @Nullable
+    static String checkNoModal(@NotNull String toolName) {
+        String detail = EdtUtil.describeModalBlocker();
+        if (detail == null || detail.isEmpty()) return null;
+        return "Error: A modal dialog is open and blocks tool '" + toolName + "'."
+            + detail
+            + " Use the interact_with_modal tool to inspect or dismiss the dialog, then retry.";
+    }
+
+    /**
+     * Pre-flight check for build-style tools: returns an error if a project
+     * build is currently in progress, otherwise null. Independent of
+     * {@link #checkReady} because only build tools care.
+     */
+    @Nullable
+    public static String checkNoBuildInProgress(@NotNull Project project, @NotNull String toolName) {
+        try {
+            CompilerManager cm = CompilerManager.getInstance(project);
+            if (cm != null && cm.isCompilationActive()) {
+                return "Error: A project build is already in progress. Tool '" + toolName
+                    + "' cannot run concurrently. Wait for the current build to finish and retry.";
+            }
+        } catch (Exception e) {
+            LOG.debug("Build-in-progress check failed", e);
+        }
+        return null;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editor/OpenInEditorTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editor/OpenInEditorTool.java
@@ -34,6 +34,11 @@ public final class OpenInEditorTool extends EditorTool {
     }
 
     @Override
+    public boolean requiresInteractiveEdt() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Open in Editor";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editor/ShowDiffTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/editor/ShowDiffTool.java
@@ -31,6 +31,11 @@ public final class ShowDiffTool extends EditorTool {
     }
 
     @Override
+    public boolean requiresInteractiveEdt() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Show Diff";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/FindReferencesTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/FindReferencesTool.java
@@ -32,6 +32,11 @@ public final class FindReferencesTool extends NavigationTool {
     }
 
     @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Find References";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/GetClassOutlineTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/GetClassOutlineTool.java
@@ -22,6 +22,11 @@ public final class GetClassOutlineTool extends NavigationTool {
     }
 
     @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Get Class Outline";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchSymbolsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchSymbolsTool.java
@@ -38,6 +38,11 @@ public final class SearchSymbolsTool extends NavigationTool {
     }
 
     @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Search Symbols";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/project/BuildProjectTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/project/BuildProjectTool.java
@@ -68,8 +68,12 @@ public final class BuildProjectTool extends ProjectTool {
 
     @Override
     public @NotNull String execute(@NotNull JsonObject args) throws Exception {
+        String externalBuildErr = com.github.catatafishen.agentbridge.psi.ToolReadinessGate
+            .checkNoBuildInProgress(project, id());
+        if (externalBuildErr != null) return externalBuildErr;
+
         if (!buildInProgress.compareAndSet(false, true)) {
-            return "Build already in progress. Please wait for the current build to complete before requesting another.";
+            return "Error: Build already in progress. Please wait for the current build to complete before requesting another.";
         }
 
         String moduleName = args.has(JSON_MODULE) ? args.get(JSON_MODULE).getAsString() : "";

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/project/RunConfigurationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/project/RunConfigurationTool.java
@@ -24,6 +24,11 @@ public final class RunConfigurationTool extends ProjectTool {
     }
 
     @Override
+    public boolean requiresInteractiveEdt() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Run Configuration";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyActionTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyActionTool.java
@@ -49,6 +49,11 @@ public final class ApplyActionTool extends QualityTool {
     }
 
     @Override
+    public boolean requiresInteractiveEdt() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Apply Action";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyQuickfixTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/ApplyQuickfixTool.java
@@ -41,6 +41,11 @@ public final class ApplyQuickfixTool extends QualityTool {
     }
 
     @Override
+    public boolean requiresInteractiveEdt() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Apply Quickfix";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetHighlightsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetHighlightsTool.java
@@ -42,6 +42,11 @@ public final class GetHighlightsTool extends QualityTool {
     }
 
     @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Get Highlights";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetProblemsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetProblemsTool.java
@@ -32,6 +32,11 @@ public final class GetProblemsTool extends QualityTool {
     }
 
     @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Get Problems";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/FindImplementationsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/FindImplementationsTool.java
@@ -35,6 +35,11 @@ public final class FindImplementationsTool extends RefactoringTool {
     }
 
     @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Find Implementations";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetCallHierarchyTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetCallHierarchyTool.java
@@ -26,6 +26,11 @@ public final class GetCallHierarchyTool extends RefactoringTool {
     }
 
     @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Get Call Hierarchy";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetDocumentationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetDocumentationTool.java
@@ -32,6 +32,11 @@ public final class GetDocumentationTool extends RefactoringTool {
     }
 
     @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Get Documentation";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetSymbolInfoTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetSymbolInfoTool.java
@@ -38,6 +38,11 @@ public final class GetSymbolInfoTool extends RefactoringTool {
     }
 
     @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Get Symbol Info";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetTypeHierarchyTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GetTypeHierarchyTool.java
@@ -33,6 +33,11 @@ public final class GetTypeHierarchyTool extends RefactoringTool {
     }
 
     @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Get Type Hierarchy";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GoToDeclarationTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/GoToDeclarationTool.java
@@ -41,6 +41,11 @@ public final class GoToDeclarationTool extends RefactoringTool {
     }
 
     @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Go to Declaration";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactorTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/refactoring/RefactorTool.java
@@ -43,6 +43,11 @@ public final class RefactorTool extends RefactoringTool {
     }
 
     @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Refactor";
     }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolDefinition.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/services/ToolDefinition.java
@@ -193,6 +193,34 @@ public interface ToolDefinition {
         return null;
     }
 
+    /**
+     * True if this tool depends on the symbol index. When true, the central
+     * pre-flight gate waits briefly for indexing to finish and otherwise
+     * returns an actionable error to the agent (so it can call
+     * {@code get_indexing_status} or retry). Default: false.
+     */
+    default boolean requiresIndex() {
+        return false;
+    }
+
+    /**
+     * True if this tool requires the project to be fully initialised
+     * (post-startup activities completed). Default: false.
+     */
+    default boolean requiresSmartProject() {
+        return false;
+    }
+
+    /**
+     * True if this tool drives interactive UI on the EDT (e.g. opens a file in
+     * the editor, shows a diff viewer). Such tools fail-fast when a modal
+     * dialog is currently blocking the EDT, with a nudge to call
+     * {@code interact_with_modal}. Default: false.
+     */
+    default boolean requiresInteractiveEdt() {
+        return false;
+    }
+
     // ── Schema ───────────────────────────────────────────────
 
     /**

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/ToolReadinessGateTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/ToolReadinessGateTest.java
@@ -1,0 +1,78 @@
+package com.github.catatafishen.agentbridge.psi;
+
+import com.github.catatafishen.agentbridge.services.ToolDefinition;
+import com.github.catatafishen.agentbridge.services.ToolRegistry;
+import com.google.gson.JsonObject;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link ToolReadinessGate}. The gate's individual methods that
+ * touch IntelliJ services ({@code awaitSmartMode}, {@code awaitProjectInitialised},
+ * {@code checkNoBuildInProgress}) require live IDE wiring and are exercised by
+ * integration tests; here we cover the pure-logic paths and the no-modal path.
+ */
+class ToolReadinessGateTest {
+
+    private static ToolDefinition def(boolean idx, boolean smart, boolean edt) {
+        return new ToolDefinition() {
+            @Override public @NotNull String id() { return "test_tool"; }
+            @Override public @NotNull Kind kind() { return Kind.READ; }
+            @Override public @NotNull String displayName() { return "Test"; }
+            @Override public @NotNull String description() { return "Test tool"; }
+            @Override public @NotNull ToolRegistry.Category category() { return ToolRegistry.Category.OTHER; }
+            @Override public boolean requiresIndex() { return idx; }
+            @Override public boolean requiresSmartProject() { return smart; }
+            @Override public boolean requiresInteractiveEdt() { return edt; }
+            @Override public @Nullable String execute(@NotNull JsonObject args) { return null; }
+        };
+    }
+
+    @Test
+    void checkNoModal_inHeadlessTestEnvironment_returnsNull() {
+        // In the test JVM there are no AWT modal dialogs, so the check passes.
+        assertNull(ToolReadinessGate.checkNoModal("test_tool"));
+    }
+
+    @Test
+    void awaitSmartMode_messagePoints_toGetIndexingStatus() {
+        // Sanity check: when we eventually do return an indexing error, it must
+        // include the actionable nudge so the agent knows what to do.
+        // We call the message-template builder via reflection-free path: assert
+        // the well-known substring documented in the public method's contract.
+        String fakeError = "Error: IDE is indexing. Tool 'foo' depends on the symbol index, "
+            + "which is not yet ready. Call get_indexing_status with wait=true to be notified "
+            + "when indexing finishes, then retry.";
+        assertTrue(fakeError.contains("get_indexing_status"));
+        assertTrue(fakeError.contains("wait=true"));
+    }
+
+    @Test
+    void modalErrorMessage_containsInteractWithModalNudge() {
+        String message = "Error: A modal dialog is open and blocks tool 'foo'."
+            + " Modal dialog blocking: 'Settings'."
+            + " Use the interact_with_modal tool to inspect or dismiss the dialog, then retry.";
+        assertTrue(message.contains("interact_with_modal"));
+    }
+
+    @Test
+    void definitionDefaults_areAllFalse() {
+        ToolDefinition empty = new ToolDefinition() {
+            @Override public @NotNull String id() { return "x"; }
+            @Override public @NotNull Kind kind() { return Kind.READ; }
+            @Override public @NotNull String displayName() { return "X"; }
+            @Override public @NotNull String description() { return "x"; }
+            @Override public @NotNull ToolRegistry.Category category() { return ToolRegistry.Category.OTHER; }
+        };
+        assertNotNull(empty);
+        // All three readiness flags default to false to preserve backwards compat.
+        org.junit.jupiter.api.Assertions.assertFalse(empty.requiresIndex());
+        org.junit.jupiter.api.Assertions.assertFalse(empty.requiresSmartProject());
+        org.junit.jupiter.api.Assertions.assertFalse(empty.requiresInteractiveEdt());
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/ToolReadinessGateTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/ToolReadinessGateTest.java
@@ -7,6 +7,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,23 +17,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit tests for {@link ToolReadinessGate}. The gate's individual methods that
  * touch IntelliJ services ({@code awaitSmartMode}, {@code awaitProjectInitialised},
  * {@code checkNoBuildInProgress}) require live IDE wiring and are exercised by
- * integration tests; here we cover the pure-logic paths and the no-modal path.
+ * integration tests; here we cover the pure-logic paths and the message builders
+ * that production code emits.
  */
 class ToolReadinessGateTest {
-
-    private static ToolDefinition def(boolean idx, boolean smart, boolean edt) {
-        return new ToolDefinition() {
-            @Override public @NotNull String id() { return "test_tool"; }
-            @Override public @NotNull Kind kind() { return Kind.READ; }
-            @Override public @NotNull String displayName() { return "Test"; }
-            @Override public @NotNull String description() { return "Test tool"; }
-            @Override public @NotNull ToolRegistry.Category category() { return ToolRegistry.Category.OTHER; }
-            @Override public boolean requiresIndex() { return idx; }
-            @Override public boolean requiresSmartProject() { return smart; }
-            @Override public boolean requiresInteractiveEdt() { return edt; }
-            @Override public @Nullable String execute(@NotNull JsonObject args) { return null; }
-        };
-    }
 
     @Test
     void checkNoModal_inHeadlessTestEnvironment_returnsNull() {
@@ -40,24 +29,37 @@ class ToolReadinessGateTest {
     }
 
     @Test
-    void awaitSmartMode_messagePoints_toGetIndexingStatus() {
-        // Sanity check: when we eventually do return an indexing error, it must
-        // include the actionable nudge so the agent knows what to do.
-        // We call the message-template builder via reflection-free path: assert
-        // the well-known substring documented in the public method's contract.
-        String fakeError = "Error: IDE is indexing. Tool 'foo' depends on the symbol index, "
-            + "which is not yet ready. Call get_indexing_status with wait=true to be notified "
-            + "when indexing finishes, then retry.";
-        assertTrue(fakeError.contains("get_indexing_status"));
-        assertTrue(fakeError.contains("wait=true"));
+    void indexingErrorMessage_pointsToGetIndexingStatus() {
+        String msg = ToolReadinessGate.indexingErrorMessage("foo");
+        assertTrue(msg.startsWith("Error: "), "must use Error: prefix so MCP marks isError");
+        assertTrue(msg.contains("'foo'"), "message must reference the calling tool");
+        assertTrue(msg.contains("get_indexing_status"), "must nudge agent to the readiness tool");
+        assertTrue(msg.contains("wait=true"), "must tell agent how to await completion");
     }
 
     @Test
-    void modalErrorMessage_containsInteractWithModalNudge() {
-        String message = "Error: A modal dialog is open and blocks tool 'foo'."
-            + " Modal dialog blocking: 'Settings'."
-            + " Use the interact_with_modal tool to inspect or dismiss the dialog, then retry.";
-        assertTrue(message.contains("interact_with_modal"));
+    void modalErrorMessage_includesInteractWithModalNudge() {
+        String msg = ToolReadinessGate.modalErrorMessage("foo", " Modal: 'Settings'.");
+        assertTrue(msg.startsWith("Error: "));
+        assertTrue(msg.contains("'foo'"));
+        assertTrue(msg.contains("Modal: 'Settings'."), "detail string must be embedded verbatim");
+        assertTrue(msg.contains("interact_with_modal"));
+    }
+
+    @Test
+    void projectInitErrorMessage_isActionable() {
+        String msg = ToolReadinessGate.projectInitErrorMessage("foo");
+        assertTrue(msg.startsWith("Error: "));
+        assertTrue(msg.contains("'foo'"));
+        assertTrue(msg.contains("Retry"), "must tell agent the failure is transient");
+    }
+
+    @Test
+    void buildInProgressErrorMessage_isActionable() {
+        String msg = ToolReadinessGate.buildInProgressErrorMessage("build_project");
+        assertTrue(msg.startsWith("Error: "));
+        assertTrue(msg.contains("'build_project'"));
+        assertTrue(msg.contains("build to finish"), "must tell agent why and what to do");
     }
 
     @Test
@@ -68,11 +70,23 @@ class ToolReadinessGateTest {
             @Override public @NotNull String displayName() { return "X"; }
             @Override public @NotNull String description() { return "x"; }
             @Override public @NotNull ToolRegistry.Category category() { return ToolRegistry.Category.OTHER; }
+            @Override public @Nullable String execute(@NotNull JsonObject args) { return null; }
         };
         assertNotNull(empty);
         // All three readiness flags default to false to preserve backwards compat.
-        org.junit.jupiter.api.Assertions.assertFalse(empty.requiresIndex());
-        org.junit.jupiter.api.Assertions.assertFalse(empty.requiresSmartProject());
-        org.junit.jupiter.api.Assertions.assertFalse(empty.requiresInteractiveEdt());
+        assertFalse(empty.requiresIndex());
+        assertFalse(empty.requiresSmartProject());
+        assertFalse(empty.requiresInteractiveEdt());
+    }
+
+    @Test
+    void messageBuilders_areStableForRepeatedCalls() {
+        // Guard against accidental non-determinism (e.g. timestamp interpolation).
+        assertEquals(
+            ToolReadinessGate.indexingErrorMessage("t"),
+            ToolReadinessGate.indexingErrorMessage("t"));
+        assertEquals(
+            ToolReadinessGate.modalErrorMessage("t", " d."),
+            ToolReadinessGate.modalErrorMessage("t", " d."));
     }
 }

--- a/plugin-experimental/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/RunInspectionsTool.java
+++ b/plugin-experimental/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/RunInspectionsTool.java
@@ -61,6 +61,11 @@ public final class RunInspectionsTool extends QualityTool {
     }
 
     @Override
+    public boolean requiresIndex() {
+        return true;
+    }
+
+    @Override
     public @NotNull String displayName() {
         return "Run Inspections";
     }
@@ -99,9 +104,6 @@ public final class RunInspectionsTool extends QualityTool {
 
         if (!project.isInitialized()) {
             return ERROR_IDE_INITIALIZING;
-        }
-        if (DumbService.isDumb(project)) {
-            return "IDE is currently indexing the project. Please wait for indexing to finish and try again.";
         }
 
         // Serve from cache if available and fresh (5 min TTL)


### PR DESCRIPTION
## Problem

Agent tool calls return cryptic errors or empty results when the IDE is in a transient state:
- **Indexing** — symbol/reference/inspection tools return incomplete results
- **Modal dialog open** — EDT-bound tools time out
- **Build in progress** — `build_project` collides with running build
- **Project initialising** — calls right after IDE startup may misbehave

The agent then wastes turns guessing what went wrong.

## Approach

Tools declare their readiness requirements via three new flags on \`ToolDefinition\`:
- \`requiresIndex()\` — symbol-index-dependent tools
- \`requiresSmartProject()\` — full project initialisation needed
- \`requiresInteractiveEdt()\` — drives UI on EDT (modal-sensitive)

A central \`ToolReadinessGate\` runs in \`PsiBridgeService.runToolExecution\` before tool dispatch:
1. Briefly waits (~2s) for transient states to clear — most pauses are short
2. If still blocked, returns an actionable error message naming the follow-up tool the agent should call (\`get_indexing_status\`, \`interact_with_modal\`, etc.)
3. Releases write-batch registration on early return so cleanup is correct

\`BuildProjectTool\` also pre-flights \`CompilerManager.isCompilationActive\` to avoid colliding with an in-progress build.

## Tagged tools

**requiresIndex (13)**: search_symbols, find_references, find_implementations, get_call_hierarchy, get_type_hierarchy, get_class_outline, get_documentation, get_symbol_info, go_to_declaration, refactor, get_highlights, get_problems, run_inspections (also drops its now-redundant inline DumbService check)

**requiresInteractiveEdt (5)**: open_in_editor, show_diff, run_configuration, apply_action, apply_quickfix

## Tests

New \`ToolReadinessGateTest\` covers pure-logic paths (default flags, modal check in headless env, error-message contracts).

## Result

The agent gets focused, actionable feedback instead of hangs or empty results, saving tokens otherwise spent guessing.