### PR TITLE
fix: remove forced JCEF OSR invalidation that caused tearing

### DIFF
--- a/docs/bugs/SCREEN-TEARING-BUG.md
+++ b/docs/bugs/SCREEN-TEARING-BUG.md
@@ -47,9 +47,14 @@ JCEF OSR tearing happens when:
 startStreaming()                               finishResponse()
      │                                              │
      ├── setFrameRate(60)                           ├── setFrameRate(30)
-     ├── repaintTimer.start()  (200ms invalidate)   ├── repaintTimer.stop()
-     └── setStreaming(true, false)  [disable smooth] └── restore smooth-scroll preference
+     └── setStreaming(true, false)  [disable        └── restore smooth-scroll preference
+            smooth + arms streaming flag]
 ```
+
+> **Note**: `repaintTimer.start()/stop()` was removed in **Fix 4** — there is no longer a
+> periodic forced OSR invalidation. CEF's natural `OnPaint` cycle (capped at the windowless
+> frame rate) handles repaints. The `streaming` flag is still maintained because
+> `MonitorSwitchRecovery` uses it to defer DOM replay until streaming ends.
 
 ### Per-token flow
 
@@ -69,8 +74,10 @@ Kotlin appendText()
 - **No smooth scroll during streaming** — `setStreaming(true, false)` disables CSS smooth scroll.
 - **Programmatic bottom-lock is always instant** — `scrollIfNeeded()`, `forceScroll()`, and
   `compensateScroll()` all go through `_scrollToInstant()` even when smooth scrolling is enabled.
-- **CEF invalidation safety net** — `repaintTimer` fires `cef.invalidate()` every 200ms during
-  streaming, plus throttled per-`executeJs` invalidation (50ms) catches inter-timer gaps.
+- **CEF invalidation removed** — Fix 4 removed both the periodic `repaintTimer` and the
+  per-`executeJs` `cef.invalidate()` calls. CEF's native `OnPaint` cycle (capped at the
+  windowless frame rate) handles repaints. Do not reintroduce manual invalidation —
+  see Fix 4 for the rationale.
 - **No code block decoration during streaming** — `_setupCodeBlocks()` skips `<pre>` elements
   inside `message-bubble[streaming]` to avoid DOM churn.
 
@@ -167,7 +174,7 @@ helper.
 
 ---
 
-
+## Code Locations
 
 | File | Component | Purpose |
 |---|---|---|

--- a/docs/bugs/SCREEN-TEARING-BUG.md
+++ b/docs/bugs/SCREEN-TEARING-BUG.md
@@ -1,6 +1,6 @@
 # Screen Tearing Bug — JCEF OSR
 
-**Status**: Recurring — mitigations applied, not confirmed fixed  
+**Status**: Fix 4 applied — forced OSR invalidation removed (pending user verification on Win/Linux)  
 **Scope**: JCEF Off-Screen Rendering (OSR) mode in the chat panel  
 **Affected area**: `ChatConsolePanel.kt`, `ChatContainer.ts`, `ChatController.ts`, `MessageBubble.ts`
 
@@ -137,16 +137,43 @@ scroll is re-enabled after streaming. During streaming this is a noop since beha
    window). The repaintTimer remains as a 200ms safety net; the per-executeJs invalidation catches
    rapid bursts of JS updates.
 
+### Fix 4 — Remove forced OSR invalidation (this commit)
+
+**Hypothesis revisited.** A new round of bug reports on Windows and Linux confirmed
+tearing/flicker still occurred during streaming despite Fixes 1–3. The user suspected
+"FPS sync issues". A deeper look at JCEF OSR architecture refined the hypothesis:
+
+- `setWindowlessFrameRate` is capped at 60 fps in CEF — matching 120/144 Hz monitors
+  is not possible.
+- `cefBrowser.invalidate()` is **not a vsync primitive**. It schedules CEF to repaint
+  the OSR buffer on the next available tick, which is then composited by Swing on the EDT.
+- The **per-`executeJs` invalidate (50ms throttle)** was being called for every streaming
+  token / tool chip / sub-agent update. This forces an OSR paint **between** the synchronous
+  `appendChild(textNode)` in `MessageBubble.appendStreamingText()` and the deferred
+  `requestAnimationFrame(() => innerHTML = renderMarkdown(...))` — capturing the DOM in a
+  half-rendered state. The user perceives this as "tearing".
+- The **200ms `repaintTimer`** added a second unsynchronized forced-paint source on top
+  of CEF's natural `OnPaint` cycle.
+
+**Fix**: removed both forced invalidation sources. CEF's natural `OnPaint` cycle (capped
+at the windowless frame rate) is left to handle repaints. The `streaming` boolean flag
+that previously gated the per-call invalidate is kept — `MonitorSwitchRecovery` still
+uses it to defer DOM replay until streaming ends.
+
+**What we kept**: 60 fps streaming / 30 fps idle frame rates (still useful for CPU/GPU
+load), smooth-scroll suppression during streaming, the `_scrollRAF` debounce gate, the
+`_setupCodeBlocks()` streaming-bubble skip, and the `_scrollToInstant()` autoscroll
+helper.
+
 ---
 
-## Code Locations
+
 
 | File | Component | Purpose |
 |---|---|---|
-| `ChatConsolePanel.kt` | `startStreaming()` | Sets 60fps, starts repaintTimer, disables smooth scroll |
-| `ChatConsolePanel.kt` | `finishResponse()` | Sets 30fps, stops repaintTimer, restores smooth scroll |
-| `ChatConsolePanel.kt` | `repaintTimer` | 200ms periodic `cef.invalidate()` during streaming |
-| `ChatConsolePanel.kt` | `executeJs()` | Throttled per-call `cef.invalidate()` (50ms) during streaming |
+| `ChatConsolePanel.kt` | `startStreaming()` | Sets 60fps, marks `streaming=true`, disables smooth scroll |
+| `ChatConsolePanel.kt` | `finishResponse()` | Sets 30fps, marks `streaming=false`, restores smooth scroll |
+| `ChatConsolePanel.kt` | `executeJs()` | Plain `executeJavaScript` — no manual `invalidate()` (Fix 4) |
 | `ChatConsolePanel.kt` | `setFrameRate()` | Wraps `setWindowlessFrameRate()` |
 | `ChatContainer.ts` | `_scrollRAF` | rAF debounce gate for scroll writes |
 | `ChatContainer.ts` | `ResizeObserver` | Debounced via `_scrollRAF` — never writes scrollTop directly |
@@ -172,8 +199,9 @@ When modifying the streaming pipeline, watch for:
    the `_scrollRAF` gate. Use `scrollIfNeeded()` for observer-driven autoscroll, or
    `_scrollToInstant()`-backed helpers for explicit snap-to-bottom operations.
 
-3. **New `executeJs` calls during streaming** — each call now triggers throttled invalidation,
-   but excessive calls still add EDT overhead via `pushJsEvent()`. Batch when possible.
+3. **New `executeJs` calls during streaming** — these no longer trigger forced
+   invalidation, but excessive calls still add EDT overhead via `pushJsEvent()`.
+   Batch when possible. Do NOT add a `cef.invalidate()` here — see Fix 4.
 
 4. **CSS `scroll-behavior` changes** — never set `scroll-behavior: smooth` during streaming.
    The `setStreaming(true, false)` call at stream start handles this.
@@ -185,3 +213,7 @@ When modifying the streaming pipeline, watch for:
 
 6. **Frame rate changes** — don't lower `STREAMING_FRAME_RATE` (60) or `IDLE_FRAME_RATE` (30)
    without testing for tearing.
+
+7. **Forced OSR invalidation** — do NOT reintroduce manual `cefBrowser.invalidate()` calls
+   keyed off streaming state (per-token, periodic timer, etc.). They paint mid-rAF and
+   capture half-rendered DOM. This was the root cause uncovered by Fix 4.

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -712,6 +712,9 @@ class ChatConsolePanel(
         entries.clear()
         currentTextData = null; currentThinkingData = null; nextSubAgentColor = 0
         turnCounter = 0; currentTurnId = ""; toolJustCompleted = false
+        // Reset streaming flag — if a session reset happens mid-stream, leaving
+        // streaming=true would make MonitorSwitchRecovery defer DOM replay forever.
+        streaming = false
         executeJs("ChatController.showPlaceholder('${escJs(text)}')")
         fallbackArea?.let { ApplicationManager.getApplication().invokeLater { it.text = text } }
         fireEntriesChanged()
@@ -723,6 +726,8 @@ class ChatConsolePanel(
         entries.clear()
         currentTextData = null; currentThinkingData = null; nextSubAgentColor = 0
         turnCounter = 0; currentTurnId = ""; toolJustCompleted = false
+        // Reset streaming flag — same reason as showPlaceholder() above.
+        streaming = false
         toolCallNames.clear(); toolCallEntries.clear()
         registry.clear()
         clearPendingAskUserRequest(null)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -130,18 +130,11 @@ class ChatConsolePanel(
         browser?.cefBrowser?.setWindowlessFrameRate(fps)
     }
 
-    // Periodic CEF invalidation during streaming — forces OSR buffer refresh
-    // as a safety net against compositor desync during rapid content changes.
-    private val repaintTimer = javax.swing.Timer(200) {
-        browser?.cefBrowser?.invalidate()
-    }.apply { isRepeats = true }
-
-    // Throttled per-executeJs invalidation during streaming. The repaintTimer
-    // provides a 200ms safety net, but individual executeJs calls (tool chips,
-    // sub-agent updates, etc.) can bunch between timer ticks. This ensures a
-    // forced repaint within 50ms of any JS execution during streaming.
-    private var lastStreamingInvalidateMs = 0L
-    private val streamingInvalidateThrottleMs = 50L
+    // Tracks whether the agent is actively streaming a response. Used by
+    // monitor-switch recovery to defer DOM replay until streaming ends, so
+    // the replay does not race with in-flight token updates.
+    @Volatile
+    private var streaming = false
 
     // ── Swing fallback ─────────────────────────────────────────────
     private val fallbackArea: JBTextArea?
@@ -340,7 +333,7 @@ class ChatConsolePanel(
 
     override fun startStreaming() {
         setFrameRate(STREAMING_FRAME_RATE)
-        repaintTimer.start()
+        streaming = true
         // Disable smooth scroll during streaming — CSS scroll animations conflict
         // with rapid programmatic scrollTop changes, causing JCEF OSR tearing.
         executeJs("document.querySelector('chat-container')?.setStreaming(true, false)")
@@ -740,7 +733,7 @@ class ChatConsolePanel(
 
     override fun finishResponse(toolCallCount: Int, modelId: String, multiplier: String) {
         setFrameRate(IDLE_FRAME_RATE)
-        repaintTimer.stop()
+        streaming = false
         val smooth = McpServerSettings.getInstance(project).isSmoothScrollEnabled
         executeJs("document.querySelector('chat-container')?.setStreaming(false, $smooth)")
         toolJustCompleted = false
@@ -812,7 +805,7 @@ class ChatConsolePanel(
 
     override fun cancelAllRunning() {
         setFrameRate(IDLE_FRAME_RATE)
-        repaintTimer.stop()
+        streaming = false
         val smooth = McpServerSettings.getInstance(project).isSmoothScrollEnabled
         executeJs("document.querySelector('chat-container')?.setStreaming(false, $smooth)")
         clearPendingAskUserRequest(null)
@@ -1183,7 +1176,7 @@ class ChatConsolePanel(
 
     override fun dispose() {
         registry.removeKindStateListener(kindStateListener)
-        repaintTimer.stop()
+        streaming = false
         if (registerAsMain) instances.remove(project)
     }
 
@@ -1218,13 +1211,11 @@ class ChatConsolePanel(
             com.intellij.openapi.diagnostic.Logger.getInstance(ChatConsolePanel::class.java)
                 .info("executeJs (ready): $short")
             browser?.cefBrowser?.executeJavaScript(js, "", 0)
-            if (repaintTimer.isRunning) {
-                val now = System.currentTimeMillis()
-                if (now - lastStreamingInvalidateMs >= streamingInvalidateThrottleMs) {
-                    lastStreamingInvalidateMs = now
-                    browser?.cefBrowser?.invalidate()
-                }
-            }
+            // Note: do NOT call cefBrowser.invalidate() here. Forcing OSR repaints
+            // mid-token paints intermediate DOM states (sync textNode append before
+            // the rAF markdown render) and was the actual cause of the recurring
+            // tearing/flicker. CEF's natural OnPaint cycle handles repaints
+            // correctly. See docs/bugs/SCREEN-TEARING-BUG.md (Fix 4).
         } else {
             com.intellij.openapi.diagnostic.Logger.getInstance(ChatConsolePanel::class.java)
                 .info("executeJs (queued): $short")
@@ -1437,7 +1428,7 @@ class ChatConsolePanel(
 
     private fun recoverBrowserStateAfterMonitorSwitch() {
         updateThemeColors()
-        if (repaintTimer.isRunning) {
+        if (streaming) {
             pendingMonitorReplay = true
             return
         }


### PR DESCRIPTION
## Problem

Recurring screen-tearing/flicker during streaming in the JCEF chat panel, reported on **both Windows and Linux**. User suspected FPS sync issues.

## Root cause (refined hypothesis)

The FPS-sync angle was a red herring:
- \`setWindowlessFrameRate\` is capped at 60 in CEF — matching 120/144 Hz monitors isn't possible.
- \`cefBrowser.invalidate()\` is **not a vsync primitive** — it just schedules a CEF repaint that Swing then composites on the EDT.

The actual culprit was **two unsynchronized forced-paint sources** layered on top of CEF's natural \`OnPaint\` cycle:

1. **Per-\`executeJs\` invalidate (50ms throttle)** fired for every streaming token / tool chip / sub-agent update. It captured the DOM mid-rAF — between the synchronous \`appendChild(textNode)\` in \`MessageBubble.appendStreamingText()\` and the deferred \`requestAnimationFrame(() => innerHTML = renderMarkdown(...))\` — painting a half-rendered state that the user perceives as tearing.
2. **200ms \`repaintTimer\`** added a second forced-paint source.

## Fix

Remove both forced invalidation sources and let CEF's natural \`OnPaint\` cycle handle repaints. Replace \`repaintTimer.isRunning\` with an explicit \`streaming: Boolean\` flag — \`MonitorSwitchRecovery\` still uses it to defer DOM replay until streaming ends.

**Kept**: 60/30 fps streaming/idle rates, smooth-scroll suppression during streaming, \`_scrollRAF\` debounce gate, \`_setupCodeBlocks\` streaming skip, \`_scrollToInstant\` autoscroll helper.

## Verification needed

Please test streaming on:
- 60 Hz monitor (Windows + Linux)
- 120/144 Hz monitor (Windows + Linux)
- Multi-monitor switch during streaming

## Docs

\`docs/bugs/SCREEN-TEARING-BUG.md\` updated with Fix 4 + a new regression guard explicitly forbidding forced OSR invalidation keyed off streaming state.