### PR TITLE
feat(side-panel): align Session/Turn layout, inline quota suffix, taller graph

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -2164,6 +2164,15 @@ class ChatToolWindowContent(
                             lastStats.totalToolCalls, lastStats.totalLinesAdded,
                             lastStats.totalLinesRemoved, turnCount
                         )
+                        processingTimerPanel.restoreLastTurnStats(
+                            lastStats.durationMs / 1000,
+                            lastStats.inputTokens.toInt(),
+                            lastStats.outputTokens.toInt(),
+                            if (lastStats.costUsd > 0.0) lastStats.costUsd else null,
+                            lastStats.toolCallCount,
+                            lastStats.linesAdded,
+                            lastStats.linesRemoved
+                        )
                     }
                     persistedEntryCount = conversationReplayer.totalLoadedCount()
                 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ProcessingTimerPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ProcessingTimerPanel.kt
@@ -48,6 +48,11 @@ internal class ProcessingTimerPanel(
     private var turnInputTokens = 0
     private var turnOutputTokens = 0
     private var turnCostUsd: Double? = null
+
+    // Snapshot of the most recently completed turn — kept so the side-panel "Last turn" section
+    // can stay populated between turns. The per-turn mutable fields above are reset on the next
+    // start(); this field captures the final elapsed time at stop() so the display doesn't lose it.
+    private var lastTurnElapsedSec = 0L
     private var sessionTotalInputTokens = 0L
     private var sessionTotalOutputTokens = 0L
     private var sessionTotalCostUsd = 0.0
@@ -137,6 +142,7 @@ internal class ProcessingTimerPanel(
     fun stop() {
         ticker.stop()
         isRunning = false
+        lastTurnElapsedSec = (System.currentTimeMillis() - startedAt) / 1000
         sessionTotalTimeMs += System.currentTimeMillis() - startedAt
         sessionTotalToolCalls += toolCallCount
         sessionTotalAddedLines += addedLineCount
@@ -168,7 +174,16 @@ internal class ProcessingTimerPanel(
         sessionTotalInputTokens = 0L
         sessionTotalOutputTokens = 0L
         sessionTotalCostUsd = 0.0
+        // Also clear the "Last turn" snapshot so a fresh session shows no stale per-turn data.
+        toolCallCount = 0
+        addedLineCount = 0
+        removedLineCount = 0
+        turnInputTokens = 0
+        turnOutputTokens = 0
+        turnCostUsd = null
+        lastTurnElapsedSec = 0L
         displayMode = modeTurn
+        refreshDisplay()
     }
 
     fun restoreSessionStats(
@@ -184,6 +199,25 @@ internal class ProcessingTimerPanel(
         sessionTotalAddedLines = totalLinesAdded
         sessionTotalRemovedLines = totalLinesRemoved
         sessionTurnCount = turnCount
+        refreshDisplay()
+    }
+
+    /**
+     * Restores the most-recent-turn snapshot after a session reload, so the Session tab's
+     * "Last turn" section shows the user's last prompt cost/usage without waiting for the
+     * next turn. Distinct from [restoreSessionStats] which restores cumulative totals.
+     */
+    fun restoreLastTurnStats(
+        elapsedSec: Long, inputTokens: Int, outputTokens: Int, costUsd: Double?,
+        toolCalls: Int, linesAdded: Int, linesRemoved: Int
+    ) {
+        lastTurnElapsedSec = elapsedSec
+        turnInputTokens = inputTokens
+        turnOutputTokens = outputTokens
+        turnCostUsd = costUsd
+        toolCallCount = toolCalls
+        addedLineCount = linesAdded
+        removedLineCount = linesRemoved
         refreshDisplay()
     }
 
@@ -290,13 +324,13 @@ internal class ProcessingTimerPanel(
         val totalTurns = sessionTurnCount + if (isRunning) 1 else 0
         return SessionStatsSnapshot(
             isRunning = isRunning,
-            turnElapsedSec = if (isRunning) (System.currentTimeMillis() - startedAt) / 1000 else 0,
-            turnToolCalls = if (isRunning) toolCallCount else 0,
-            turnLinesAdded = if (isRunning) addedLineCount else 0,
-            turnLinesRemoved = if (isRunning) removedLineCount else 0,
-            turnInputTokens = if (isRunning) turnInputTokens else 0,
-            turnOutputTokens = if (isRunning) turnOutputTokens else 0,
-            turnCostUsd = if (isRunning) turnCostUsd else null,
+            turnElapsedSec = if (isRunning) (System.currentTimeMillis() - startedAt) / 1000 else lastTurnElapsedSec,
+            turnToolCalls = toolCallCount,
+            turnLinesAdded = addedLineCount,
+            turnLinesRemoved = removedLineCount,
+            turnInputTokens = turnInputTokens,
+            turnOutputTokens = turnOutputTokens,
+            turnCostUsd = turnCostUsd,
             sessionTotalTimeSec = totalMs / 1000,
             sessionTurnCount = totalTurns,
             sessionToolCalls = totalTools,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -17,7 +17,6 @@ import com.intellij.util.ui.JBUI;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
-import javax.swing.ScrollPaneConstants;
 import java.awt.*;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -56,8 +55,9 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
     private final JLabel clientIconLabel = new JLabel();
     private final JLabel clientNameLabel = new JLabel();
 
-    // Current turn section
+    // Current turn section (also displays the most recent completed turn between turns)
     private final JLabel turnHeaderLabel = new JLabel("Active turn");
+    private final JLabel turnTimeValue = new JLabel();
     private final JLabel turnToolsValue = new JLabel();
     private final JLabel turnLinesValue = new JLabel();
     private final JLabel turnTokensRowLabel = new JLabel(LABEL_TOKENS);
@@ -89,8 +89,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
     private final JPanel usageRow;
     private final JPanel remainingRow;
     private final JPanel resetsRow;
-    private final JPanel billingHeader;
-    private final JLabel billingNoteLabel;
+    private final JPanel billingSection;
     private final ProjectFilesPanel filesPanel;
 
     public SessionStatsPanel(
@@ -121,7 +120,8 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         clientSection.add(createSectionHeader("Selected client"));
         clientSection.add(clientRow);
 
-        // Current turn section
+        // Current turn section — mirrors the Session grid layout (Time row first) so the
+        // two visually align. Stays visible after the turn ends, then re-labels as "Last turn".
         JPanel turnHeader = createSectionHeader(turnHeaderLabel);
 
         JPanel turnGrid = new JPanel(new GridBagLayout());
@@ -130,6 +130,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
             JBUI.scale(2), JBUI.scale(8), JBUI.scale(4), JBUI.scale(8)));
 
         int tRow = 0;
+        addStatRow(turnGrid, tRow++, "Time", turnTimeValue);
         addStatRow(turnGrid, tRow++, "Tool calls", turnToolsValue);
         addStatRow(turnGrid, tRow++, "Lines changed", turnLinesValue);
         turnTokensRow = addStatRowWithLabel(turnGrid, tRow++, turnTokensRowLabel, turnTokensValue);
@@ -157,12 +158,13 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         tokensRow = addStatRowWithLabel(statsGrid, row++, tokensRowLabel, tokensValue);
         costRow = addStatRowWithLabel(statsGrid, row, costRowLabel, costValue);
 
-        // Usage graph — thin full-width sparkline
+        // Usage graph — full-width sparkline rendered last in the Monthly quota section.
+        // 5x taller than the original 20px to make trends visually readable at a glance.
         JPanel graphSection = new JPanel(new BorderLayout());
         graphSection.setOpaque(false);
         graphSection.setBorder(BorderFactory.createEmptyBorder(
-            JBUI.scale(4), JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
-        int graphH = JBUI.scale(20);
+            JBUI.scale(6), JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
+        int graphH = JBUI.scale(100);
         usageGraphPanel.setPreferredSize(new Dimension(0, graphH));
         usageGraphPanel.setMinimumSize(new Dimension(0, graphH));
         usageGraphPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, graphH));
@@ -172,18 +174,25 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         JPanel billingGrid = new JPanel(new GridBagLayout());
         billingGrid.setOpaque(false);
         billingGrid.setBorder(BorderFactory.createEmptyBorder(
-            JBUI.scale(2), JBUI.scale(8), JBUI.scale(8), JBUI.scale(8)));
+            JBUI.scale(2), JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
 
-        billingHeader = createSectionHeader("Monthly quota");
-        billingNoteLabel = new JLabel("via gh CLI");
-        billingNoteLabel.setFont(smallFont);
-        billingNoteLabel.setForeground(dimColor);
-        billingNoteLabel.setBorder(BorderFactory.createEmptyBorder(0, JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
+        // Section header inlines the data-source note ("via gh CLI") next to the bold
+        // title — replacing the old standalone subtitle row that looked disconnected.
+        JPanel billingHeader = createSectionHeaderWithSuffix("Monthly quota", "via gh CLI");
 
         int brow = 0;
         usageRow = addStatRow(billingGrid, brow++, "Used", usageValue);
         remainingRow = addStatRow(billingGrid, brow++, "Remaining", remainingValue);
         resetsRow = addStatRow(billingGrid, brow, "Resets", resetsValue);
+
+        // Wrap the entire billing area in one section so we can hide all of it (including
+        // the now-tall graph) when no billing data is available — avoids leaving a 100px gap.
+        billingSection = new JPanel();
+        billingSection.setLayout(new BoxLayout(billingSection, BoxLayout.Y_AXIS));
+        billingSection.setOpaque(false);
+        billingSection.add(billingHeader);
+        billingSection.add(billingGrid);
+        billingSection.add(graphSection);
 
         // Assemble the stats content (pinned to the top)
         JPanel content = new JPanel();
@@ -193,10 +202,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         content.add(turnSection);
         content.add(createSectionHeader("Session"));
         content.add(statsGrid);
-        content.add(billingHeader);
-        content.add(billingNoteLabel);
-        content.add(graphSection);
-        content.add(billingGrid);
+        content.add(billingSection);
         content.add(createSectionHeader("Project files"));
 
         // Project files tree expands to its full preferred height; the outer
@@ -271,6 +277,20 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         return header;
     }
 
+    /**
+     * Section header with a non-bold dim suffix (e.g. data-source note) shown next to the
+     * bold title. Keeps the title's visual weight while inlining the supplemental info that
+     * would otherwise need its own subtitle row.
+     */
+    private JPanel createSectionHeaderWithSuffix(String title, String suffix) {
+        JPanel header = createSectionHeader(title);
+        JLabel suffixLabel = new JLabel(suffix);
+        suffixLabel.setFont(smallFont);
+        suffixLabel.setForeground(dimColor);
+        header.add(suffixLabel);
+        return header;
+    }
+
     private JPanel addStatRow(JPanel grid, int row, String labelText, JLabel value) {
         return addStatRowWithLabel(grid, row, new JLabel(labelText), value);
     }
@@ -321,15 +341,20 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
     }
 
     private void refreshTurnSection(SessionStatsSnapshot snap) {
-        if (!snap.isRunning()) {
+        // Show the section whenever there's any turn worth displaying — either an active
+        // turn or at least one completed turn in this session. Previously the section was
+        // hidden between turns, leaving users without a record of their last prompt's cost.
+        boolean hasTurn = snap.isRunning() || snap.getSessionTurnCount() > 0;
+        if (!hasTurn) {
             turnSection.setVisible(false);
             return;
         }
-
-        String elapsed = TimerDisplayFormatter.INSTANCE.formatElapsedTime(snap.getTurnElapsedSec());
-        turnHeaderLabel.setText("Active turn  " + elapsed);
         turnSection.setVisible(true);
+        turnHeaderLabel.setText(snap.isRunning() ? "Active turn" : "Last turn");
 
+        // Time as a labeled row (mirrors the Session section) instead of inline in the
+        // header — the two sections now align visually.
+        turnTimeValue.setText(TimerDisplayFormatter.INSTANCE.formatElapsedTime(snap.getTurnElapsedSec()));
         turnToolsValue.setText(String.valueOf(snap.getTurnToolCalls()));
 
         if (snap.getMultiplierMode()) {
@@ -416,8 +441,9 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
 
     private void refreshBilling(BillingDisplayData bill) {
         boolean hasBilling = bill.getEntitlement() > 0 || bill.getUnlimited();
-        billingHeader.setVisible(hasBilling);
-        billingNoteLabel.setVisible(hasBilling);
+        // Hide the entire section (header + grid + 100px graph) when no billing data —
+        // otherwise a tall empty graph leaves a visually broken gap in the side panel.
+        billingSection.setVisible(hasBilling);
 
         if (bill.getUnlimited()) {
             usageValue.setText("Unlimited");


### PR DESCRIPTION
> ⚠️ Posted on behalf of the repo owner by an AI agent.

Visual cleanup of the Session tab side panel based on user feedback (with reference screenshot in chat):

### Changes
- **Active turn / Last turn alignment** — time is now a labeled `Time` row mirroring the Session section, instead of inline in the section header. Both sections line up visually.
- **Persistent turn section** — previously hidden between turns. Section now re-labels to `Last turn` and keeps showing the most recent prompt's stats (time, tools, tokens, cost) as long as the session has any turn.
- **Restore last-turn snapshot on reload** — `ChatToolWindowContent` feeds persisted turn stats into the new `ProcessingTimerPanel.restoreLastTurnStats` so `Last turn` survives session reload, not just live transitions.
- **Monthly quota header** — `via gh CLI` subtitle moved into the section header as a dim suffix next to the bold title. The standalone subtitle row looked disconnected from the data below it.
- **Taller usage graph rendered last** — sparkline is now 100px (5× the previous 20px) and rendered after the stats grid, so it reads as the visual summary of the section.
- **Hide entire billing section when no data** — wrapped header + grid + graph in a single `billingSection` panel so the now-tall graph doesn't leave a visible gap when the user isn't authenticated with gh CLI.

### Files
- \`ProcessingTimerPanel.kt\` — new \`lastTurnElapsedSec\` field, \`restoreLastTurnStats(...)\` method, snapshot exposes turn fields unconditionally; \`resetSession()\` now clears all turn fields and refreshes display.
- \`ChatToolWindowContent.kt\` — wires \`restoreLastTurnStats\` into the session restore path.
- \`SessionStatsPanel.java\` — Time row added to Active/Last turn grid; new \`createSectionHeaderWithSuffix\` helper; single \`billingSection\` wrapper; graph reordered last and resized to 100px.

### Verification
- \`build_project\` ✓ (0 errors, 0 warnings)
- All compile checks pass on modified files