### PR TITLE
feat: UI/UX polish — input frame, chat visuals, table overflow

### DIFF
--- a/plugin-core/chat-ui/src/BatchRenderer.ts
+++ b/plugin-core/chat-ui/src/BatchRenderer.ts
@@ -5,7 +5,7 @@
  * sends structured JSON with pre-rendered markdown, and this module creates
  * the DOM programmatically using custom elements.
  */
-import {decodeBase64} from './helpers';
+import {decodeBase64, hideRedundantTimestamp} from './helpers';
 
 // ── Batch data types (matching Kotlin serialization) ────────
 
@@ -94,20 +94,28 @@ export function renderBatchFragment(encodedJson: string): DocumentFragment {
 
     for (const turn of turns) {
         switch (turn.type) {
-            case 'user':
-                fragment.appendChild(_renderUserTurn(turn));
+            case 'user': {
+                const el = _renderUserTurn(turn);
+                fragment.appendChild(el);
+                hideRedundantTimestamp(el);
                 break;
+            }
             case 'agent':
                 for (const segment of turn.segments) {
-                    fragment.appendChild(_renderAgentSegment(turn.agent, segment));
+                    const el = _renderAgentSegment(turn.agent, segment);
+                    fragment.appendChild(el);
+                    hideRedundantTimestamp(el);
                 }
                 break;
             case 'separator':
                 fragment.appendChild(_renderSeparator(turn));
                 break;
-            case 'nudge_sent':
-                fragment.appendChild(_renderNudgeSentTurn(turn));
+            case 'nudge_sent': {
+                const el = _renderNudgeSentTurn(turn);
+                fragment.appendChild(el);
+                hideRedundantTimestamp(el);
                 break;
+            }
             case 'stats':
                 _appendStatsToLastAgent(fragment, turn);
                 break;

--- a/plugin-core/chat-ui/src/ChatController.ts
+++ b/plugin-core/chat-ui/src/ChatController.ts
@@ -1,4 +1,4 @@
-import {decodeBase64, escHtml} from './helpers';
+import {decodeBase64, escHtml, hideRedundantTimestamp} from './helpers';
 import {renderBatchFragment} from './BatchRenderer';
 import type {TurnContext} from './types';
 
@@ -211,6 +211,7 @@ const ChatController = {
         } else {
             msgs.appendChild(msg);
         }
+        if (msg.tagName === 'CHAT-MESSAGE') hideRedundantTimestamp(msg);
     },
 
     _collapseThinkingFor(ctx: TurnContext & {

--- a/plugin-core/chat-ui/src/chat.css
+++ b/plugin-core/chat-ui/src/chat.css
@@ -55,10 +55,13 @@
     --tool-a08: rgba(180, 160, 220, 0.08);
     --tool-a16: rgba(180, 160, 220, 0.16);
     --tool-a40: rgba(180, 160, 220, 0.40);
-    /* Tool kind colors */
-    --kind-read: rgb(100, 185, 185);
+    /* Tool kind colors — semantic:
+       read/search = safe (green/blue), edit/write/move = local mutate (amber),
+       delete/execute = destructive or remote (red). */
+    --kind-read: rgb(120, 190, 120);
     --kind-edit: rgb(205, 155, 95);
-    --kind-execute: rgb(130, 190, 130);
+    --kind-execute: rgb(210, 105, 105);
+    --kind-destructive: rgb(210, 105, 105);
     --kind-think: rgb(170, 155, 210);
     --kind-search: rgb(110, 165, 210);
     --kind-other: rgb(160, 165, 170);
@@ -394,6 +397,11 @@ working-indicator .working-text {
     flex-shrink: 0;
 }
 
+/* Hide redundant timestamps when the previous message shares the same minute */
+.ts.ts-hidden {
+    display: none;
+}
+
 /* User message timestamp: push to the right edge of the meta strip */
 .prompt-row .meta .ts {
     order: 10;
@@ -539,13 +547,24 @@ working-indicator .working-text {
     border-color: color-mix(in srgb, var(--kind-edit) 22%, transparent);
 }
 
-/* write, delete, move share the edit color */
+/* write, move share the edit (local mutate) color.
+   delete is destructive — separate mapping below. */
 .turn-chip.kind-write,
-.turn-chip.kind-delete,
 .turn-chip.kind-move {
     color: var(--kind-edit);
     background: color-mix(in srgb, var(--kind-edit) 10%, transparent);
     border-color: color-mix(in srgb, var(--kind-edit) 22%, transparent);
+}
+
+.turn-chip.kind-delete {
+    color: var(--kind-destructive);
+    background: color-mix(in srgb, var(--kind-destructive) 10%, transparent);
+    border-color: color-mix(in srgb, var(--kind-destructive) 22%, transparent);
+}
+
+.turn-chip.kind-delete:hover {
+    background: color-mix(in srgb, var(--kind-destructive) 18%, transparent);
+    border-color: color-mix(in srgb, var(--kind-destructive) 32%, transparent);
 }
 
 .turn-chip.kind-execute {
@@ -784,11 +803,18 @@ thinking-chip.thinking-active .thought-bubble {
 }
 
 /* ── Session separator ───────────────────────────────── */
+session-divider {
+    display: block;
+    width: 100%;
+}
+
 .session-sep {
     display: flex;
     align-items: center;
+    justify-content: center;
     gap: var(--sp-5);
     margin: var(--sp-8) 0;
+    width: 100%;
     opacity: 0.6;
 }
 

--- a/plugin-core/chat-ui/src/chat.css
+++ b/plugin-core/chat-ui/src/chat.css
@@ -148,10 +148,10 @@ chat-container {
     height: 100%;
     overflow-y: auto;
     overflow-x: hidden;
-    /* No right padding so the vertical scrollbar sits flush against the
-       tool-window right edge. Bubbles already cap at max-width: 94%, which
-       gives them visible breathing room from the scrollbar lane. */
-    padding: var(--sp-4) 0 var(--sp-4) var(--sp-4);
+    /* Small right padding (sp-1 = 2px) so bubbles align with the input frame's
+       right edge. The scrollbar still sits inside this narrow lane — this is
+       the visual gap that previously made bubbles look offset from the input. */
+    padding: var(--sp-4) var(--sp-2) var(--sp-4) var(--sp-4);
     contain: paint;
 }
 

--- a/plugin-core/chat-ui/src/chat.css
+++ b/plugin-core/chat-ui/src/chat.css
@@ -148,7 +148,10 @@ chat-container {
     height: 100%;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: var(--sp-4);
+    /* No right padding so the vertical scrollbar sits flush against the
+       tool-window right edge. Bubbles already cap at max-width: 94%, which
+       gives them visible breathing room from the scrollbar lane. */
+    padding: var(--sp-4) 0 var(--sp-4) var(--sp-4);
     contain: paint;
 }
 

--- a/plugin-core/chat-ui/src/chat.css
+++ b/plugin-core/chat-ui/src/chat.css
@@ -925,6 +925,49 @@ table::-webkit-scrollbar-track {
     background: transparent;
 }
 
+/* Wrapper added by JS when a table is present — positions the "Open in editor" overlay */
+.table-wrap {
+    position: relative;
+}
+
+.table-open-btn {
+    position: absolute;
+    top: calc(var(--sp-4) + 2px);
+    right: var(--sp-2);
+    display: none;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    font-size: 0.85em;
+    line-height: 1.4;
+    color: var(--fg-muted);
+    background: var(--bg);
+    border: 1px solid var(--tbl-border);
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 120ms ease, color 120ms ease, border-color 120ms ease;
+    z-index: 1;
+}
+
+.table-open-btn svg {
+    flex-shrink: 0;
+}
+
+.table-wrap.table-overflow .table-open-btn {
+    display: inline-flex;
+}
+
+.table-wrap.table-overflow:hover .table-open-btn,
+.table-open-btn:focus-visible {
+    opacity: 1;
+}
+
+.table-open-btn:hover {
+    color: var(--fg);
+    border-color: var(--fg-muted);
+}
+
 th, td {
     border: none;
     border-bottom: 1px solid var(--tbl-border);

--- a/plugin-core/chat-ui/src/components/ChatContainer.ts
+++ b/plugin-core/chat-ui/src/components/ChatContainer.ts
@@ -17,6 +17,11 @@ export default class ChatContainer extends HTMLElement {
     private _touchStartY = 0;
     private _wheelRAF: number | null = null;
     private _resizeObs: ResizeObserver | null = null;
+    // Per-instance shared ResizeObserver for table overflow detection. Reusing one
+    // observer across all tables avoids the per-table overhead and reference retention
+    // that would accumulate in long chats.
+    private _tableResizeObs: ResizeObserver | null = null;
+    private _tableOverflowCallbacks: WeakMap<Element, () => void> = new WeakMap();
 
     connectedCallback(): void {
         if (this._init) return;
@@ -217,7 +222,20 @@ export default class ChatContainer extends HTMLElement {
                 wrap.classList.toggle('table-overflow', table.scrollWidth > table.clientWidth + 1);
             };
             updateOverflow();
-            new ResizeObserver(updateOverflow).observe(table);
+            // Lazily create a single shared observer for *all* tables in this container,
+            // and dispatch resize events to the per-table callback via a WeakMap. Avoids
+            // creating a fresh observer per table (which would also retain references to
+            // tables removed from the DOM until GC).
+            if (!this._tableResizeObs) {
+                this._tableResizeObs = new ResizeObserver((entries) => {
+                    for (const entry of entries) {
+                        const cb = this._tableOverflowCallbacks.get(entry.target);
+                        if (cb) cb();
+                    }
+                });
+            }
+            this._tableOverflowCallbacks.set(table, updateOverflow);
+            this._tableResizeObs.observe(table);
         });
     }
 
@@ -349,6 +367,8 @@ export default class ChatContainer extends HTMLElement {
         this._observer?.disconnect();
         this._copyObs?.disconnect();
         this._resizeObs?.disconnect();
+        this._tableResizeObs?.disconnect();
+        this._tableResizeObs = null;
         if (this._onScroll) this.removeEventListener('scroll', this._onScroll);
         if (this._onWheel) this.removeEventListener('wheel', this._onWheel);
         if (this._onTouchStart) this.removeEventListener('touchstart', this._onTouchStart);

--- a/plugin-core/chat-ui/src/components/ChatContainer.ts
+++ b/plugin-core/chat-ui/src/components/ChatContainer.ts
@@ -122,6 +122,7 @@ export default class ChatContainer extends HTMLElement {
                 this._copyRAF = requestAnimationFrame(() => {
                     this._copyRAF = null;
                     this._setupCodeBlocks();
+                    this._setupTables();
                 });
             }
         });
@@ -187,6 +188,64 @@ export default class ChatContainer extends HTMLElement {
             toolbar.append(scratchBtn, wrapBtn, copyBtn);
             pre.prepend(toolbar);
         });
+    }
+
+    private _setupTables(): void {
+        this._messages.querySelectorAll('table:not([data-table-btn])').forEach(tableEl => {
+            const table = tableEl as HTMLTableElement;
+            if (table.closest('message-bubble[streaming]')) return;
+            table.dataset.tableBtn = '1';
+
+            const btn = document.createElement('button');
+            btn.className = 'table-open-btn';
+            btn.type = 'button';
+            btn.innerHTML = '<svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 1.5H4a1.5 1.5 0 0 0-1.5 1.5v10A1.5 1.5 0 0 0 4 14.5h8a1.5 1.5 0 0 0 1.5-1.5V6L9 1.5z"/><polyline points="9 1.5 9 6 13.5 6"/></svg><span>Open in editor</span>';
+            btn.title = 'Open full table in a scratch editor';
+            btn.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                globalThis._bridge?.openScratch('md', this._tableToMarkdown(table));
+            });
+
+            const wrap = document.createElement('div');
+            wrap.className = 'table-wrap';
+            table.parentNode?.insertBefore(wrap, table);
+            wrap.appendChild(table);
+            wrap.appendChild(btn);
+
+            const updateOverflow = () => {
+                wrap.classList.toggle('table-overflow', table.scrollWidth > table.clientWidth + 1);
+            };
+            updateOverflow();
+            new ResizeObserver(updateOverflow).observe(table);
+        });
+    }
+
+    private _tableToMarkdown(table: HTMLTableElement): string {
+        const rows: string[][] = [];
+        table.querySelectorAll('tr').forEach(tr => {
+            const cells: string[] = [];
+            tr.querySelectorAll('th, td').forEach(cell => {
+                cells.push((cell.textContent ?? '').replaceAll(/\s+/g, ' ').replaceAll('|', String.raw`\|`).trim());
+            });
+            if (cells.length > 0) rows.push(cells);
+        });
+        if (rows.length === 0) return '';
+        const width = Math.max(...rows.map(r => r.length));
+        const pad = (r: string[]) => {
+            while (r.length < width) r.push('');
+            return r;
+        };
+        const lines: string[] = [];
+        const header = pad(rows[0]);
+        lines.push(
+            '| ' + header.join(' | ') + ' |',
+            '| ' + header.map(() => '---').join(' | ') + ' |',
+        );
+        for (let i = 1; i < rows.length; i++) {
+            lines.push('| ' + pad(rows[i]).join(' | ') + ' |');
+        }
+        return lines.join('\n') + '\n';
     }
 
     private _resetCopyButton(btn: HTMLButtonElement): void {

--- a/plugin-core/chat-ui/src/helpers.ts
+++ b/plugin-core/chat-ui/src/helpers.ts
@@ -23,3 +23,32 @@ export function collapseAllChips(container: Element | null, except?: Element): v
 export function escHtml(s: string | null | undefined): string {
     return s ? s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;') : '';
 }
+
+/**
+ * Collapse a bubble's timestamp when the previous chat-message shares the same minute
+ * (timestamps are rendered as "HH:MM"). Reduces visual noise in streams of close messages
+ * while still marking the first bubble of each minute.
+ *
+ * Call *after* the message's .ts span has been populated and the message has been
+ * inserted into the DOM. A session-divider between two messages always re-shows the
+ * next timestamp, since a new session is a natural break regardless of minute.
+ */
+export function hideRedundantTimestamp(msg: Element): void {
+    const tsEl = msg.querySelector('.ts');
+    if (!tsEl || !tsEl.textContent) return;
+    const current = tsEl.textContent.trim();
+    if (!current) return;
+    let prev = msg.previousElementSibling;
+    while (prev) {
+        const tag = prev.tagName;
+        if (tag === 'SESSION-DIVIDER') return;
+        if (tag === 'CHAT-MESSAGE') {
+            const prevTs = prev.querySelector('.ts');
+            if (prevTs && prevTs.textContent?.trim() === current) {
+                tsEl.classList.add('ts-hidden');
+            }
+            return;
+        }
+        prev = prev.previousElementSibling;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
@@ -241,17 +241,26 @@ public final class GitCommitTool extends GitTool {
      * into a single "... and N more files" suffix.
      */
     private static String formatPathList(String rawNewlineSeparated) {
-        if (rawNewlineSeparated == null || rawNewlineSeparated.isEmpty()) return "";
-        String[] parts = rawNewlineSeparated.split("\n");
-        if (parts.length <= PATH_LIST_LIMIT) {
+        if (rawNewlineSeparated == null || rawNewlineSeparated.isBlank()) return "";
+        // Split on \r?\n and trim each entry — git output on Windows uses CRLF, and a
+        // raw "\n"-only split would leave stray \r characters in the rendered hint.
+        java.util.List<String> parts = new java.util.ArrayList<>();
+        for (String line : rawNewlineSeparated.split("\\r?\\n")) {
+            String trimmed = line.trim();
+            if (!trimmed.isEmpty()) {
+                parts.add(trimmed);
+            }
+        }
+        if (parts.isEmpty()) return "";
+        if (parts.size() <= PATH_LIST_LIMIT) {
             return String.join(", ", parts);
         }
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < PATH_LIST_LIMIT; i++) {
             if (i > 0) sb.append(", ");
-            sb.append(parts[i]);
+            sb.append(parts.get(i));
         }
-        sb.append(", ... and ").append(parts.length - PATH_LIST_LIMIT).append(" more files");
+        sb.append(", ... and ").append(parts.size() - PATH_LIST_LIMIT).append(" more files");
         return sb.toString();
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitCommitTool.java
@@ -232,6 +232,29 @@ public final class GitCommitTool extends GitTool {
         return basePath + "/" + path;
     }
 
+    private static final int PATH_LIST_LIMIT = 10;
+
+    /**
+     * Caps a newline-separated path list so the "nothing to commit" hint stays
+     * readable when a sub-directory like {@code .agent-work/} contains hundreds of
+     * gitignored files. Anything beyond {@value #PATH_LIST_LIMIT} entries is folded
+     * into a single "... and N more files" suffix.
+     */
+    private static String formatPathList(String rawNewlineSeparated) {
+        if (rawNewlineSeparated == null || rawNewlineSeparated.isEmpty()) return "";
+        String[] parts = rawNewlineSeparated.split("\n");
+        if (parts.length <= PATH_LIST_LIMIT) {
+            return String.join(", ", parts);
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < PATH_LIST_LIMIT; i++) {
+            if (i > 0) sb.append(", ");
+            sb.append(parts[i]);
+        }
+        sb.append(", ... and ").append(parts.length - PATH_LIST_LIMIT).append(" more files");
+        return sb.toString();
+    }
+
     /**
      * Builds a detailed hint for the "nothing to commit" case, listing which paths are
      * unstaged/untracked/ignored so the agent knows exactly what to stage (or force-add).
@@ -253,13 +276,13 @@ public final class GitCommitTool extends GitTool {
 
         hint.append(" Changes exist but were not staged by --all:");
         if (hasUnstaged) {
-            hint.append("\n  Modified (not staged): ").append(unstaged.replace("\n", ", "));
+            hint.append("\n  Modified (not staged): ").append(formatPathList(unstaged));
         }
         if (hasUntracked) {
-            hint.append("\n  Untracked: ").append(untracked.replace("\n", ", "));
+            hint.append("\n  Untracked: ").append(formatPathList(untracked));
         }
         if (hasIgnored) {
-            hint.append("\n  Gitignored: ").append(ignored.replace("\n", ", "))
+            hint.append("\n  Gitignored: ").append(formatPathList(ignored))
                 .append("\n  (ignored files require explicit `git add -f <path>` — git_stage will not force-add them)");
         }
         hint.append("\nUse git_stage with an explicit path to include specific files, "

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
@@ -192,13 +192,27 @@ public final class SearchTextTool extends NavigationTool {
             AgentTabTracker.getInstance(project).trackTab("Find", tabText);
             // Auto-expand all groups so the agent's results are immediately visible —
             // by default the Find tool window collapses every file group, requiring an
-            // extra click before any usages are shown. expandAll() lives on UsageViewImpl,
-            // so cast cautiously and schedule on a later EDT pump because usage nodes are
-            // appended asynchronously after showUsages returns.
-            if (view instanceof com.intellij.usages.impl.UsageViewImpl impl) {
-                ApplicationManager.getApplication().invokeLater(impl::expandAll);
-            }
+            // extra click before any usages are shown. Schedule expansion on a later EDT
+            // pump because usage nodes are appended asynchronously after showUsages returns.
+            ApplicationManager.getApplication().invokeLater(() -> expandUsageViewIfSupported(view));
         });
+    }
+
+    /**
+     * Expands all groups in a {@link com.intellij.usages.UsageView} by reflection, so we
+     * don't take a compile-time dependency on {@code com.intellij.usages.impl.UsageViewImpl}
+     * — that's an internal implementation class whose presence/signature can shift across
+     * IDE versions and break Marketplace verification.
+     */
+    private static void expandUsageViewIfSupported(@Nullable com.intellij.usages.UsageView view) {
+        if (view == null) return;
+        try {
+            java.lang.reflect.Method expandAllMethod = view.getClass().getMethod("expandAll");
+            expandAllMethod.invoke(view);
+        } catch (ReflectiveOperationException ignored) {
+            // Older/newer IDEs may use a different impl or omit expandAll() — auto-expand
+            // is a UX nicety, not a correctness requirement, so silently skip.
+        }
     }
 
     private boolean processFile(VirtualFile vf, SearchParams p) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/navigation/SearchTextTool.java
@@ -187,8 +187,17 @@ public final class SearchTextTool extends NavigationTool {
             UsageViewPresentation pres = new UsageViewPresentation();
             String tabText = "Search: " + query;
             pres.setTabText(tabText);
-            UsageViewManager.getInstance(project).showUsages(UsageTarget.EMPTY_ARRAY, usages, pres);
+            com.intellij.usages.UsageView view =
+                UsageViewManager.getInstance(project).showUsages(UsageTarget.EMPTY_ARRAY, usages, pres);
             AgentTabTracker.getInstance(project).trackTab("Find", tabText);
+            // Auto-expand all groups so the agent's results are immediately visible —
+            // by default the Find tool window collapses every file group, requiring an
+            // extra click before any usages are shown. expandAll() lives on UsageViewImpl,
+            // so cast cautiously and schedule on a later EDT pump because usage nodes are
+            // appended asynchronously after showUsages returns.
+            if (view instanceof com.intellij.usages.impl.UsageViewImpl impl) {
+                ApplicationManager.getApplication().invokeLater(impl::expandAll);
+            }
         });
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/BillingManager.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/BillingManager.kt
@@ -52,6 +52,22 @@ class BillingManager {
         localSessionPremiumRequests = 0.0
     }
 
+    /**
+     * Restores session-level counters from persisted turn history.
+     * Called once during conversation replay so the side-panel "Premium req" total reflects
+     * the entire session (matching the restored "Turns" count) instead of starting at 0
+     * after each IDE restart.
+     */
+    fun restoreSessionCounters(turns: Int, premium: Double) {
+        localSessionRequests = turns
+        localSessionPremiumRequests = premium
+        previousUsedCount = estimatedUsed()
+        ApplicationManager.getApplication().invokeLater {
+            refreshUsageDisplay()
+            updateUsageGraph(estimatedUsed(), lastBillingEntitlement, lastBillingUnlimited, lastBillingResetDate)
+        }
+    }
+
     private var previousUsedCount = -1
     private var usageAnimationTimer: javax.swing.Timer? = null
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -957,23 +957,30 @@ class ChatToolWindowContent(
         val innerBar = JBPanel<JBPanel<*>>(BorderLayout())
         innerBar.isOpaque = false
         innerBar.border = JBUI.Borders.empty(0, 2, 0, 2)
-        // Wrap both sides in BorderLayout.SOUTH so they share the same bottom edge,
-        // regardless of their intrinsic heights (badges are shorter than buttons).
-        val leftWrapper = JBPanel<JBPanel<*>>(BorderLayout()).apply {
+        // Layout strategy: a single horizontal row with all three groups vertically
+        // centered via FlowLayout. Centering (rather than BorderLayout.SOUTH wrappers)
+        // is what produces the perceived "same bottom" alignment — the model selector
+        // and Send button have internal padding that makes their content sit above
+        // their bounding-box bottom, so SOUTH-anchoring the bounding boxes leaves the
+        // shortcut text visually below the buttons. Centering aligns all three on the
+        // same eye-line, which reads as bottom-aligned for the visible content.
+        //
+        // Shortcut hints live in CENTER, FlowLayout.CENTER, so they sit centered in
+        // the horizontal gap between the left side-buttons (+, power) and the
+        // right-side model+Send group.
+        val centerWrapper = JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.CENTER, 0, 0)).apply {
             isOpaque = false
-            add(shortcutHintPanel, BorderLayout.SOUTH)
+            add(shortcutHintPanel)
         }
-        innerBar.add(leftWrapper, BorderLayout.WEST)
-        // Model selector and Send button grouped together on the right
-        val rightSide = JBPanel<JBPanel<*>>(BorderLayout(JBUI.scale(2), 0))
-        rightSide.isOpaque = false
-        rightSide.add(modelToolbar.component, BorderLayout.WEST)
-        rightSide.add(innerInputToolbar.component, BorderLayout.EAST)
-        val rightWrapper = JBPanel<JBPanel<*>>(BorderLayout()).apply {
+        innerBar.add(centerWrapper, BorderLayout.CENTER)
+        // Model selector and Send button grouped together on the right, vertically
+        // centered via FlowLayout so they share the same eye-line as the hints.
+        val rightSide = JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.RIGHT, JBUI.scale(2), 0)).apply {
             isOpaque = false
-            add(rightSide, BorderLayout.SOUTH)
         }
-        innerBar.add(rightWrapper, BorderLayout.EAST)
+        rightSide.add(modelToolbar.component)
+        rightSide.add(innerInputToolbar.component)
+        innerBar.add(rightSide, BorderLayout.EAST)
         row.add(innerBar, BorderLayout.SOUTH)
 
         refreshShortcutHints()

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -954,33 +954,34 @@ class ChatToolWindowContent(
         innerInputToolbar.isReservePlaceAutoPopupIcon = false
         innerInputToolbar.component.isOpaque = false
 
-        val innerBar = JBPanel<JBPanel<*>>(BorderLayout())
-        innerBar.isOpaque = false
-        innerBar.border = JBUI.Borders.empty(0, 2, 0, 2)
-        // Layout strategy: a single horizontal row with all three groups vertically
-        // centered via FlowLayout. Centering (rather than BorderLayout.SOUTH wrappers)
-        // is what produces the perceived "same bottom" alignment — the model selector
-        // and Send button have internal padding that makes their content sit above
-        // their bounding-box bottom, so SOUTH-anchoring the bounding boxes leaves the
-        // shortcut text visually below the buttons. Centering aligns all three on the
-        // same eye-line, which reads as bottom-aligned for the visible content.
-        //
-        // Shortcut hints live in CENTER, FlowLayout.CENTER, so they sit centered in
-        // the horizontal gap between the left side-buttons (+, power) and the
-        // right-side model+Send group.
-        val centerWrapper = JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.CENTER, 0, 0)).apply {
+        // Layout strategy: a single horizontal BoxLayout row where every child has
+        // alignmentY = CENTER_ALIGNMENT. This is what produces a true visual midline
+        // alignment across heterogeneous components. Earlier attempts using
+        // BorderLayout.CENTER + FlowLayout failed because BorderLayout.CENTER stretches
+        // its cell to the full container height, but FlowLayout still positions its
+        // single row at the *top* of that stretched cell — so the shortcut hints
+        // ended up visually anchored to the top while the Send / Model toolbars
+        // (added via BorderLayout.EAST, which respects preferred size and vertically
+        // centers) sat in the middle. BoxLayout X_AXIS with alignmentY=0.5 on every
+        // child centers each one independently on the row's midline regardless of
+        // its preferred height or internal padding.
+        val innerBar = JBPanel<JBPanel<*>>().apply {
+            layout = BoxLayout(this, BoxLayout.X_AXIS)
             isOpaque = false
-            add(shortcutHintPanel)
+            border = JBUI.Borders.empty(0, 2, 0, 2)
         }
-        innerBar.add(centerWrapper, BorderLayout.CENTER)
-        // Model selector and Send button grouped together on the right, vertically
-        // centered via FlowLayout so they share the same eye-line as the hints.
-        val rightSide = JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.RIGHT, JBUI.scale(2), 0)).apply {
-            isOpaque = false
-        }
-        rightSide.add(modelToolbar.component)
-        rightSide.add(innerInputToolbar.component)
-        innerBar.add(rightSide, BorderLayout.EAST)
+        shortcutHintPanel.alignmentY = Component.CENTER_ALIGNMENT
+        modelToolbar.component.alignmentY = Component.CENTER_ALIGNMENT
+        innerInputToolbar.component.alignmentY = Component.CENTER_ALIGNMENT
+        // Glue on both sides of the hints centers them in the horizontal gap
+        // between the left side-buttons (+, power, attachments) and the right-side
+        // model + Send group.
+        innerBar.add(Box.createHorizontalGlue())
+        innerBar.add(shortcutHintPanel)
+        innerBar.add(Box.createHorizontalGlue())
+        innerBar.add(modelToolbar.component)
+        innerBar.add(Box.createHorizontalStrut(JBUI.scale(2)))
+        innerBar.add(innerInputToolbar.component)
         row.add(innerBar, BorderLayout.SOUTH)
 
         refreshShortcutHints()

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -90,7 +90,7 @@ class ChatToolWindowContent(
     private var restartSessionGroup: RestartSessionGroup? = null
     private lateinit var promptTextArea: EditorTextField
     private lateinit var shortcutHintPanel: PromptShortcutHintPanel
-    private var isInputHovered = false
+    private val queuedTexts = ArrayDeque<String>()
 
     @Volatile
     private var isSending = false
@@ -339,9 +339,7 @@ class ChatToolWindowContent(
     private fun updatePromptPlaceholder() {
         val editor = promptTextArea.editor as? EditorEx ?: return
         editor.setPlaceholder(promptPlaceholder())
-        if (::shortcutHintPanel.isInitialized) {
-            shortcutHintPanel.setNudgeMode(isSending)
-        }
+        refreshShortcutHints()
     }
 
     fun disconnectFromAgent() {
@@ -907,20 +905,17 @@ class ChatToolWindowContent(
                 sendPromptDirectly = ::sendPromptDirectly,
                 restorePromptText = ::restorePromptText,
                 onTurnMineEntries = ::mineEntriesAfterTurn,
+                onQueuedMessageConsumed = { text ->
+                    queuedTexts.remove(text)
+                    ApplicationManager.getApplication().invokeLater { refreshShortcutHints() }
+                },
             )
         )
 
-        // Shortcut hint overlay — initialized here so the focus listener below can reference it.
+        // Shortcut hint bar — initialized here so input wiring below can reference it.
         shortcutHintPanel = PromptShortcutHintPanel()
         shortcutHintPanel.isVisible =
             com.github.catatafishen.agentbridge.settings.ChatInputSettings.getInstance().isShowShortcutHints
-        // Clicking the panel background (between key badges) focuses the input.
-        shortcutHintPanel.addMouseListener(object : java.awt.event.MouseAdapter() {
-            override fun mouseClicked(e: java.awt.event.MouseEvent) {
-                promptTextArea.requestFocusInWindow()
-            }
-        })
-        shortcutHintPanel.cursor = Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR)
 
         setupPromptDragDrop(promptTextArea)
         promptTextArea.addSettingsProvider { editor ->
@@ -931,11 +926,6 @@ class ChatToolWindowContent(
             editor.settings.isUseSoftWraps =
                 com.github.catatafishen.agentbridge.settings.ChatInputSettings.getInstance().isSoftWrapsEnabled
             editor.setBorder(null)
-            // Overlay hides while the user types; reappears when the input is idle and empty.
-            editor.contentComponent.addFocusListener(object : java.awt.event.FocusAdapter() {
-                override fun focusGained(e: java.awt.event.FocusEvent) = updateShortcutHintVisibility()
-                override fun focusLost(e: java.awt.event.FocusEvent) = updateShortcutHintVisibility()
-            })
         }
 
         promptTextArea.addDocumentListener(object : com.intellij.openapi.editor.event.DocumentListener {
@@ -946,60 +936,11 @@ class ChatToolWindowContent(
                 ApplicationManager.getApplication().invokeLater {
                     promptTextArea.revalidate()
                     checkSlashCommandAutocomplete()
-                    updateShortcutHintVisibility()
                 }
             }
         })
 
-        // Overlay container: promptTextArea fills all bounds; shortcutHintPanel is centered on top.
-        // null layout with doLayout() gives precise control without resize listeners.
-        val inputContainer = object : JPanel(null) {
-            override fun doLayout() {
-                promptTextArea.setBounds(0, 0, width, height)
-                if (shortcutHintPanel.isVisible) {
-                    val pref = shortcutHintPanel.preferredSize
-                    shortcutHintPanel.setBounds(
-                        (width - pref.width) / 2,
-                        (height - pref.height) / 2,
-                        pref.width, pref.height
-                    )
-                }
-            }
-
-            override fun getPreferredSize(): Dimension = promptTextArea.preferredSize
-            override fun getMinimumSize(): Dimension = promptTextArea.minimumSize
-        }
-        inputContainer.isOpaque = false
-        inputContainer.add(shortcutHintPanel) // index 0 = lowest z-order index = painted last = on top
-        inputContainer.add(promptTextArea)    // index 1 = behind, visible through transparent shortcutHintPanel
-        // exitCheck defers to the next EDT cycle so getMousePosition(true) reflects the cursor's
-        // new location after the event. This correctly distinguishes "moved to child" (returns
-        // non-null → still hovered) from "left the container" (returns null → not hovered).
-        // The listener is also attached to promptTextArea because Swing only fires mouseExited on
-        // a parent when the cursor moves from the parent's own area to a child — not when the
-        // cursor exits a child directly to outside the parent. Without the child listener,
-        // fast movements leave isInputHovered stuck at true.
-        val exitCheckRun = Runnable {
-            SwingUtilities.invokeLater {
-                if (inputContainer.getMousePosition(true) == null) {
-                    isInputHovered = false
-                    updateShortcutHintVisibility()
-                }
-            }
-        }
-        inputContainer.addMouseListener(object : java.awt.event.MouseAdapter() {
-            override fun mouseEntered(e: java.awt.event.MouseEvent) {
-                isInputHovered = true
-                updateShortcutHintVisibility()
-            }
-
-            override fun mouseExited(e: java.awt.event.MouseEvent) = exitCheckRun.run()
-        })
-        promptTextArea.addMouseListener(object : java.awt.event.MouseAdapter() {
-            override fun mouseExited(e: java.awt.event.MouseEvent) = exitCheckRun.run()
-        })
-
-        row.add(inputContainer, BorderLayout.CENTER)
+        row.add(promptTextArea, BorderLayout.CENTER)
 
         val modelGroup = DefaultActionGroup()
         modelGroup.add(ModelSelectorAction())
@@ -1016,13 +957,26 @@ class ChatToolWindowContent(
         val innerBar = JBPanel<JBPanel<*>>(BorderLayout())
         innerBar.isOpaque = false
         innerBar.border = JBUI.Borders.empty(0, 2, 0, 2)
+        // Wrap both sides in BorderLayout.SOUTH so they share the same bottom edge,
+        // regardless of their intrinsic heights (badges are shorter than buttons).
+        val leftWrapper = JBPanel<JBPanel<*>>(BorderLayout()).apply {
+            isOpaque = false
+            add(shortcutHintPanel, BorderLayout.SOUTH)
+        }
+        innerBar.add(leftWrapper, BorderLayout.WEST)
         // Model selector and Send button grouped together on the right
         val rightSide = JBPanel<JBPanel<*>>(BorderLayout(JBUI.scale(2), 0))
         rightSide.isOpaque = false
         rightSide.add(modelToolbar.component, BorderLayout.WEST)
         rightSide.add(innerInputToolbar.component, BorderLayout.EAST)
-        innerBar.add(rightSide, BorderLayout.EAST)
+        val rightWrapper = JBPanel<JBPanel<*>>(BorderLayout()).apply {
+            isOpaque = false
+            add(rightSide, BorderLayout.SOUTH)
+        }
+        innerBar.add(rightWrapper, BorderLayout.EAST)
         row.add(innerBar, BorderLayout.SOUTH)
+
+        refreshShortcutHints()
 
         return row
     }
@@ -1117,8 +1071,10 @@ class ChatToolWindowContent(
                     consolePanel.addNudgeEntry(resolveId, capturedText)
                     appendNewEntries()
                 }
+                refreshShortcutHints()
             }
         }
+        refreshShortcutHints()
     }
 
     /** Clears pending nudge state and removes the nudge bubble from the chat panel. */
@@ -1128,7 +1084,10 @@ class ChatToolWindowContent(
         val psiBridge = com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(project)
         psiBridge.setPendingNudge(null)
         psiBridge.setOnNudgeConsumed(null)
-        ApplicationManager.getApplication().invokeLater { consolePanel.removeNudgeBubble(nudgeId) }
+        ApplicationManager.getApplication().invokeLater {
+            consolePanel.removeNudgeBubble(nudgeId)
+            refreshShortcutHints()
+        }
     }
 
     private fun buildBubbleHtml(rawText: String, items: List<ContextItemData>): String? =
@@ -1140,17 +1099,60 @@ class ChatToolWindowContent(
 
     fun setShortcutHintsVisible() {
         if (!::shortcutHintPanel.isInitialized) return
-        updateShortcutHintVisibility()
-    }
-
-    /** Shows or hides the hint overlay based on hover, focus, and text state. */
-    private fun updateShortcutHintVisibility() {
-        if (!::shortcutHintPanel.isInitialized) return
-        val hasText = promptTextArea.text.isNotEmpty()
-        val isFocused = promptTextArea.editor?.contentComponent?.hasFocus() == true
         shortcutHintPanel.isVisible =
             com.github.catatafishen.agentbridge.settings.ChatInputSettings.getInstance().isShowShortcutHints
-                && !hasText && !isFocused && !isInputHovered
+        refreshShortcutHints()
+    }
+
+    /**
+     * Rebuilds the shortcut hint bar based on the current input/turn state.
+     *
+     * - Idle: Enter ▸ Send, Shift+Enter ▸ New line.
+     * - Busy: Enter ▸ Nudge, Ctrl+Enter ▸ Stop && send, Ctrl+Shift+Enter ▸ Queue,
+     *         Shift+Enter ▸ New line — all four are relevant during a turn.
+     * - When a nudge or queued message is pending, an extra `↑ ▸ Edit last`
+     *   hint is appended so the user knows they can recall it.
+     */
+    private fun refreshShortcutHints() {
+        if (!::shortcutHintPanel.isInitialized) return
+        if (!shortcutHintPanel.isVisible) return
+        val list = mutableListOf<Pair<KeyStroke, String>>()
+        if (isSending) {
+            list += PromptShortcutAction.resolveKeystroke(
+                PromptShortcutAction.SEND_ID,
+                KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_ENTER, 0)
+            ) to "Nudge"
+            list += PromptShortcutAction.resolveKeystroke(
+                PromptShortcutAction.STOP_AND_SEND_ID,
+                KeyStroke.getKeyStroke(
+                    java.awt.event.KeyEvent.VK_ENTER,
+                    java.awt.event.InputEvent.CTRL_DOWN_MASK
+                )
+            ) to "Stop && send"
+            list += PromptShortcutAction.resolveKeystroke(
+                PromptShortcutAction.QUEUE_ID,
+                KeyStroke.getKeyStroke(
+                    java.awt.event.KeyEvent.VK_ENTER,
+                    java.awt.event.InputEvent.CTRL_DOWN_MASK or java.awt.event.InputEvent.SHIFT_DOWN_MASK
+                )
+            ) to "Queue"
+        } else {
+            list += PromptShortcutAction.resolveKeystroke(
+                PromptShortcutAction.SEND_ID,
+                KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_ENTER, 0)
+            ) to "Send"
+        }
+        list += PromptShortcutAction.resolveKeystroke(
+            PromptShortcutAction.NEW_LINE_ID,
+            KeyStroke.getKeyStroke(
+                java.awt.event.KeyEvent.VK_ENTER,
+                java.awt.event.InputEvent.SHIFT_DOWN_MASK
+            )
+        ) to "New line"
+        if (pendingNudgeId != null || queuedTexts.isNotEmpty()) {
+            list += KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_UP, 0) to "Edit last"
+        }
+        shortcutHintPanel.setShortcuts(list)
     }
 
     private fun setSendingState(sending: Boolean) {
@@ -1190,6 +1192,7 @@ class ChatToolWindowContent(
             updatePromptPlaceholder()
             controlsToolbar.updateActionsAsync()
             innerInputToolbar.updateActionsAsync()
+            refreshShortcutHints()
             if (::processingTimerPanel.isInitialized) {
                 if (sending) processingTimerPanel.start() else processingTimerPanel.stop()
             }
@@ -1274,6 +1277,12 @@ class ChatToolWindowContent(
             "/icons/send.svg", SendAction::class.java
         )
 
+        // Captured at createCustomComponent time so actionPerformed has a stable popup anchor.
+        // We can't rely on AnActionEvent.inputEvent (null when synthesized by the JButton listener)
+        // or presentation.getClientProperty(COMPONENT_KEY) (null because actionPerformed receives
+        // a freshly built Presentation, not the toolbar's annotated one).
+        private var sendButton: JButton? = null
+
         override fun getActionUpdateThread() = ActionUpdateThread.EDT
 
         override fun createCustomComponent(presentation: Presentation, place: String): JComponent {
@@ -1293,6 +1302,7 @@ class ChatToolWindowContent(
                 )
                 actionPerformed(event)
             }
+            sendButton = button
             return button
         }
 
@@ -1326,10 +1336,7 @@ class ChatToolWindowContent(
                 return
             }
             // Agent is running: show nudge/queue/stop-and-send dropdown.
-            val inputEvent = e.inputEvent
-            val component = (inputEvent?.source as? Component)
-                ?: (e.presentation.getClientProperty(com.intellij.openapi.actionSystem.ex.CustomComponentAction.COMPONENT_KEY) as? Component)
-                ?: return
+            val component: Component = sendButton ?: return
             val hasText = promptTextArea.text.trim().isNotEmpty()
 
             val group = DefaultActionGroup()
@@ -1765,7 +1772,13 @@ class ChatToolWindowContent(
         chatConsolePanel.onCancelQueuedMessage = { id, text ->
             val psiBridge = com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(project)
             psiBridge.removeQueuedMessage(text)
-            ApplicationManager.getApplication().invokeLater { consolePanel.removeQueuedMessage(id) }
+            // Drop the most-recent matching entry so Up-arrow recall reflects what's still queued.
+            val lastIdx = queuedTexts.indexOfLast { it == text }
+            if (lastIdx >= 0) queuedTexts.removeAt(lastIdx)
+            ApplicationManager.getApplication().invokeLater {
+                consolePanel.removeQueuedMessage(id)
+                refreshShortcutHints()
+            }
         }
         chatConsolePanel.onAutoScrollDisabled = {
             autoScrollEnabled = false
@@ -1842,6 +1855,7 @@ class ChatToolWindowContent(
         registerCtrlEnterNudge(contentComponent)
         registerCtrlShiftEnterQueue(contentComponent)
         registerShowShortcutsPopup(contentComponent)
+        registerUpArrowRecall(contentComponent)
         registerPasteIntercept(editor, contentComponent)
         registerTriggerCharDetection(editor)
     }
@@ -1931,6 +1945,54 @@ class ChatToolWindowContent(
         )
     }
 
+    /**
+     * Up-arrow recall: when the prompt is empty and a nudge or queued message
+     * is pending, pop the most recent one back into the input box for editing.
+     * Pending nudge takes priority over queued messages (it's the more recent
+     * pending action). The Up-arrow is only consumed when the input is empty
+     * so multi-line caret navigation still works once the user starts typing.
+     */
+    private fun registerUpArrowRecall(contentComponent: JComponent) {
+        object : AnAction() {
+            override fun getActionUpdateThread(): com.intellij.openapi.actionSystem.ActionUpdateThread =
+                com.intellij.openapi.actionSystem.ActionUpdateThread.EDT
+
+            override fun update(e: AnActionEvent) {
+                // Only consume Up when the prompt is empty AND something is pending to recall.
+                // When disabled, the keystroke falls through to the editor's default
+                // caret-up behavior so multi-line navigation isn't blocked.
+                val empty = promptTextArea.text.isEmpty()
+                val hasPending = pendingNudgeId != null || queuedTexts.isNotEmpty()
+                e.presentation.isEnabledAndVisible = empty && hasPending
+            }
+
+            override fun actionPerformed(e: AnActionEvent) {
+                if (promptTextArea.text.isNotEmpty()) return
+                val nudgeId = pendingNudgeId
+                val nudgeText = pendingNudgeText
+                if (nudgeId != null && nudgeText != null) {
+                    promptTextArea.text = nudgeText
+                    clearAndRemoveNudge(nudgeId)
+                    refreshShortcutHints()
+                    return
+                }
+                val lastQueued = queuedTexts.removeLastOrNull() ?: return
+                promptTextArea.text = lastQueued
+                val psiBridge = com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(project)
+                psiBridge.removeQueuedMessage(lastQueued)
+                ApplicationManager.getApplication().invokeLater {
+                    consolePanel.removeQueuedMessageByText(lastQueued)
+                    refreshShortcutHints()
+                }
+            }
+        }.registerCustomShortcutSet(
+            com.intellij.openapi.actionSystem.CustomShortcutSet(
+                KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_UP, 0)
+            ),
+            contentComponent
+        )
+    }
+
     private fun onQueueMessageClicked() {
         val rawText = promptTextArea.text.trim()
         if (rawText.isEmpty()) return
@@ -1940,6 +2002,8 @@ class ChatToolWindowContent(
         consolePanel.showQueuedMessage(id, rawText)
         com.github.catatafishen.agentbridge.psi.PsiBridgeService.getInstance(project)
             .enqueueMessage(rawText)
+        queuedTexts.addLast(rawText)
+        refreshShortcutHints()
     }
 
     private fun onForceStopAndSend() {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -744,6 +744,12 @@ class ChatToolWindowContent(
 
         val inputRow = createInputRow()
 
+        val sideButtonsPanel = createSideButtonsPanel()
+
+        // Single rounded white frame that contains BOTH the side-button rail and the editor row —
+        // visually unifies the input area so there is no grey gutter around the side buttons.
+        // A 1px vertical divider is painted between the rail and the editor column.
+        val sideRailWidth = { sideButtonsPanel.preferredSize.width }
         val inputSection = object : JBPanel<JBPanel<*>>(BorderLayout()) {
             override fun paintComponent(g: Graphics) {
                 // Non-opaque components must call super so Swing can satisfy dirty-region
@@ -755,6 +761,14 @@ class ChatToolWindowContent(
                     val arc = JBUI.scale(8)
                     g2.color = com.intellij.util.ui.UIUtil.getTextFieldBackground()
                     g2.fillRoundRect(0, 0, width, height, arc, arc)
+                    // Subtle vertical divider between the side-button rail and the editor column.
+                    // Uses the tool-window separator color so it reads as a seam, not a hard border.
+                    val insets = insets
+                    val dividerX = insets.left + sideRailWidth()
+                    if (dividerX > insets.left && dividerX < width - insets.right) {
+                        g2.color = JBUI.CurrentTheme.ToolWindow.borderColor()
+                        g2.drawLine(dividerX, insets.top + JBUI.scale(2), dividerX, height - insets.bottom - JBUI.scale(2))
+                    }
                     // Use the component border color (typically ~#ADADAD light / #5A5D63 dark),
                     // which is more visible than the tool-window separator color.
                     g2.color = UIManager.getColor("Component.borderColor")
@@ -767,24 +781,18 @@ class ChatToolWindowContent(
         }
         inputSection.isOpaque = false
         // 8px top inset doubles as the resize drag zone (see resizeHandler below)
-        inputSection.border = JBUI.Borders.empty(8, 4, 4, 4)
+        inputSection.border = JBUI.Borders.empty(8, 0, 4, 4)
+        inputSection.add(sideButtonsPanel, BorderLayout.WEST)
         inputSection.add(inputRow, BorderLayout.CENTER)
 
-        val sideButtonsPanel = createSideButtonsPanel()
         controlsToolbar.targetComponent = inputSection
         innerInputToolbar.targetComponent = inputSection
 
-        val inputWithSidebar = JBPanel<JBPanel<*>>(BorderLayout(JBUI.scale(4), 0))
-        inputWithSidebar.isOpaque = false
-        inputWithSidebar.add(sideButtonsPanel, BorderLayout.WEST)
-        inputWithSidebar.add(inputSection, BorderLayout.CENTER)
-
         val bottomSection = JBPanel<JBPanel<*>>(BorderLayout())
         bottomSection.isOpaque = false
-        // Left/right padding mirrors responsePanelContainer's compound(empty(4),...) so columns align.
-        // Right gets extra padding to match the chat bubble right margin; left gets 5px more.
-        bottomSection.border = JBUI.Borders.empty(0, 9, 8, 17)
-        bottomSection.add(inputWithSidebar, BorderLayout.CENTER)
+        // Symmetric 4px side padding mirrors the chat panel above so columns align.
+        bottomSection.border = JBUI.Borders.empty(0, 4, 4, 4)
+        bottomSection.add(inputSection, BorderLayout.CENTER)
 
         // Drag-to-resize: the user drags the top border of inputSection to adjust the split.
         // We replace OnePixelSplitter (which draws a visible 1px divider) with a plain BorderLayout

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -954,34 +954,46 @@ class ChatToolWindowContent(
         innerInputToolbar.isReservePlaceAutoPopupIcon = false
         innerInputToolbar.component.isOpaque = false
 
-        // Layout strategy: a single horizontal BoxLayout row where every child has
-        // alignmentY = CENTER_ALIGNMENT. This is what produces a true visual midline
-        // alignment across heterogeneous components. Earlier attempts using
-        // BorderLayout.CENTER + FlowLayout failed because BorderLayout.CENTER stretches
-        // its cell to the full container height, but FlowLayout still positions its
-        // single row at the *top* of that stretched cell — so the shortcut hints
-        // ended up visually anchored to the top while the Send / Model toolbars
-        // (added via BorderLayout.EAST, which respects preferred size and vertically
-        // centers) sat in the middle. BoxLayout X_AXIS with alignmentY=0.5 on every
-        // child centers each one independently on the row's midline regardless of
-        // its preferred height or internal padding.
+        // Right-side group: model selector + Send button, packed tightly with FlowLayout
+        // so the right edge anchors to the EAST cell. FlowLayout vertically centers its
+        // row within the panel, but since the panel's preferred height matches the row
+        // exactly, that centering only matters once GridBagLayout (below) gives the cell
+        // its row height — which it does via anchor=EAST (vertical-center anchor).
+        val rightGroup = JPanel(FlowLayout(FlowLayout.RIGHT, JBUI.scale(2), 0)).apply {
+            isOpaque = false
+        }
+        rightGroup.add(modelToolbar.component)
+        rightGroup.add(innerInputToolbar.component)
+
+        // Layout strategy: GridBagLayout with two cells.
+        //   cell 0: shortcutHintPanel    weightx=1.0  anchor=CENTER  fill=NONE
+        //   cell 1: rightGroup           weightx=0.0  anchor=EAST    fill=NONE
+        //
+        // GridBagLayout sizes the row to the tallest child's preferred height, then
+        // positions every cell's component using its anchor *within that row height*.
+        // Both CENTER and EAST anchors are vertically centered, so all three groups
+        // (hints, model toolbar, send button) land on the same horizontal midline
+        // regardless of their individual heights — solving the alignment problem that
+        // BorderLayout+FlowLayout and BoxLayout+alignmentY both failed to solve.
+        // weightx=1.0 on cell 0 absorbs all extra horizontal space, pushing the
+        // rightGroup hard against the right edge.
         val innerBar = JBPanel<JBPanel<*>>().apply {
-            layout = BoxLayout(this, BoxLayout.X_AXIS)
+            layout = GridBagLayout()
             isOpaque = false
             border = JBUI.Borders.empty(0, 2, 0, 2)
         }
-        shortcutHintPanel.alignmentY = Component.CENTER_ALIGNMENT
-        modelToolbar.component.alignmentY = Component.CENTER_ALIGNMENT
-        innerInputToolbar.component.alignmentY = Component.CENTER_ALIGNMENT
-        // Glue on both sides of the hints centers them in the horizontal gap
-        // between the left side-buttons (+, power, attachments) and the right-side
-        // model + Send group.
-        innerBar.add(Box.createHorizontalGlue())
-        innerBar.add(shortcutHintPanel)
-        innerBar.add(Box.createHorizontalGlue())
-        innerBar.add(modelToolbar.component)
-        innerBar.add(Box.createHorizontalStrut(JBUI.scale(2)))
-        innerBar.add(innerInputToolbar.component)
+        innerBar.add(shortcutHintPanel, GridBagConstraints().apply {
+            gridx = 0; gridy = 0
+            weightx = 1.0; weighty = 0.0
+            fill = GridBagConstraints.NONE
+            anchor = GridBagConstraints.CENTER
+        })
+        innerBar.add(rightGroup, GridBagConstraints().apply {
+            gridx = 1; gridy = 0
+            weightx = 0.0; weighty = 0.0
+            fill = GridBagConstraints.NONE
+            anchor = GridBagConstraints.EAST
+        })
         row.add(innerBar, BorderLayout.SOUTH)
 
         refreshShortcutHints()

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -1276,12 +1276,39 @@ class ChatToolWindowContent(
      * Enter key handling is separate (keyboard shortcuts route to the same underlying functions)
      * and is unchanged by this class.
      */
-    private inner class SendAction : AnAction() {
+    private inner class SendAction : AnAction(), com.intellij.openapi.actionSystem.ex.CustomComponentAction {
         private val sendIcon = com.intellij.openapi.util.IconLoader.getIcon(
             "/icons/send.svg", SendAction::class.java
         )
 
         override fun getActionUpdateThread() = ActionUpdateThread.EDT
+
+        override fun createCustomComponent(presentation: Presentation, place: String): JComponent {
+            // Primary-styled button so the "Send" action reads as the dominant CTA in the
+            // input toolbar, matching JetBrains primary buttons (blue fill).
+            // The ActionToolbar's ActionButton renders as a flat icon which doesn't
+            // communicate "this is the main action" — the primary style fixes that.
+            val button = JButton(sendIcon)
+            button.putClientProperty("JButton.buttonType", "primary")
+            button.isFocusable = false
+            button.margin = JBUI.insets(2, 6)
+            button.toolTipText = presentation.description
+            button.addActionListener {
+                val event = AnActionEvent.createFromAnAction(
+                    this, null, place,
+                    com.intellij.openapi.actionSystem.impl.SimpleDataContext.getProjectContext(project)
+                )
+                actionPerformed(event)
+            }
+            return button
+        }
+
+        override fun updateCustomComponent(component: JComponent, presentation: Presentation) {
+            (component as? JButton)?.let { btn ->
+                btn.isEnabled = presentation.isEnabled
+                btn.toolTipText = presentation.description
+            }
+        }
 
         override fun update(e: AnActionEvent) {
             val isLoggedIn = authService.pendingAuthError == null
@@ -1306,8 +1333,10 @@ class ChatToolWindowContent(
                 return
             }
             // Agent is running: show nudge/queue/stop-and-send dropdown.
-            val inputEvent = e.inputEvent ?: return
-            val component = inputEvent.source as? Component ?: return
+            val inputEvent = e.inputEvent
+            val component = (inputEvent?.source as? Component)
+                ?: (e.presentation.getClientProperty(com.intellij.openapi.actionSystem.ex.CustomComponentAction.COMPONENT_KEY) as? Component)
+                ?: return
             val hasText = promptTextArea.text.trim().isNotEmpty()
 
             val group = DefaultActionGroup()

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -906,7 +906,14 @@ class ChatToolWindowContent(
                 restorePromptText = ::restorePromptText,
                 onTurnMineEntries = ::mineEntriesAfterTurn,
                 onQueuedMessageConsumed = { text ->
-                    queuedTexts.remove(text)
+                    // Mirror the cancel path: remove the LAST matching entry so that when
+                    // the same text was queued multiple times, "recall most recent queued
+                    // message" ordering remains intact (Up-arrow restores the oldest copies
+                    // first, newest copies last).
+                    val lastMatchingIndex = queuedTexts.lastIndexOf(text)
+                    if (lastMatchingIndex >= 0) {
+                        queuedTexts.removeAt(lastMatchingIndex)
+                    }
                     ApplicationManager.getApplication().invokeLater { refreshShortcutHints() }
                 },
             )
@@ -936,6 +943,12 @@ class ChatToolWindowContent(
                 ApplicationManager.getApplication().invokeLater {
                     promptTextArea.revalidate()
                     checkSlashCommandAutocomplete()
+                    // Refresh Send button enabled-state immediately on every keystroke.
+                    // ActionToolbar's default polling cycle (~500ms) makes the button feel
+                    // sluggish to enable/disable when text appears/disappears.
+                    if (::innerInputToolbar.isInitialized) {
+                        innerInputToolbar.updateActionsAsync()
+                    }
                 }
             }
         })
@@ -1294,8 +1307,9 @@ class ChatToolWindowContent(
 
         override fun createCustomComponent(presentation: Presentation, place: String): JComponent {
             // Primary-styled labeled button so the Send action reads as the dominant CTA.
-            // Icon on the left, "Send" text on the right — text is updated dynamically via
-            // updateCustomComponent when the agent is running ("More" with dropdown).
+            // Icon on the left, "Send" text on the right. The label stays "Send" in all
+            // states; the button's behavior (direct send vs. nudge/queue/stop dropdown)
+            // depends on isSending and is handled in the action listener below.
             val button = JButton(presentation.text ?: "Send", sendIcon)
             button.putClientProperty("JButton.buttonType", "primary")
             button.isFocusable = false
@@ -1326,7 +1340,7 @@ class ChatToolWindowContent(
             val hasText = promptTextArea.text.trim().isNotEmpty()
             if (isSending && !consolePanel.hasPendingAskUserRequest()) {
                 e.presentation.icon = sendIcon
-                e.presentation.text = "More"
+                e.presentation.text = "Send"
                 e.presentation.description = "Nudge, queue, or stop and send"
                 e.presentation.isEnabled = hasText
             } else {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -897,6 +897,9 @@ class ChatToolWindowContent(
                 onTimerRecordUsage = { i, o, c ->
                     if (::processingTimerPanel.isInitialized) processingTimerPanel.recordUsage(i, o, c)
                 },
+                onTimerSetLastTurnMultiplier = { mult ->
+                    if (::processingTimerPanel.isInitialized) processingTimerPanel.setLastTurnMultiplier(mult)
+                },
                 onTimerSetCodeChangeStats = { a, r ->
                     if (::processingTimerPanel.isInitialized) processingTimerPanel.setCodeChangeStats(a, r)
                 },
@@ -2184,7 +2187,15 @@ class ChatToolWindowContent(
                     if (deferred > 0) chatConsolePanel.showLoadMore(deferred)
                     val lastStats = entries.filterIsInstance<EntryData.TurnStats>().lastOrNull()
                     if (lastStats != null && ::processingTimerPanel.isInitialized) {
-                        val turnCount = entries.count { it is EntryData.TurnStats }
+                        val turnStatsList = entries.filterIsInstance<EntryData.TurnStats>()
+                        val turnCount = turnStatsList.size
+                        // Sum each turn's premium-request weight so the side panel's "Premium req"
+                        // total reflects the entire restored session — not just turns since IDE start.
+                        // Aligns with the restored "Turns" count above (both span the whole session).
+                        val totalPremium = turnStatsList.sumOf {
+                            BillingCalculator.parseMultiplier(it.multiplier.ifEmpty { "1x" })
+                        }
+                        billing.restoreSessionCounters(turnCount, totalPremium)
                         processingTimerPanel.restoreSessionStats(
                             lastStats.totalDurationMs, lastStats.totalInputTokens,
                             lastStats.totalOutputTokens, lastStats.totalCostUsd,
@@ -2198,7 +2209,8 @@ class ChatToolWindowContent(
                             if (lastStats.costUsd > 0.0) lastStats.costUsd else null,
                             lastStats.toolCallCount,
                             lastStats.linesAdded,
-                            lastStats.linesRemoved
+                            lastStats.linesRemoved,
+                            lastStats.multiplier
                         )
                     }
                     persistedEntryCount = conversationReplayer.totalLoadedCount()

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -780,8 +780,10 @@ class ChatToolWindowContent(
             }
         }
         inputSection.isOpaque = false
-        // 8px top inset doubles as the resize drag zone (see resizeHandler below)
-        inputSection.border = JBUI.Borders.empty(8, 0, 4, 4)
+        // 8px top inset doubles as the resize drag zone (see resizeHandler below).
+        // Bottom inset is 2 (not 4) so the model selector / send button sit close
+        // to the rounded bottom border instead of leaving a wide empty band.
+        inputSection.border = JBUI.Borders.empty(8, 0, 2, 4)
         inputSection.add(sideButtonsPanel, BorderLayout.WEST)
         inputSection.add(inputRow, BorderLayout.CENTER)
 
@@ -790,8 +792,11 @@ class ChatToolWindowContent(
 
         val bottomSection = JBPanel<JBPanel<*>>(BorderLayout())
         bottomSection.isOpaque = false
-        // Symmetric 4px side padding mirrors the chat panel above so columns align.
-        bottomSection.border = JBUI.Borders.empty(0, 4, 4, 4)
+        // 12px side padding aligns the input-frame edges with the chat-message
+        // bubbles above (responsePanelContainer's 4px outer margin + chat-container's
+        // 8px CSS padding = 12px from the tool-window edge). 2px bottom keeps the
+        // frame close to the tool-window bottom without touching the IDE status bar.
+        bottomSection.border = JBUI.Borders.empty(0, 12, 2, 12)
         bottomSection.add(inputSection, BorderLayout.CENTER)
 
         // Drag-to-resize: the user drags the top border of inputSection to adjust the split.
@@ -1022,7 +1027,7 @@ class ChatToolWindowContent(
 
         val innerBar = JBPanel<JBPanel<*>>(BorderLayout())
         innerBar.isOpaque = false
-        innerBar.border = JBUI.Borders.empty(0, 2, 1, 2)
+        innerBar.border = JBUI.Borders.empty(0, 2, 0, 2)
         // Model selector and Send button grouped together on the right
         val rightSide = JBPanel<JBPanel<*>>(BorderLayout(JBUI.scale(2), 0))
         rightSide.isOpaque = false

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -703,34 +703,11 @@ class ChatToolWindowContent(
         statusBanner = sb
         northStack.add(sb)
 
-        // Rounded border makes the chat area a distinct panel matching the side panel and input row,
-        // styled like the IDE's own tool-window frames.
-        // Custom border with 0 bottom inset: the rounded rect is drawn taller than the component so
-        // the bottom arc is clipped away, leaving only top, left, and right sides visible. This
-        // eliminates the 1px gap that RoundedLineBorder's bottom inset would otherwise create between
-        // the chat output and the input box.
-        responsePanelContainer.border = JBUI.Borders.compound(
-            JBUI.Borders.empty(4, 4, 0, 4),
-            object : javax.swing.border.AbstractBorder() {
-                override fun getBorderInsets(c: Component, insets: Insets): Insets {
-                    insets.set(1, 1, 0, 1)
-                    return insets
-                }
-
-                override fun paintBorder(c: Component, g: Graphics, x: Int, y: Int, width: Int, height: Int) {
-                    val g2 = g.create() as Graphics2D
-                    try {
-                        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
-                        g2.color = JBUI.CurrentTheme.ToolWindow.borderColor()
-                        val arc = JBUI.scale(8)
-                        // Extend height by arc so the bottom arc falls outside the clip and is not painted.
-                        g2.drawRoundRect(x, y, width - 1, height - 1 + arc, arc, arc)
-                    } finally {
-                        g2.dispose()
-                    }
-                }
-            }
-        )
+        // Edge-to-edge chat panel: no outer margin and no rounded frame so the JCEF
+        // browser fills the entire tool-window width and its scrollbar can sit flush
+        // against the right edge (chat-container's CSS drops right padding to match).
+        // The input frame below provides its own rounded styling for visual grouping.
+        responsePanelContainer.border = JBUI.Borders.empty()
 
         consolePanel.onStatusMessage = { type, message ->
             when (type) {
@@ -767,7 +744,12 @@ class ChatToolWindowContent(
                     val dividerX = insets.left + sideRailWidth()
                     if (dividerX > insets.left && dividerX < width - insets.right) {
                         g2.color = JBUI.CurrentTheme.ToolWindow.borderColor()
-                        g2.drawLine(dividerX, insets.top + JBUI.scale(2), dividerX, height - insets.bottom - JBUI.scale(2))
+                        g2.drawLine(
+                            dividerX,
+                            insets.top + JBUI.scale(2),
+                            dividerX,
+                            height - insets.bottom - JBUI.scale(2)
+                        )
                     }
                     // Use the component border color (typically ~#ADADAD light / #5A5D63 dark),
                     // which is more visible than the tool-window separator color.
@@ -792,11 +774,14 @@ class ChatToolWindowContent(
 
         val bottomSection = JBPanel<JBPanel<*>>(BorderLayout())
         bottomSection.isOpaque = false
-        // 12px side padding aligns the input-frame edges with the chat-message
-        // bubbles above (responsePanelContainer's 4px outer margin + chat-container's
-        // 8px CSS padding = 12px from the tool-window edge). 2px bottom keeps the
-        // frame close to the tool-window bottom without touching the IDE status bar.
-        bottomSection.border = JBUI.Borders.empty(0, 12, 2, 12)
+        // 8px left padding aligns the input-frame edge with the chat-message bubbles
+        // above (chat-container's 8px CSS left padding = 8px from the tool-window edge).
+        // The right side keeps an 8px gap too — the chat scrollbar sits flush against
+        // the tool-window right edge, but symmetric padding here prevents the input
+        // frame from overlapping that vertical scrollbar lane visually.
+        // 2px bottom keeps the frame close to the tool-window bottom without touching
+        // the IDE status bar.
+        bottomSection.border = JBUI.Borders.empty(0, 8, 2, 8)
         bottomSection.add(inputSection, BorderLayout.CENTER)
 
         // Drag-to-resize: the user drags the top border of inputSection to adjust the split.

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -1270,45 +1270,32 @@ class ChatToolWindowContent(
         }
     }
 
-    /**
-     * Send button inside the input box.
-     *
-     * - Idle: sends the prompt (enabled only when logged in).
-     * - Pending ask-user: submits the user's answer (same as idle path).
-     * - Agent running: opens a popup with Nudge / Queue / Stop and Send.
-     *
-     * Enter key handling is separate (keyboard shortcuts route to the same underlying functions)
-     * and is unchanged by this class.
-     */
     private inner class SendAction : AnAction(), com.intellij.openapi.actionSystem.ex.CustomComponentAction {
         private val sendIcon = com.intellij.openapi.util.IconLoader.getIcon(
             "/icons/send.svg", SendAction::class.java
         )
 
-        // Captured at createCustomComponent time so actionPerformed has a stable popup anchor.
-        // We can't rely on AnActionEvent.inputEvent (null when synthesized by the JButton listener)
-        // or presentation.getClientProperty(COMPONENT_KEY) (null because actionPerformed receives
-        // a freshly built Presentation, not the toolbar's annotated one).
+        // Captured at createCustomComponent time so showSendDropdown has a stable popup anchor.
         private var sendButton: JButton? = null
 
         override fun getActionUpdateThread() = ActionUpdateThread.EDT
 
         override fun createCustomComponent(presentation: Presentation, place: String): JComponent {
-            // Primary-styled button so the "Send" action reads as the dominant CTA in the
-            // input toolbar, matching JetBrains primary buttons (blue fill).
-            // The ActionToolbar's ActionButton renders as a flat icon which doesn't
-            // communicate "this is the main action" — the primary style fixes that.
-            val button = JButton(sendIcon)
+            // Primary-styled labeled button so the Send action reads as the dominant CTA.
+            // Icon on the left, "Send" text on the right — text is updated dynamically via
+            // updateCustomComponent when the agent is running ("More" with dropdown).
+            val button = JButton(presentation.text ?: "Send", sendIcon)
             button.putClientProperty("JButton.buttonType", "primary")
             button.isFocusable = false
-            button.margin = JBUI.insets(2, 6)
+            button.margin = JBUI.insets(2, 8)
             button.toolTipText = presentation.description
+            // Direct routing avoids the deprecated AnActionEvent.createFromAnAction.
             button.addActionListener {
-                val event = AnActionEvent.createFromAnAction(
-                    this, null, place,
-                    com.intellij.openapi.actionSystem.impl.SimpleDataContext.getProjectContext(project)
-                )
-                actionPerformed(event)
+                if (!isSending || consolePanel.hasPendingAskUserRequest()) {
+                    onSendStopClicked()
+                } else {
+                    showSendDropdown(button)
+                }
             }
             sendButton = button
             return button
@@ -1317,6 +1304,7 @@ class ChatToolWindowContent(
         override fun updateCustomComponent(component: JComponent, presentation: Presentation) {
             (component as? JButton)?.let { btn ->
                 btn.isEnabled = presentation.isEnabled
+                btn.text = presentation.text
                 btn.toolTipText = presentation.description
             }
         }
@@ -1338,15 +1326,15 @@ class ChatToolWindowContent(
         }
 
         override fun actionPerformed(e: AnActionEvent) {
-            // Pending ask-user or idle: normal send/answer flow.
             if (!isSending || consolePanel.hasPendingAskUserRequest()) {
                 onSendStopClicked()
                 return
             }
-            // Agent is running: show nudge/queue/stop-and-send dropdown.
-            val component: Component = sendButton ?: return
-            val hasText = promptTextArea.text.trim().isNotEmpty()
+            showSendDropdown(sendButton ?: return)
+        }
 
+        private fun showSendDropdown(anchor: Component) {
+            val hasText = promptTextArea.text.trim().isNotEmpty()
             val group = DefaultActionGroup()
             group.add(object : AnAction("Nudge", "Send a nudge to the running agent", AllIcons.Actions.Forward) {
                 override fun getActionUpdateThread() = ActionUpdateThread.EDT
@@ -1377,10 +1365,11 @@ class ChatToolWindowContent(
 
             val popup = com.intellij.openapi.ui.popup.JBPopupFactory.getInstance()
                 .createActionGroupPopup(
-                    null, group, e.dataContext,
+                    null, group,
+                    com.intellij.openapi.actionSystem.impl.SimpleDataContext.getProjectContext(project),
                     com.intellij.openapi.ui.popup.JBPopupFactory.ActionSelectionAid.SPEEDSEARCH, false
                 )
-            popup.showUnderneathOf(component)
+            popup.showUnderneathOf(anchor)
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ProcessingTimerPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ProcessingTimerPanel.kt
@@ -53,6 +53,12 @@ internal class ProcessingTimerPanel(
     // can stay populated between turns. The per-turn mutable fields above are reset on the next
     // start(); this field captures the final elapsed time at stop() so the display doesn't lose it.
     private var lastTurnElapsedSec = 0L
+    /**
+     * Premium-request weight of the most recently completed turn. Sourced from the model's
+     * cost multiplier (e.g. "3x" → 3.0). 1.0 is the safe default; resets on each new turn.
+     * Distinct from session-wide premium counts which live on [BillingManager].
+     */
+    private var lastTurnPremium = 1.0
     private var sessionTotalInputTokens = 0L
     private var sessionTotalOutputTokens = 0L
     private var sessionTotalCostUsd = 0.0
@@ -119,6 +125,7 @@ internal class ProcessingTimerPanel(
         turnInputTokens = 0
         turnOutputTokens = 0
         turnCostUsd = null
+        lastTurnPremium = 1.0
         isRunning = true
         displayMode = modeTurn
         timerLabel.text = "0s"
@@ -182,6 +189,7 @@ internal class ProcessingTimerPanel(
         turnOutputTokens = 0
         turnCostUsd = null
         lastTurnElapsedSec = 0L
+        lastTurnPremium = 1.0
         displayMode = modeTurn
         refreshDisplay()
     }
@@ -209,7 +217,7 @@ internal class ProcessingTimerPanel(
      */
     fun restoreLastTurnStats(
         elapsedSec: Long, inputTokens: Int, outputTokens: Int, costUsd: Double?,
-        toolCalls: Int, linesAdded: Int, linesRemoved: Int
+        toolCalls: Int, linesAdded: Int, linesRemoved: Int, multiplier: String = ""
     ) {
         lastTurnElapsedSec = elapsedSec
         turnInputTokens = inputTokens
@@ -218,6 +226,18 @@ internal class ProcessingTimerPanel(
         toolCallCount = toolCalls
         addedLineCount = linesAdded
         removedLineCount = linesRemoved
+        lastTurnPremium = BillingCalculator.parseMultiplier(multiplier.ifEmpty { "1x" })
+        refreshDisplay()
+    }
+
+    /**
+     * Records the premium-request multiplier of the just-completed turn so the side panel's
+     * "Last turn — Premium req" row can display the actual weight (e.g. "3" for Opus) instead
+     * of the previous hardcoded "1". Called from [PromptOrchestrator] right after the model
+     * finishes responding, regardless of whether the agent supports multipliers (defaults to 1.0).
+     */
+    fun setLastTurnMultiplier(multiplier: String?) {
+        lastTurnPremium = BillingCalculator.parseMultiplier(multiplier?.ifEmpty { "1x" } ?: "1x")
         refreshDisplay()
     }
 
@@ -331,6 +351,7 @@ internal class ProcessingTimerPanel(
             turnInputTokens = turnInputTokens,
             turnOutputTokens = turnOutputTokens,
             turnCostUsd = turnCostUsd,
+            turnPremiumRequests = lastTurnPremium,
             sessionTotalTimeSec = totalMs / 1000,
             sessionTurnCount = totalTurns,
             sessionToolCalls = totalTools,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
@@ -45,6 +45,11 @@ data class PromptOrchestratorCallbacks(
     val restorePromptText: (rawText: String) -> Unit,
     /** Called after turn completion to mine entries into semantic memory (async, non-blocking). */
     val onTurnMineEntries: (sessionId: String, agentName: String) -> Unit,
+    /**
+     * Called when a queued message is auto-dequeued by the orchestrator at the end
+     * of a turn so the UI layer can drop it from its recall stack.
+     */
+    val onQueuedMessageConsumed: (text: String) -> Unit,
 )
 
 /** Stored banner message to re-display at the start of the next prompt turn. */
@@ -464,6 +469,7 @@ class PromptOrchestrator(
 
         val nextMsg = PsiBridgeService.getInstance(project).nextQueuedMessage
         if (nextMsg != null) {
+            callbacks.onQueuedMessageConsumed(nextMsg)
             ApplicationManager.getApplication().invokeLater {
                 consolePanel().removeQueuedMessageByText(nextMsg)
                 callbacks.sendPromptDirectly(nextMsg)

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
@@ -30,6 +30,12 @@ data class PromptOrchestratorCallbacks(
     val requestFocusAfterTurn: () -> Unit,
     val onTimerIncrementToolCalls: () -> Unit,
     val onTimerRecordUsage: (inputTokens: Int, outputTokens: Int, costUsd: Double?) -> Unit,
+    /**
+     * Reports the multiplier of the just-completed turn so the side panel's "Last turn"
+     * section can display the correct premium-request weight. Always called once at turn
+     * completion; the multiplier may be null/empty when unknown (handled as 1.0 downstream).
+     */
+    val onTimerSetLastTurnMultiplier: (multiplier: String?) -> Unit,
     val onTimerSetCodeChangeStats: (added: Int, removed: Int) -> Unit,
     /** Called for plan-tree and file-tracking side-effects (remains in ChatToolWindowContent). */
     val onClientUpdate: (SessionUpdate) -> Unit,
@@ -413,9 +419,11 @@ class PromptOrchestrator(
             val multiplier = getModelMultiplier(turnModelId)
             consolePanel().finishResponse(turnToolCallCount, turnModelId, multiplier ?: "")
             billing.recordTurnCompleted(multiplier)
+            callbacks.onTimerSetLastTurnMultiplier(multiplier)
             callbacks.onTimerRecordUsage(0, 0, 0.0)
         } else {
             consolePanel().finishResponse(turnToolCallCount, turnModelId, "")
+            callbacks.onTimerSetLastTurnMultiplier(null)
             callbacks.onTimerRecordUsage(turnInputTokens, turnOutputTokens, turnCostUsd)
         }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutHintPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutHintPanel.kt
@@ -4,79 +4,60 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBPanel
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
-import java.awt.BorderLayout
 import java.awt.FlowLayout
-import java.awt.event.InputEvent
-import java.awt.event.KeyEvent
+import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.KeyStroke
 
 /**
- * Footer panel showing a single, context-appropriate keyboard shortcut hint
- * below the chat prompt:
- *  - Idle  → `Enter` Send
- *  - Busy  → `Ctrl+Enter` Stop && Send
+ * Bottom-toolbar panel that lists the keyboard shortcuts relevant to the
+ * current chat-input state, left-aligned alongside the model selector and
+ * Send button.
  *
- * The previous 2×2 hint grid listed four shortcuts at once, which added
- * visual weight without providing information the user needed right now.
- * Users can still see the full list in Settings → AgentBridge → Chat Input
- * documentation, and all shortcuts continue to work regardless of what is
- * displayed here.
+ *  - Idle  → Enter ▸ Send,  Shift+Enter ▸ New line
+ *  - Busy  → Enter ▸ Nudge,  Ctrl+Enter ▸ Stop && send,  Ctrl+Shift+Enter ▸ Queue,  Shift+Enter ▸ New line
+ *  - When a nudge or queued message is pending, an extra `↑ ▸ Edit last` hint
+ *    is appended.
  *
- * Reads actual key bindings from the IntelliJ keymap so customized
- * shortcuts are reflected in the displayed hints.
+ * Each entry renders as one or more [KeyBadge]s followed by a small action
+ * label. Reads actual key bindings from the IntelliJ keymap so customized
+ * shortcuts are reflected.
  *
- * The shortcut hints feature can be disabled in Settings → AgentBridge → Chat Input.
+ * Visibility honours the *Show shortcut hints* toggle in
+ * Settings → AgentBridge → Chat Input.
  */
-class PromptShortcutHintPanel : JBPanel<JBPanel<*>>(BorderLayout()) {
-
-    private val cell: JPanel = JPanel(FlowLayout(FlowLayout.CENTER, JBUI.scale(4), 0)).apply {
-        isOpaque = false
-    }
-    private val actionLabel: JBLabel = JBLabel().apply {
-        font = JBUI.Fonts.smallFont()
-        foreground = UIUtil.getContextHelpForeground()
-    }
+class PromptShortcutHintPanel : JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.LEFT, JBUI.scale(8), 0)) {
 
     init {
         isOpaque = false
-        border = JBUI.Borders.empty(4, 8, 4, 8)
-        add(cell, BorderLayout.CENTER)
-        setRunning(false)
+        border = JBUI.Borders.empty(0, 4, 0, 4)
     }
 
     /**
-     * Switch the displayed shortcut to match the most relevant action for the
-     * current state:
-     *  - `false` → Enter ▸ Send
-     *  - `true`  → Ctrl+Enter ▸ Stop && Send
+     * Replace the displayed hints with the given keystroke/label pairs. The
+     * order of [shortcuts] is preserved, rendered left-to-right.
      */
-    fun setRunning(running: Boolean) {
-        val (actionId, fallbackStroke, label) = if (running) {
-            Triple(
-                PromptShortcutAction.STOP_AND_SEND_ID,
-                KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.CTRL_DOWN_MASK),
-                "Stop && Send"
-            )
-        } else {
-            Triple(
-                PromptShortcutAction.SEND_ID,
-                KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
-                "Send"
-            )
+    fun setShortcuts(shortcuts: List<Pair<KeyStroke, String>>) {
+        removeAll()
+        for ((stroke, label) in shortcuts) {
+            add(buildEntry(stroke, label))
         }
-        cell.removeAll()
-        val stroke = PromptShortcutAction.resolveKeystroke(actionId, fallbackStroke)
-        KeyBadge.keystrokeTokens(stroke).forEach { cell.add(KeyBadge(it)) }
-        actionLabel.text = label
-        cell.add(actionLabel)
-        cell.revalidate()
-        cell.repaint()
+        revalidate()
+        repaint()
     }
 
-    /**
-     * Legacy entry point — now delegates to [setRunning]. Kept so callers that
-     * were toggling "send/nudge" don't need to change signature.
-     */
-    fun setNudgeMode(nudge: Boolean) = setRunning(nudge)
+    private fun buildEntry(stroke: KeyStroke, label: String): JComponent {
+        val cell = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(2), 0)).apply {
+            isOpaque = false
+            border = JBUI.Borders.empty()
+        }
+        KeyBadge.keystrokeTokens(stroke).forEach { cell.add(KeyBadge(it)) }
+        val text = JBLabel(label).apply {
+            font = JBUI.Fonts.smallFont()
+            foreground = UIUtil.getContextHelpForeground()
+            border = JBUI.Borders.emptyLeft(2)
+        }
+        cell.add(text)
+        return cell
+    }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutHintPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutHintPanel.kt
@@ -6,87 +6,77 @@ import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import java.awt.BorderLayout
 import java.awt.FlowLayout
-import java.awt.GridLayout
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
 import javax.swing.JPanel
 import javax.swing.KeyStroke
 
 /**
- * Footer panel showing keyboard shortcut hints below the chat prompt.
- * Dismisses on hover (and focus); re-appears when the input is empty and idle.
- * The shortcut hints feature can be disabled in Settings → AgentBridge → Chat Input.
+ * Footer panel showing a single, context-appropriate keyboard shortcut hint
+ * below the chat prompt:
+ *  - Idle  → `Enter` Send
+ *  - Busy  → `Ctrl+Enter` Stop && Send
+ *
+ * The previous 2×2 hint grid listed four shortcuts at once, which added
+ * visual weight without providing information the user needed right now.
+ * Users can still see the full list in Settings → AgentBridge → Chat Input
+ * documentation, and all shortcuts continue to work regardless of what is
+ * displayed here.
  *
  * Reads actual key bindings from the IntelliJ keymap so customized
  * shortcuts are reflected in the displayed hints.
  *
- * The four hints are arranged in a 2×2 grid so items in the same column
- * are vertically aligned across rows.
+ * The shortcut hints feature can be disabled in Settings → AgentBridge → Chat Input.
  */
 class PromptShortcutHintPanel : JBPanel<JBPanel<*>>(BorderLayout()) {
 
-    private val sendLabel: JBLabel
+    private val cell: JPanel = JPanel(FlowLayout(FlowLayout.CENTER, JBUI.scale(4), 0)).apply {
+        isOpaque = false
+    }
+    private val actionLabel: JBLabel = JBLabel().apply {
+        font = JBUI.Fonts.smallFont()
+        foreground = UIUtil.getContextHelpForeground()
+    }
 
     init {
         isOpaque = false
         border = JBUI.Borders.empty(4, 8, 4, 8)
-
-        // 2×2 grid — equal-width columns keep entries vertically aligned.
-        val grid = JPanel(GridLayout(2, 2, JBUI.scale(16), JBUI.scale(6)))
-        grid.isOpaque = false
-
-        sendLabel = addShortcutEntry(
-            grid,
-            PromptShortcutAction.SEND_ID,
-            KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
-            "Send"
-        )
-        addShortcutEntry(
-            grid,
-            PromptShortcutAction.NEW_LINE_ID,
-            KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.SHIFT_DOWN_MASK),
-            "New Line"
-        )
-        addShortcutEntry(
-            grid,
-            PromptShortcutAction.STOP_AND_SEND_ID,
-            KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.CTRL_DOWN_MASK),
-            "Stop && Send"
-        )
-        addShortcutEntry(
-            grid,
-            PromptShortcutAction.QUEUE_ID,
-            KeyStroke.getKeyStroke(
-                KeyEvent.VK_ENTER,
-                InputEvent.CTRL_DOWN_MASK or InputEvent.SHIFT_DOWN_MASK
-            ),
-            "Queue"
-        )
-
-        add(grid, BorderLayout.CENTER)
+        add(cell, BorderLayout.CENTER)
+        setRunning(false)
     }
 
-    /** Toggle between "send" and "nudge" label when the agent is working. */
-    fun setNudgeMode(nudge: Boolean) {
-        sendLabel.text = if (nudge) "Nudge" else "Send"
-    }
-
-    private fun addShortcutEntry(
-        grid: JPanel,
-        actionId: String,
-        fallbackStroke: KeyStroke,
-        label: String
-    ): JBLabel {
-        val cell = JPanel(FlowLayout(FlowLayout.CENTER, JBUI.scale(4), 0))
-        cell.isOpaque = false
+    /**
+     * Switch the displayed shortcut to match the most relevant action for the
+     * current state:
+     *  - `false` → Enter ▸ Send
+     *  - `true`  → Ctrl+Enter ▸ Stop && Send
+     */
+    fun setRunning(running: Boolean) {
+        val (actionId, fallbackStroke, label) = if (running) {
+            Triple(
+                PromptShortcutAction.STOP_AND_SEND_ID,
+                KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.CTRL_DOWN_MASK),
+                "Stop && Send"
+            )
+        } else {
+            Triple(
+                PromptShortcutAction.SEND_ID,
+                KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
+                "Send"
+            )
+        }
+        cell.removeAll()
         val stroke = PromptShortcutAction.resolveKeystroke(actionId, fallbackStroke)
         KeyBadge.keystrokeTokens(stroke).forEach { cell.add(KeyBadge(it)) }
-        val lbl = JBLabel(label).apply {
-            font = JBUI.Fonts.smallFont()
-            foreground = UIUtil.getContextHelpForeground()
-        }
-        cell.add(lbl)
-        grid.add(cell)
-        return lbl
+        actionLabel.text = label
+        cell.add(actionLabel)
+        cell.revalidate()
+        cell.repaint()
     }
+
+    /**
+     * Legacy entry point — now delegates to [setRunning]. Kept so callers that
+     * were toggling "send/nudge" don't need to change signature.
+     */
+    fun setNudgeMode(nudge: Boolean) = setRunning(nudge)
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/SessionStatsSnapshot.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/SessionStatsSnapshot.kt
@@ -14,6 +14,12 @@ data class SessionStatsSnapshot(
     val turnInputTokens: Int,
     val turnOutputTokens: Int,
     val turnCostUsd: Double?,
+    /**
+     * Premium-request weight of the most recent turn (e.g. 3.0 for an Opus turn, 1.0 default).
+     * Used by the side panel's "Last turn — Premium req" row to show the actual multiplier
+     * instead of a hardcoded "1". Defaults to 1.0 when no multiplier is known.
+     */
+    val turnPremiumRequests: Double = 1.0,
     val sessionTotalTimeSec: Long,
     val sessionTurnCount: Int,
     val sessionToolCalls: Int,

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/DiffPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/DiffPanel.java
@@ -45,9 +45,10 @@ import java.util.List;
  * Side panel listing files the agent has touched in the current {@link AgentEditSession}.
  * <p>
  * Uses a {@link JBList} with a single row renderer instead of a multi-column table.
- * Each row shows: timestamp + status-colored filename + diff counts on the left,
- * approve toggle + remove/reject icon on the right. Click zones are determined by
- * x-position relative to cell bounds.
+ * Each row shows: file-type icon + status-colored filename on the left,
+ * a +N -M diff-counts column, and approve/remove icons on the right. Full
+ * relative path and last-edit timestamp are shown in the row tooltip. Click
+ * zones are determined by x-position relative to cell bounds.
  */
 public final class DiffPanel extends JPanel implements Disposable {
 
@@ -492,18 +493,21 @@ public final class DiffPanel extends JPanel implements Disposable {
     }
 
     /**
-     * Renders a single review row in the same compact "file-row" style as the
-     * session-tab project files list:
+     * Renders a single review row in a compact three-column layout:
      * <ul>
-     *   <li>LEFT: file-type icon</li>
-     *   <li>CENTER: status-colored filename + dim path suffix + animated diff counts</li>
-     *   <li>RIGHT: small approve toggle and reject/remove icons</li>
+     *   <li>LEFT: file-type icon + status-colored filename only (no inline path —
+     *       full relative path moved to the row tooltip together with the last-edit
+     *       timestamp).</li>
+     *   <li>MIDDLE-RIGHT: dedicated column with animated +N -M diff counts.</li>
+     *   <li>RIGHT: small approve toggle and reject/remove icons.</li>
      * </ul>
-     * Per-row timestamp moved to the tooltip so each row stays single-line.
+     * Removing the inline path keeps the row narrow enough for the side panel
+     * width; the path remains discoverable via tooltip.
      */
     private final class ReviewRowRenderer extends JPanel implements ListCellRenderer<ReviewItem> {
         private final JLabel fileIconLabel = new JLabel();
         private final SimpleColoredComponent fileText = new SimpleColoredComponent();
+        private final SimpleColoredComponent diffCountsText = new SimpleColoredComponent();
         private final BadgeLabel approveLabel = new BadgeLabel();
         private final JLabel removeLabel = new JLabel();
 
@@ -517,12 +521,18 @@ public final class DiffPanel extends JPanel implements Disposable {
             fileIconLabel.setBorder(JBUI.Borders.emptyRight(6));
             add(fileIconLabel, BorderLayout.WEST);
 
-            // CENTER: filename + path suffix + diff counts on a single line.
+            // CENTER: filename only on a single line.
             fileText.setOpaque(false);
             fileText.setIpad(JBUI.emptyInsets());
             add(fileText, BorderLayout.CENTER);
 
-            // RIGHT: compact approve + reject icons in a small panel.
+            // RIGHT: diff counts column + compact approve + reject icons.
+            // BorderLayout pins actions to the far right; diff counts get their own
+            // column to the left of the action buttons.
+            diffCountsText.setOpaque(false);
+            diffCountsText.setIpad(JBUI.emptyInsets());
+            diffCountsText.setBorder(JBUI.Borders.emptyRight(8));
+
             JPanel actions = new JPanel(new FlowLayout(FlowLayout.RIGHT, JBUI.scale(2), 0));
             actions.setOpaque(false);
             approveLabel.setHorizontalAlignment(SwingConstants.CENTER);
@@ -533,7 +543,12 @@ public final class DiffPanel extends JPanel implements Disposable {
             removeLabel.setPreferredSize(btnDim);
             actions.add(approveLabel);
             actions.add(removeLabel);
-            add(actions, BorderLayout.EAST);
+
+            JPanel east = new JPanel(new BorderLayout());
+            east.setOpaque(false);
+            east.add(diffCountsText, BorderLayout.CENTER);
+            east.add(actions, BorderLayout.EAST);
+            add(east, BorderLayout.EAST);
         }
 
         @Override
@@ -554,7 +569,7 @@ public final class DiffPanel extends JPanel implements Disposable {
                 .getInstance().getFileTypeByFileName(fileName).getIcon();
             fileIconLabel.setIcon(icon != null ? icon : AllIcons.FileTypes.Text);
 
-            // Filename + dim path suffix + animated diff counts on one line.
+            // Filename only — full path is in the tooltip.
             fileText.clear();
             fileText.setFont(jList.getFont());
             Color fileColor = isSelected ? fg : switch (item.status()) {
@@ -564,24 +579,20 @@ public final class DiffPanel extends JPanel implements Disposable {
             };
             fileText.append(fileName, new SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, fileColor));
 
-            String relPath = item.relativePath();
-            String parentPath = parentPathOf(relPath);
-            if (!parentPath.isEmpty()) {
-                fileText.append("  " + parentPath,
-                    new SimpleTextAttributes(SimpleTextAttributes.STYLE_SMALLER,
-                        isSelected ? fg : JBColor.GRAY));
-            }
-
+            // Diff counts column.
+            diffCountsText.clear();
+            diffCountsText.setFont(jList.getFont());
             long now = System.currentTimeMillis();
             ReviewDiffCountAnimator.DiffCounts counts = diffCountAnimator.displayCounts(item, now);
             if (counts.added() > 0) {
                 Color c = isSelected ? fg : DIFF_GREEN;
-                fileText.append("  +" + counts.added(),
+                diffCountsText.append("+" + counts.added(),
                     new SimpleTextAttributes(SimpleTextAttributes.STYLE_SMALLER, c));
             }
             if (counts.removed() > 0) {
                 Color c = isSelected ? fg : DIFF_RED;
-                fileText.append(" -" + counts.removed(),
+                String prefix = counts.added() > 0 ? " " : "";
+                diffCountsText.append(prefix + "-" + counts.removed(),
                     new SimpleTextAttributes(SimpleTextAttributes.STYLE_SMALLER, c));
             }
 
@@ -590,12 +601,6 @@ public final class DiffPanel extends JPanel implements Disposable {
             removeLabel.setIcon(item.approved() ? AllIcons.Actions.Close : AllIcons.Actions.Rollback);
 
             return this;
-        }
-
-        private static @NotNull String parentPathOf(@NotNull String relPath) {
-            int slash = relPath.lastIndexOf('/');
-            if (slash < 0) slash = relPath.lastIndexOf('\\');
-            return slash > 0 ? relPath.substring(0, slash) : "";
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/DiffPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/review/DiffPanel.java
@@ -57,8 +57,10 @@ public final class DiffPanel extends JPanel implements Disposable {
 
     /**
      * Unscaled button zone width (each action icon gets this much horizontal space).
+     * Compact 18px buttons match the file-row aesthetic of the session-tab
+     * project files list, replacing the previous 28px tile look.
      */
-    private static final int BUTTON_SIZE = 28;
+    private static final int BUTTON_SIZE = 18;
 
     private static final JBColor DIFF_GREEN = new JBColor(new Color(0, 128, 0), new Color(80, 200, 80));
     private static final JBColor DIFF_RED = new JBColor(new Color(200, 0, 0), new Color(255, 80, 80));
@@ -308,10 +310,13 @@ public final class DiffPanel extends JPanel implements Disposable {
 
     private static int hitTestZone(int relativeX, int cellWidth) {
         int btn = JBUI.scale(BUTTON_SIZE);
-        int leftPad = JBUI.scale(8);   // matches empty(6, 8, 6, 4) left inset
-        int rightPad = JBUI.scale(4);  // matches empty(6, 8, 6, 4) right inset
-        if (relativeX < leftPad + btn) return ZONE_APPROVE;
-        if (relativeX >= cellWidth - rightPad - btn) return ZONE_REMOVE;
+        int rightPad = JBUI.scale(6);  // matches empty(2, 8, 2, 6) right inset
+        int gap = JBUI.scale(2);       // gap between approve and reject icons
+        // Reject icon is rightmost; approve icon sits immediately to its left.
+        int rejectStart = cellWidth - rightPad - btn;
+        int approveStart = rejectStart - gap - btn;
+        if (relativeX >= rejectStart) return ZONE_REMOVE;
+        if (relativeX >= approveStart) return ZONE_APPROVE;
         return ZONE_FILE;
     }
 
@@ -326,7 +331,13 @@ public final class DiffPanel extends JPanel implements Disposable {
         return switch (zone) {
             case ZONE_REMOVE -> item.approved() ? "Remove from list" : "Reject this change…";
             case ZONE_APPROVE -> item.approved() ? "Approved — click to unapprove" : "Approve this change";
-            default -> item.relativePath() + (item.approved() ? " · Approved" : " · Pending review");
+            default -> {
+                String tip = item.relativePath() + (item.approved() ? " · Approved" : " · Pending review");
+                if (item.lastEditedMillis() > 0) {
+                    tip += " · " + TimestampDisplayFormatter.formatEpochMillis(item.lastEditedMillis());
+                }
+                yield tip;
+            }
         };
     }
 
@@ -481,46 +492,48 @@ public final class DiffPanel extends JPanel implements Disposable {
     }
 
     /**
-     * Renders a single review row with a two-column layout:
+     * Renders a single review row in the same compact "file-row" style as the
+     * session-tab project files list:
      * <ul>
-     *   <li>LEFT: approve badge</li>
-     *   <li>CENTER: timestamp (top), status-coloured filename (middle), animated diff counts (bottom)</li>
-     *   <li>RIGHT: remove/reject icon</li>
+     *   <li>LEFT: file-type icon</li>
+     *   <li>CENTER: status-colored filename + dim path suffix + animated diff counts</li>
+     *   <li>RIGHT: small approve toggle and reject/remove icons</li>
      * </ul>
+     * Per-row timestamp moved to the tooltip so each row stays single-line.
      */
     private final class ReviewRowRenderer extends JPanel implements ListCellRenderer<ReviewItem> {
-        private final BadgeLabel approveLabel = new BadgeLabel();
-        private final SimpleColoredComponent timestampText = new SimpleColoredComponent();
+        private final JLabel fileIconLabel = new JLabel();
         private final SimpleColoredComponent fileText = new SimpleColoredComponent();
-        private final SimpleColoredComponent diffText = new SimpleColoredComponent();
+        private final BadgeLabel approveLabel = new BadgeLabel();
         private final JLabel removeLabel = new JLabel();
 
         ReviewRowRenderer() {
             setLayout(new BorderLayout());
-            setBorder(JBUI.Borders.empty(6, 8, 6, 4));
+            setBorder(JBUI.Borders.empty(2, 8, 2, 6));
 
             Dimension btnDim = new Dimension(JBUI.scale(BUTTON_SIZE), JBUI.scale(BUTTON_SIZE));
 
-            approveLabel.setHorizontalAlignment(SwingConstants.CENTER);
-            approveLabel.setPreferredSize(btnDim);
-            add(approveLabel, BorderLayout.WEST);
+            // LEFT: file-type icon (matches FileNodeRenderer in ProjectFilesPanel).
+            fileIconLabel.setBorder(JBUI.Borders.emptyRight(6));
+            add(fileIconLabel, BorderLayout.WEST);
 
-            JPanel textPanel = new JPanel();
-            textPanel.setOpaque(false);
-            textPanel.setLayout(new BoxLayout(textPanel, BoxLayout.Y_AXIS));
-            textPanel.setBorder(JBUI.Borders.emptyLeft(6));
-            timestampText.setOpaque(false);
+            // CENTER: filename + path suffix + diff counts on a single line.
             fileText.setOpaque(false);
-            diffText.setOpaque(false);
-            textPanel.add(timestampText);
-            textPanel.add(fileText);
-            textPanel.add(diffText);
-            add(textPanel, BorderLayout.CENTER);
+            fileText.setIpad(JBUI.emptyInsets());
+            add(fileText, BorderLayout.CENTER);
 
+            // RIGHT: compact approve + reject icons in a small panel.
+            JPanel actions = new JPanel(new FlowLayout(FlowLayout.RIGHT, JBUI.scale(2), 0));
+            actions.setOpaque(false);
+            approveLabel.setHorizontalAlignment(SwingConstants.CENTER);
+            approveLabel.setVerticalAlignment(SwingConstants.CENTER);
+            approveLabel.setPreferredSize(btnDim);
             removeLabel.setHorizontalAlignment(SwingConstants.CENTER);
             removeLabel.setVerticalAlignment(SwingConstants.CENTER);
             removeLabel.setPreferredSize(btnDim);
-            add(removeLabel, BorderLayout.EAST);
+            actions.add(approveLabel);
+            actions.add(removeLabel);
+            add(actions, BorderLayout.EAST);
         }
 
         @Override
@@ -533,20 +546,17 @@ public final class DiffPanel extends JPanel implements Disposable {
             setBackground(bg);
             setOpaque(true);
 
-            timestampText.clear();
-            if (item.lastEditedMillis() > 0) {
-                timestampText.append(
-                    TimestampDisplayFormatter.formatEpochMillis(item.lastEditedMillis()),
-                    new SimpleTextAttributes(SimpleTextAttributes.STYLE_SMALLER, isSelected ? fg : JBColor.GRAY));
-                timestampText.setVisible(true);
-            } else {
-                timestampText.setVisible(false);
-            }
-
-            fileText.clear();
-            fileText.setFont(jList.getFont());
+            // File icon — derived from the filename so each row renders with the same
+            // language icon it would have in the Project view / Editor tab strip.
             Path p = Path.of(item.path());
             String fileName = p.getFileName() != null ? p.getFileName().toString() : item.path();
+            Icon icon = com.intellij.openapi.fileTypes.FileTypeManager
+                .getInstance().getFileTypeByFileName(fileName).getIcon();
+            fileIconLabel.setIcon(icon != null ? icon : AllIcons.FileTypes.Text);
+
+            // Filename + dim path suffix + animated diff counts on one line.
+            fileText.clear();
+            fileText.setFont(jList.getFont());
             Color fileColor = isSelected ? fg : switch (item.status()) {
                 case ADDED -> STATUS_ADDED;
                 case MODIFIED -> STATUS_MODIFIED;
@@ -554,24 +564,25 @@ public final class DiffPanel extends JPanel implements Disposable {
             };
             fileText.append(fileName, new SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, fileColor));
 
-            diffText.clear();
+            String relPath = item.relativePath();
+            String parentPath = parentPathOf(relPath);
+            if (!parentPath.isEmpty()) {
+                fileText.append("  " + parentPath,
+                    new SimpleTextAttributes(SimpleTextAttributes.STYLE_SMALLER,
+                        isSelected ? fg : JBColor.GRAY));
+            }
+
             long now = System.currentTimeMillis();
             ReviewDiffCountAnimator.DiffCounts counts = diffCountAnimator.displayCounts(item, now);
-            if (counts.added() > 0 || counts.removed() > 0) {
-                if (counts.added() > 0) {
-                    Color c = isSelected ? fg : DIFF_GREEN;
-                    diffText.append("+" + counts.added(),
-                        new SimpleTextAttributes(SimpleTextAttributes.STYLE_SMALLER, c));
-                }
-                if (counts.removed() > 0) {
-                    if (counts.added() > 0) diffText.append(" ", SimpleTextAttributes.REGULAR_ATTRIBUTES);
-                    Color c = isSelected ? fg : DIFF_RED;
-                    diffText.append("-" + counts.removed(),
-                        new SimpleTextAttributes(SimpleTextAttributes.STYLE_SMALLER, c));
-                }
-                diffText.setVisible(true);
-            } else {
-                diffText.setVisible(false);
+            if (counts.added() > 0) {
+                Color c = isSelected ? fg : DIFF_GREEN;
+                fileText.append("  +" + counts.added(),
+                    new SimpleTextAttributes(SimpleTextAttributes.STYLE_SMALLER, c));
+            }
+            if (counts.removed() > 0) {
+                Color c = isSelected ? fg : DIFF_RED;
+                fileText.append(" -" + counts.removed(),
+                    new SimpleTextAttributes(SimpleTextAttributes.STYLE_SMALLER, c));
             }
 
             approveLabel.setIcon(AllIcons.Actions.Checked);
@@ -579,6 +590,12 @@ public final class DiffPanel extends JPanel implements Disposable {
             removeLabel.setIcon(item.approved() ? AllIcons.Actions.Close : AllIcons.Actions.Rollback);
 
             return this;
+        }
+
+        private static @NotNull String parentPathOf(@NotNull String relPath) {
+            int slash = relPath.lastIndexOf('/');
+            if (slash < 0) slash = relPath.lastIndexOf('\\');
+            return slash > 0 ? relPath.substring(0, slash) : "";
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
@@ -55,6 +55,15 @@ final class ProjectFilesPanel extends JPanel {
         tree.setRootVisible(false);
         tree.setShowsRootHandles(true);
         tree.setCellRenderer(new FileNodeRenderer());
+        // Single-selection only — discontiguous selection (the JTree default) was
+        // letting the selection model report multiple paths after expand/collapse,
+        // which lit every file row blue as if all were selected.
+        tree.getSelectionModel().setSelectionMode(
+            javax.swing.tree.TreeSelectionModel.SINGLE_TREE_SELECTION);
+        // Disable the connector/branch guide line: in some L&Fs it paints a thin
+        // selection-tinted band down through the selected node's descendants,
+        // which read as "child rows are selected too".
+        tree.putClientProperty("JTree.lineStyle", "None");
         // Let the parent's background show through so dark mode doesn't
         // paint a gray rectangle behind the file rows.
         tree.setOpaque(false);
@@ -316,39 +325,65 @@ final class ProjectFilesPanel extends JPanel {
         }
     }
 
+    /**
+     * Tree cell renderer that paints a selection background only on the actually-selected
+     * row and stays fully transparent otherwise. {@link DefaultTreeCellRenderer}'s default
+     * {@code paint()} fills with {@code backgroundNonSelectionColor} (which inherits a
+     * panel-grey from the L&F) before drawing icon and text, leaving a visible grey rect
+     * behind every row even with {@code setOpaque(false)}. We override {@code paintComponent}
+     * to skip the fill entirely when not selected.
+     */
     private static final class FileNodeRenderer extends DefaultTreeCellRenderer {
+        private boolean rowSelected;
+
         FileNodeRenderer() {
-            // DefaultTreeCellRenderer.paint() fills the cell with this color even when
-            // setOpaque(false). Null it out so the tree (and parent) background shows through.
+            // Belt-and-braces: also clear the field DefaultTreeCellRenderer.paint reads from.
             setBackgroundNonSelectionColor(null);
+            setBorderSelectionColor(null);
         }
 
         @Override
         public void updateUI() {
             super.updateUI();
-            // L&F change can reset backgroundNonSelectionColor; re-apply the null so that
-            // the transparent background survives theme switches.
+            // L&F change can reset both colors; re-clear so the transparent background
+            // and missing focus rectangle survive theme switches.
             setBackgroundNonSelectionColor(null);
+            setBorderSelectionColor(null);
         }
 
         @Override
         public Component getTreeCellRendererComponent(JTree tree, Object value, boolean sel,
                                                       boolean expanded, boolean leaf, int row,
                                                       boolean hasFocus) {
-            Component c = super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
-            if (!sel) {
+            super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
+            this.rowSelected = sel;
+            // Selected row gets an opaque label painted with the L&F's tree selection color;
+            // every other row is fully transparent so the side-panel background shows through.
+            setOpaque(sel);
+            if (sel) {
+                setBackground(com.intellij.util.ui.UIUtil.getTreeSelectionBackground(true));
+                setForeground(com.intellij.util.ui.UIUtil.getTreeSelectionForeground(true));
+            } else {
+                setBackground(null);
+                setForeground(com.intellij.util.ui.UIUtil.getTreeForeground());
+            }
+            if (value instanceof DefaultMutableTreeNode node && node.getUserObject() instanceof FileNode fn) {
+                setIcon(fn.icon());
+                setText(fn.label);
+                setToolTipText(fn.relativePath);
+            }
+            return this;
+        }
+
+        @Override
+        protected void paintComponent(Graphics g) {
+            // When unselected, skip the background fill that DefaultTreeCellRenderer (via
+            // JLabel) would otherwise paint. When selected, fall through to the default
+            // opaque paint so the row gets the proper selection band.
+            if (!rowSelected) {
                 setOpaque(false);
-                if (c instanceof JLabel label) {
-                    label.setOpaque(false);
-                }
             }
-            if (value instanceof DefaultMutableTreeNode node && node.getUserObject() instanceof FileNode fn
-                && c instanceof JLabel label) {
-                label.setIcon(fn.icon());
-                label.setText(fn.label);
-                label.setToolTipText(fn.relativePath);
-            }
-            return c;
+            super.paintComponent(g);
         }
     }
 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
@@ -361,8 +361,11 @@ final class ProjectFilesPanel extends JPanel {
             // every other row is fully transparent so the side-panel background shows through.
             setOpaque(sel);
             if (sel) {
-                setBackground(com.intellij.util.ui.UIUtil.getTreeSelectionBackground(true));
-                setForeground(com.intellij.util.ui.UIUtil.getTreeSelectionForeground(true));
+                // Use the focused/unfocused selection palette based on actual tree focus —
+                // otherwise unfocused selections incorrectly look focused, which breaks the
+                // IDE's standard selection semantics (focused = vivid, unfocused = muted).
+                setBackground(com.intellij.util.ui.UIUtil.getTreeSelectionBackground(hasFocus));
+                setForeground(com.intellij.util.ui.UIUtil.getTreeSelectionForeground(hasFocus));
             } else {
                 setBackground(null);
                 setForeground(com.intellij.util.ui.UIUtil.getTreeForeground());

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
@@ -5,6 +5,7 @@ import com.github.catatafishen.agentbridge.services.ActiveAgentManager;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileTypes.FileTypeManager;
+import com.intellij.openapi.fileTypes.UnknownFileType;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -147,6 +148,9 @@ final class ProjectFilesPanel extends JPanel {
 
     /**
      * Recursively lists files under the session directory, using relative paths as labels.
+     * Files with unrecognized file types (rendered with the generic "?" icon) are skipped
+     * — they're almost always noise (temp files, internal state) rather than content the
+     * user wants to open.
      */
     private static @NotNull List<FileNode> listSessionFiles(@NotNull File root, @NotNull File dir) {
         List<FileNode> results = new ArrayList<>();
@@ -155,12 +159,16 @@ final class ProjectFilesPanel extends JPanel {
         for (File child : children) {
             if (child.isDirectory()) {
                 results.addAll(listSessionFiles(root, child));
-            } else {
+            } else if (isRecognizedFileType(child.getName())) {
                 String rel = root.toURI().relativize(child.toURI()).getPath();
                 results.add(new FileNode(root.getAbsolutePath(), rel, rel, false));
             }
         }
         return results;
+    }
+
+    private static boolean isRecognizedFileType(@NotNull String fileName) {
+        return !(FileTypeManager.getInstance().getFileTypeByFileName(fileName) instanceof UnknownFileType);
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/ProjectFilesPanel.java
@@ -367,10 +367,28 @@ final class ProjectFilesPanel extends JPanel {
                 setBackground(null);
                 setForeground(com.intellij.util.ui.UIUtil.getTreeForeground());
             }
-            if (value instanceof DefaultMutableTreeNode node && node.getUserObject() instanceof FileNode fn) {
-                setIcon(fn.icon());
-                setText(fn.label);
-                setToolTipText(fn.relativePath);
+            // Reset font + icon each call — JTree reuses a single renderer instance, so
+            // a section node painted right after a file node must not inherit its bold/dim
+            // styling, and vice versa.
+            setFont(tree.getFont());
+            if (value instanceof DefaultMutableTreeNode node) {
+                Object userObject = node.getUserObject();
+                if (userObject instanceof FileNode fn) {
+                    setIcon(fn.icon());
+                    setText(fn.label);
+                    setToolTipText(fn.relativePath);
+                } else if (userObject instanceof String label) {
+                    // Section header node (e.g. "Shared", "Copilot CLI"): render dim + bold
+                    // with no icon to match the SessionStatsPanel section-header style above.
+                    setIcon(null);
+                    setText(label);
+                    setToolTipText(null);
+                    setFont(tree.getFont().deriveFont(Font.BOLD));
+                    if (!sel) {
+                        setForeground(com.intellij.util.ui.JBUI.CurrentTheme
+                            .Label.disabledForeground());
+                    }
+                }
             }
             return this;
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -64,6 +64,8 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
     private final JLabel turnTokensValue = new JLabel();
     private final JLabel turnCostRowLabel = new JLabel("Cost");
     private final JLabel turnCostValue = new JLabel();
+    private final JPanel turnToolsRow;
+    private final JPanel turnLinesRow;
     private final JPanel turnTokensRow;
     private final JPanel turnCostRow;
     private final JPanel turnSection;
@@ -79,6 +81,9 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
     // Dynamic labels whose text changes based on provider mode
     private final JLabel tokensRowLabel = new JLabel(LABEL_TOKENS);
     private final JLabel costRowLabel = new JLabel("Cost");
+    private final JPanel turnsRow;
+    private final JPanel sessionToolsRow;
+    private final JPanel linesRow;
     private final JPanel tokensRow;
     private final JPanel costRow;
 
@@ -131,8 +136,8 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
 
         int tRow = 0;
         addStatRow(turnGrid, tRow++, "Time", turnTimeValue);
-        addStatRow(turnGrid, tRow++, "Tool calls", turnToolsValue);
-        addStatRow(turnGrid, tRow++, "Lines changed", turnLinesValue);
+        turnToolsRow = addStatRow(turnGrid, tRow++, "Tool calls", turnToolsValue);
+        turnLinesRow = addStatRow(turnGrid, tRow++, "Lines changed", turnLinesValue);
         turnTokensRow = addStatRowWithLabel(turnGrid, tRow++, turnTokensRowLabel, turnTokensValue);
         turnCostRow = addStatRowWithLabel(turnGrid, tRow, turnCostRowLabel, turnCostValue);
 
@@ -151,9 +156,9 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
 
         int row = 0;
         addStatRow(statsGrid, row++, "Time", timeValue);
-        addStatRow(statsGrid, row++, "Turns", turnsValue);
-        addStatRow(statsGrid, row++, "Tool calls", toolsValue);
-        addStatRow(statsGrid, row++, "Lines changed", linesValue);
+        turnsRow = addStatRow(statsGrid, row++, "Turns", turnsValue);
+        sessionToolsRow = addStatRow(statsGrid, row++, "Tool calls", toolsValue);
+        linesRow = addStatRow(statsGrid, row++, "Lines changed", linesValue);
 
         tokensRow = addStatRowWithLabel(statsGrid, row++, tokensRowLabel, tokensValue);
         costRow = addStatRowWithLabel(statsGrid, row, costRowLabel, costValue);
@@ -299,6 +304,8 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         label.setFont(smallFont);
         label.setForeground(UIManager.getColor("Label.foreground"));
         value.setFont(smallFont);
+        // Right-align values so columns line up cleanly across sections; label stays left.
+        value.setHorizontalAlignment(SwingConstants.RIGHT);
 
         JPanel rowPanel = new JPanel(new BorderLayout(JBUI.scale(8), 0));
         rowPanel.setOpaque(false);
@@ -355,7 +362,12 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         // Time as a labeled row (mirrors the Session section) instead of inline in the
         // header — the two sections now align visually.
         turnTimeValue.setText(TimerDisplayFormatter.INSTANCE.formatElapsedTime(snap.getTurnElapsedSec()));
-        turnToolsValue.setText(String.valueOf(snap.getTurnToolCalls()));
+        int turnTools = snap.getTurnToolCalls();
+        turnToolsValue.setText(String.valueOf(turnTools));
+        // Hide zero-value rows to reduce visual noise — a row of "0"s conveys no signal.
+        turnToolsRow.setVisible(turnTools > 0);
+        long turnLines = snap.getTurnLinesAdded() + snap.getTurnLinesRemoved();
+        turnLinesRow.setVisible(turnLines > 0);
 
         if (snap.getMultiplierMode()) {
             turnTokensRowLabel.setText("Premium req");
@@ -386,8 +398,14 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
 
     private void refreshSessionStats(SessionStatsSnapshot snap) {
         timeValue.setText(TimerDisplayFormatter.INSTANCE.formatElapsedTime(snap.getSessionTotalTimeSec()));
-        turnsValue.setText(String.valueOf(snap.getSessionTurnCount()));
-        toolsValue.setText(String.valueOf(snap.getSessionToolCalls()));
+        int turns = snap.getSessionTurnCount();
+        turnsValue.setText(String.valueOf(turns));
+        turnsRow.setVisible(turns > 0);
+        int sessionTools = snap.getSessionToolCalls();
+        toolsValue.setText(String.valueOf(sessionTools));
+        sessionToolsRow.setVisible(sessionTools > 0);
+        long sessionLines = snap.getSessionLinesAdded() + snap.getSessionLinesRemoved();
+        linesRow.setVisible(sessionLines > 0);
 
         if (snap.getMultiplierMode()) {
             tokensRowLabel.setText("Premium req");

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.ui.side;
 
 import com.github.catatafishen.agentbridge.services.ActiveAgentManager;
+import com.github.catatafishen.agentbridge.services.ToolCallStatisticsService;
 import com.github.catatafishen.agentbridge.ui.AgentIconProvider;
 import com.github.catatafishen.agentbridge.ui.BillingCalculator;
 import com.github.catatafishen.agentbridge.ui.BillingDisplayData;
@@ -11,6 +12,7 @@ import com.github.catatafishen.agentbridge.ui.TimerDisplayFormatter;
 import com.github.catatafishen.agentbridge.ui.UsageGraphPanel;
 import com.github.catatafishen.agentbridge.ui.renderers.ToolRenderers;
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.util.ui.JBUI;
@@ -21,6 +23,8 @@ import java.awt.*;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Side panel tab displaying session statistics as labeled rows: an optional
@@ -39,6 +43,9 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
 
     private static final DateTimeFormatter RESET_DATE_FMT = DateTimeFormatter.ofPattern("MMM d, yyyy");
     private static final String LABEL_TOKENS = "Tokens";
+    private static final String LABEL_PREMIUM_REQ = "Premium req";
+    private static final String TOKENS_IN_OUT_SEP = " in / ";
+    private static final String TOKENS_OUT_SUFFIX = " out";
 
     private final ProcessingTimerPanel timerPanel;
     private final BillingManager billing;
@@ -97,6 +104,24 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
     private final JPanel billingSection;
     private final ProjectFilesPanel filesPanel;
 
+    // "Today" section — aggregates persisted turn_stats rows for the current local date,
+    // across all agents. Independent of the in-memory Session totals (which only track
+    // the current chat session).
+    private final Project project;
+    private final JLabel todayTimeValue = new JLabel();
+    private final JLabel todayTurnsValue = new JLabel();
+    private final JLabel todayToolsValue = new JLabel();
+    private final JLabel todayLinesValue = new JLabel();
+    private final JLabel todayTokensRowLabel = new JLabel(LABEL_TOKENS);
+    private final JLabel todayTokensValue = new JLabel();
+    private final JPanel todayToolsRow;
+    private final JPanel todayLinesRow;
+    private final JPanel todayTokensRow;
+    private final JPanel todaySection;
+    private final AtomicReference<TodayTotals> todayTotalsRef = new AtomicReference<>(TodayTotals.EMPTY);
+    private long lastTodayQueryNanos = 0L;
+    private static final long TODAY_REFRESH_INTERVAL_NANOS = 5_000_000_000L;
+
     public SessionStatsPanel(
         @NotNull Project project,
         @NotNull ProcessingTimerPanel timerPanel,
@@ -104,6 +129,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         @NotNull BillingManager billing
     ) {
         super(new BorderLayout());
+        this.project = project;
         this.timerPanel = timerPanel;
         this.billing = billing;
         this.agentManager = ActiveAgentManager.getInstance(project);
@@ -163,6 +189,27 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         tokensRow = addStatRowWithLabel(statsGrid, row++, tokensRowLabel, tokensValue);
         costRow = addStatRowWithLabel(statsGrid, row, costRowLabel, costValue);
 
+        // Today section — same row layout as Session, sourced from the persistent turn_stats DB.
+        // Spans across all chat sessions for the current local date so users see how much they've
+        // used the assistant today regardless of how many times they've reopened the IDE.
+        JPanel todayGrid = new JPanel(new GridBagLayout());
+        todayGrid.setOpaque(false);
+        todayGrid.setBorder(BorderFactory.createEmptyBorder(
+            JBUI.scale(2), JBUI.scale(8), JBUI.scale(4), JBUI.scale(8)));
+        int dRow = 0;
+        addStatRow(todayGrid, dRow++, "Time", todayTimeValue);
+        addStatRow(todayGrid, dRow++, "Turns", todayTurnsValue);
+        todayToolsRow = addStatRow(todayGrid, dRow++, "Tool calls", todayToolsValue);
+        todayLinesRow = addStatRow(todayGrid, dRow++, "Lines changed", todayLinesValue);
+        todayTokensRow = addStatRowWithLabel(todayGrid, dRow, todayTokensRowLabel, todayTokensValue);
+
+        todaySection = new JPanel();
+        todaySection.setLayout(new BoxLayout(todaySection, BoxLayout.Y_AXIS));
+        todaySection.setOpaque(false);
+        todaySection.add(createSectionHeader("Today"));
+        todaySection.add(todayGrid);
+        todaySection.setVisible(false);
+
         // Usage graph — full-width sparkline rendered last in the Monthly quota section.
         // 5x taller than the original 20px to make trends visually readable at a glance.
         JPanel graphSection = new JPanel(new BorderLayout());
@@ -207,6 +254,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         content.add(turnSection);
         content.add(createSectionHeader("Session"));
         content.add(statsGrid);
+        content.add(todaySection);
         content.add(billingSection);
         content.add(createSectionHeader("Project files"));
 
@@ -357,6 +405,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
 
         refreshTurnSection(snap);
         refreshSessionStats(snap);
+        refreshTodayStats(snap);
         refreshBilling(bill);
         updateDiffLabels(now);
         startAnimationTimerIfNeeded(now);
@@ -395,8 +444,8 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         turnLinesRow.setVisible(turnLines > 0);
 
         if (snap.getMultiplierMode()) {
-            turnTokensRowLabel.setText("Premium req");
-            turnTokensValue.setText("1");
+            turnTokensRowLabel.setText(LABEL_PREMIUM_REQ);
+            turnTokensValue.setText(BillingCalculator.INSTANCE.formatPremium(snap.getTurnPremiumRequests()));
             turnTokensRow.setVisible(true);
             turnCostRow.setVisible(false);
         } else {
@@ -407,9 +456,9 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
                 turnTokensRowLabel.setText(LABEL_TOKENS);
                 turnTokensValue.setText(
                     TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getTurnInputTokens()) +
-                        " in / " +
+                        TOKENS_IN_OUT_SEP +
                         TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getTurnOutputTokens()) +
-                        " out");
+                        TOKENS_OUT_SUFFIX);
                 turnTokensRow.setVisible(true);
                 turnCostRowLabel.setText("Cost");
                 turnCostValue.setText(TimerDisplayFormatter.INSTANCE.formatCost(turnCost != null ? turnCost : 0.0));
@@ -433,7 +482,7 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         linesRow.setVisible(sessionLines > 0);
 
         if (snap.getMultiplierMode()) {
-            tokensRowLabel.setText("Premium req");
+            tokensRowLabel.setText(LABEL_PREMIUM_REQ);
             tokensValue.setText(BillingCalculator.INSTANCE.formatPremium(snap.getLocalSessionPremiumRequests()));
             tokensRow.setVisible(true);
             costRow.setVisible(false);
@@ -443,9 +492,9 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
                 tokensRowLabel.setText(LABEL_TOKENS);
                 tokensValue.setText(
                     TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getSessionInputTokens()) +
-                        " in / " +
+                        TOKENS_IN_OUT_SEP +
                         TimerDisplayFormatter.INSTANCE.formatTokenCount(snap.getSessionOutputTokens()) +
-                        " out");
+                        TOKENS_OUT_SUFFIX);
                 tokensRow.setVisible(true);
                 costRowLabel.setText("Cost");
                 costValue.setText(TimerDisplayFormatter.INSTANCE.formatCost(snap.getSessionCostUsd()));
@@ -520,6 +569,107 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         } else {
             resetsRow.setVisible(false);
         }
+    }
+
+    /**
+     * Aggregates today's persisted turn_stats rows across all agents and updates the
+     * Today section. Throttled — at most one DB query every {@code TODAY_REFRESH_INTERVAL_NANOS}
+     * nanoseconds, executed on a pooled thread; UI updates are marshalled to the EDT.
+     * The cached {@link TodayTotals} is rendered immediately so the panel stays responsive
+     * even when no fresh query has fired yet.
+     */
+    private void refreshTodayStats(SessionStatsSnapshot snap) {
+        long nowNanos = System.nanoTime();
+        if (nowNanos - lastTodayQueryNanos > TODAY_REFRESH_INTERVAL_NANOS) {
+            lastTodayQueryNanos = nowNanos;
+            ApplicationManager.getApplication().executeOnPooledThread(() -> {
+                try {
+                    LocalDate today = LocalDate.now();
+                    String iso = today.format(DateTimeFormatter.ISO_LOCAL_DATE);
+                    List<ToolCallStatisticsService.DailyTurnAggregate> rows =
+                        ToolCallStatisticsService.getInstance(project).queryDailyTurnStats(iso, iso);
+                    int turns = 0;
+                    int tools = 0;
+                    long inTok = 0;
+                    long outTok = 0;
+                    long linesAdded = 0;
+                    long linesRemoved = 0;
+                    long durMs = 0;
+                    double premium = 0.0;
+                    for (ToolCallStatisticsService.DailyTurnAggregate r : rows) {
+                        turns += r.turns();
+                        tools += r.toolCalls();
+                        inTok += r.inputTokens();
+                        outTok += r.outputTokens();
+                        linesAdded += r.linesAdded();
+                        linesRemoved += r.linesRemoved();
+                        durMs += r.durationMs();
+                        premium += r.premiumRequests();
+                    }
+                    TodayTotals totals = new TodayTotals(turns, tools, inTok, outTok,
+                        linesAdded, linesRemoved, durMs, premium);
+                    todayTotalsRef.set(totals);
+                    SwingUtilities.invokeLater(() -> applyTodayTotals(totals, snap.getMultiplierMode()));
+                } catch (Exception ignored) {
+                    // Stats are advisory — never let a query failure crash the UI refresh loop.
+                }
+            });
+        }
+        applyTodayTotals(todayTotalsRef.get(), snap.getMultiplierMode());
+    }
+
+    private void applyTodayTotals(TodayTotals t, boolean multiplierMode) {
+        if (t.turns() <= 0) {
+            todaySection.setVisible(false);
+            return;
+        }
+        todaySection.setVisible(true);
+        todayTimeValue.setText(TimerDisplayFormatter.INSTANCE.formatElapsedTime(t.durationMs() / 1000));
+        todayTurnsValue.setText(String.valueOf(t.turns()));
+        todayToolsValue.setText(String.valueOf(t.toolCalls()));
+        todayToolsRow.setVisible(t.toolCalls() > 0);
+        long lines = t.linesAdded() + t.linesRemoved();
+        todayLinesValue.setText(lines > 0
+            ? "+" + t.linesAdded() + " / -" + t.linesRemoved()
+            : "0");
+        todayLinesRow.setVisible(lines > 0);
+
+        if (multiplierMode) {
+            todayTokensRowLabel.setText(LABEL_PREMIUM_REQ);
+            todayTokensValue.setText(BillingCalculator.INSTANCE.formatPremium(t.premiumRequests()));
+            todayTokensRow.setVisible(true);
+        } else {
+            long totalTokens = t.inputTokens() + t.outputTokens();
+            if (totalTokens > 0) {
+                todayTokensRowLabel.setText(LABEL_TOKENS);
+                todayTokensValue.setText(
+                    TimerDisplayFormatter.INSTANCE.formatTokenCount(t.inputTokens()) +
+                        TOKENS_IN_OUT_SEP +
+                        TimerDisplayFormatter.INSTANCE.formatTokenCount(t.outputTokens()) +
+                        TOKENS_OUT_SUFFIX);
+                todayTokensRow.setVisible(true);
+            } else {
+                todayTokensRow.setVisible(false);
+            }
+        }
+    }
+
+    /**
+     * Snapshot of today's aggregated turn stats across all agents. Held in an
+     * {@link AtomicReference} so the pooled-thread query and the EDT render path
+     * never trip over each other.
+     */
+    private record TodayTotals(
+        int turns,
+        int toolCalls,
+        long inputTokens,
+        long outputTokens,
+        long linesAdded,
+        long linesRemoved,
+        long durationMs,
+        double premiumRequests
+    ) {
+        static final TodayTotals EMPTY = new TodayTotals(0, 0, 0, 0, 0, 0, 0, 0.0);
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -150,6 +150,8 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         clientSection.setOpaque(false);
         clientSection.add(createSectionHeader("Selected client"));
         clientSection.add(clientRow);
+        leftAlignSection(clientSection);
+        leftAlignChild(clientRow);
 
         // Current turn section — mirrors the Session grid layout (Time row first) so the
         // two visually align. Stays visible after the turn ends, then re-labels as "Last turn".
@@ -173,6 +175,8 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         turnSection.add(turnHeader);
         turnSection.add(turnGrid);
         turnSection.setVisible(false);
+        leftAlignSection(turnSection);
+        leftAlignChild(turnGrid);
 
         // Session stats grid
         JPanel statsGrid = new JPanel(new GridBagLayout());
@@ -209,6 +213,8 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         todaySection.add(createSectionHeader("Today"));
         todaySection.add(todayGrid);
         todaySection.setVisible(false);
+        leftAlignSection(todaySection);
+        leftAlignChild(todayGrid);
 
         // Usage graph — full-width sparkline rendered last in the Monthly quota section.
         // 5x taller than the original 20px to make trends visually readable at a glance.
@@ -245,18 +251,30 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         billingSection.add(billingHeader);
         billingSection.add(billingGrid);
         billingSection.add(graphSection);
+        leftAlignSection(billingSection);
+        leftAlignChild(billingGrid);
+        leftAlignChild(graphSection);
 
         // Assemble the stats content (pinned to the top)
         JPanel content = new JPanel();
         content.setLayout(new BoxLayout(content, BoxLayout.Y_AXIS));
         content.setOpaque(false);
+        JPanel sessionHeader = createSectionHeader("Session");
+        JPanel filesHeader = createSectionHeader("Project files");
         content.add(clientSection);
         content.add(turnSection);
-        content.add(createSectionHeader("Session"));
+        content.add(sessionHeader);
         content.add(statsGrid);
         content.add(todaySection);
         content.add(billingSection);
-        content.add(createSectionHeader("Project files"));
+        content.add(filesHeader);
+        // BoxLayout.Y_AXIS centers children with default CENTER_ALIGNMENT and sizes them
+        // to their preferredWidth — section panels would visually float in the middle of
+        // the side panel. Anchor each direct child of `content` at the left edge and let
+        // it grow to the full width.
+        leftAlignChild(sessionHeader);
+        leftAlignChild(statsGrid);
+        leftAlignChild(filesHeader);
 
         // Project files tree expands to its full preferred height; the outer
         // scroll pane (below) handles scrolling for the entire side panel.
@@ -313,6 +331,27 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         timerPanel.setOnStatsChanged(null);
         billing.setOnBillingChanged(null);
         animationTimer.stop();
+    }
+
+    /**
+     * Anchors a section wrapper panel (BoxLayout.Y_AXIS) at the left edge of its parent
+     * BoxLayout.Y_AXIS container and stretches it horizontally so its left-aligned children
+     * read against the side panel's left margin instead of being centered.
+     */
+    private static void leftAlignSection(JComponent section) {
+        section.setAlignmentX(Component.LEFT_ALIGNMENT);
+        section.setMaximumSize(new Dimension(Integer.MAX_VALUE, Integer.MAX_VALUE));
+    }
+
+    /**
+     * Anchors a single child component within a BoxLayout.Y_AXIS parent at the left edge
+     * and lets it grow to full width while keeping its preferred height. Used for grids
+     * and rows whose preferredWidth is less than the panel's width.
+     */
+    private static void leftAlignChild(JComponent child) {
+        child.setAlignmentX(Component.LEFT_ALIGNMENT);
+        Dimension pref = child.getPreferredSize();
+        child.setMaximumSize(new Dimension(Integer.MAX_VALUE, pref.height));
     }
 
     private JPanel createSectionHeader(String title) {
@@ -635,9 +674,10 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         todayToolsValue.setText(String.valueOf(t.toolCalls()));
         todayToolsRow.setVisible(t.toolCalls() > 0);
         long lines = t.linesAdded() + t.linesRemoved();
-        todayLinesValue.setText(lines > 0
-            ? "+" + t.linesAdded() + " / -" + t.linesRemoved()
-            : "0");
+        String linesHtml = TimerDisplayFormatter.formatDiffCountHtml(
+            (int) t.linesAdded(), (int) t.linesRemoved(),
+            ToolRenderers.INSTANCE.getADD_COLOR(), ToolRenderers.INSTANCE.getDEL_COLOR());
+        todayLinesValue.setText(lines > 0 ? linesHtml : "0");
         todayLinesRow.setVisible(lines > 0);
 
         if (multiplierMode) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -151,6 +151,10 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         clientSection.add(createSectionHeader("Selected client"));
         clientSection.add(clientRow);
         leftAlignSection(clientSection);
+        // Populate the icon + name BEFORE measuring preferred size in leftAlignChild —
+        // otherwise the row is capped at the empty-label height (≈0px) and the value
+        // becomes invisible after the asynchronous refreshClientSection() updates it.
+        refreshClientSection();
         leftAlignChild(clientRow);
 
         // Current turn section — mirrors the Session grid layout (Time row first) so the

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -658,7 +658,17 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
                     TodayTotals totals = new TodayTotals(turns, tools, inTok, outTok,
                         linesAdded, linesRemoved, durMs, premium);
                     todayTotalsRef.set(totals);
-                    SwingUtilities.invokeLater(() -> applyTodayTotals(totals, snap.getMultiplierMode()));
+                    SwingUtilities.invokeLater(() -> {
+                        // Read multiplier mode on the EDT at apply time. The pooled-thread
+                        // DB query may take long enough that the user has switched providers
+                        // by the time we repaint — using the *current* snapshot avoids
+                        // rendering "Today" totals in the stale mode.
+                        SessionStatsSnapshot currentSnap = timerPanel.getSessionSnapshot();
+                        boolean multiplierMode = currentSnap != null
+                            ? currentSnap.getMultiplierMode()
+                            : snap.getMultiplierMode();
+                        applyTodayTotals(totals, multiplierMode);
+                    });
                 } catch (Exception ignored) {
                     // Stats are advisory — never let a query failure crash the UI refresh loop.
                 }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -274,11 +274,29 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
     private JPanel createSectionHeader(JLabel label) {
         label.setFont(smallFont.deriveFont(Font.BOLD));
         label.setForeground(dimColor);
-        JPanel header = new JPanel(new FlowLayout(FlowLayout.LEFT, JBUI.scale(8), 0));
+        JPanel titleRow = new JPanel(new FlowLayout(FlowLayout.LEFT, JBUI.scale(8), 0));
+        titleRow.setOpaque(false);
+        titleRow.setBorder(BorderFactory.createEmptyBorder(
+            JBUI.scale(8), 0, JBUI.scale(2), 0));
+        titleRow.add(label);
+
+        // Hairline separator below the title visually unifies all section headers
+        // across the side panel (Selected client / Active turn / Session / Monthly quota
+        // / Project files) — the same divider treatment makes them read as a single
+        // family of headers regardless of which createSectionHeader variant produced them.
+        JSeparator divider = new JSeparator(SwingConstants.HORIZONTAL);
+        divider.setForeground(JBUI.CurrentTheme.ToolWindow.borderColor());
+        divider.setOpaque(false);
+        divider.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        JPanel header = new JPanel();
+        header.setLayout(new BoxLayout(header, BoxLayout.Y_AXIS));
         header.setOpaque(false);
         header.setBorder(BorderFactory.createEmptyBorder(
-            JBUI.scale(6), 0, JBUI.scale(2), 0));
-        header.add(label);
+            0, JBUI.scale(8), JBUI.scale(2), JBUI.scale(8)));
+        titleRow.setAlignmentX(Component.LEFT_ALIGNMENT);
+        header.add(titleRow);
+        header.add(divider);
         return header;
     }
 
@@ -292,7 +310,14 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         JLabel suffixLabel = new JLabel(suffix);
         suffixLabel.setFont(smallFont);
         suffixLabel.setForeground(dimColor);
-        header.add(suffixLabel);
+        // The header is now a vertical box (title row + divider). The first child
+        // is the title FlowLayout row — append the suffix label there so it appears
+        // inline next to the bold title (matching the original behaviour).
+        if (header.getComponentCount() > 0 && header.getComponent(0) instanceof JPanel titleRow) {
+            titleRow.add(suffixLabel);
+        } else {
+            header.add(suffixLabel);
+        }
         return header;
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -345,6 +345,12 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
         titleRow.setAlignmentX(Component.LEFT_ALIGNMENT);
         header.add(titleRow);
         header.add(divider);
+        // Force the header to fill the full width of its BoxLayout.Y_AXIS parent so
+        // the FlowLayout-LEFT title row can anchor at the left edge. Without this,
+        // BoxLayout sizes the header to its (small) preferredSize and the default
+        // CENTER_ALIGNMENT centers it, making the title appear in the middle.
+        header.setAlignmentX(Component.LEFT_ALIGNMENT);
+        header.setMaximumSize(new Dimension(Integer.MAX_VALUE, header.getPreferredSize().height));
         return header;
     }
 

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitToolsTest.java
@@ -586,9 +586,28 @@ public class GitToolsTest extends BasePlatformTestCase {
         // Add an entry to .gitignore so we can create many tracked-as-ignored files.
         Path gitignore = Path.of(basePath, ".gitignore");
         String existing = Files.exists(gitignore) ? Files.readString(gitignore) : "";
-        Files.writeString(gitignore, existing + "\nignored-dir/\n");
-        // Stage and commit the .gitignore update so the dir creation that follows
-        // is the only "untracked + ignored" change in the working tree.
+        String updated = existing.contains("ignored-dir/")
+            ? existing
+            : existing + (existing.isEmpty() || existing.endsWith("\n") ? "" : "\n") + "ignored-dir/\n";
+        if (!updated.equals(existing)) {
+            Files.writeString(gitignore, updated);
+            // Stage and commit the .gitignore update so the dir creation that follows
+            // is the only "untracked + ignored" change in the working tree — otherwise the
+            // .gitignore edit itself shows up as Modified/Untracked and pollutes the hint.
+            ProcessBuilder addBuilder = new ProcessBuilder("git", "add", ".gitignore");
+            addBuilder.directory(new File(basePath));
+            addBuilder.redirectErrorStream(true);
+            Process addProcess = addBuilder.start();
+            String addOutput = new String(addProcess.getInputStream().readAllBytes());
+            assertEquals("git add .gitignore failed: " + addOutput, 0, addProcess.waitFor());
+
+            ProcessBuilder commitBuilder = new ProcessBuilder("git", "commit", "-m", "test: track ignored dir");
+            commitBuilder.directory(new File(basePath));
+            commitBuilder.redirectErrorStream(true);
+            Process commitProcess = commitBuilder.start();
+            String commitOutput = new String(commitProcess.getInputStream().readAllBytes());
+            assertEquals("git commit for .gitignore failed: " + commitOutput, 0, commitProcess.waitFor());
+        }
         Path ignoredDir = Path.of(basePath, "ignored-dir");
         Files.createDirectories(ignoredDir);
         // 25 ignored files — well above the cap of 10.

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitToolsTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/git/GitToolsTest.java
@@ -576,6 +576,43 @@ public class GitToolsTest extends BasePlatformTestCase {
             result.contains("Untracked") && result.contains("new-untracked.txt"));
     }
 
+    /**
+     * When a directory like {@code .agent-work/} contains hundreds of gitignored
+     * files, the "nothing to commit" hint must truncate the listing instead of
+     * dumping every path. Verifies the cap kicks in at PATH_LIST_LIMIT (10) entries
+     * and the overflow is summarised as "... and N more files".
+     */
+    public void testGitCommitHintTruncatesLongIgnoredList() throws Exception {
+        // Add an entry to .gitignore so we can create many tracked-as-ignored files.
+        Path gitignore = Path.of(basePath, ".gitignore");
+        String existing = Files.exists(gitignore) ? Files.readString(gitignore) : "";
+        Files.writeString(gitignore, existing + "\nignored-dir/\n");
+        // Stage and commit the .gitignore update so the dir creation that follows
+        // is the only "untracked + ignored" change in the working tree.
+        Path ignoredDir = Path.of(basePath, "ignored-dir");
+        Files.createDirectories(ignoredDir);
+        // 25 ignored files — well above the cap of 10.
+        for (int i = 0; i < 25; i++) {
+            Files.writeString(ignoredDir.resolve("file" + i + ".txt"), "ignored " + i + "\n");
+        }
+
+        GitCommitTool tool = new GitCommitTool(getProject());
+        String result = tool.execute(args("message", "test: must not be committed", "all", "false"));
+
+        assertNotNull(result);
+        assertTrue("Expected 'nothing to commit' error, got: " + result,
+            result.startsWith("Error: nothing to commit."));
+        // The truncation suffix must appear, naming exactly the overflow count (15 = 25 - 10).
+        assertTrue("Hint must truncate long lists with '... and N more files', got: " + result,
+            result.contains("... and 15 more files"));
+        // First entry must still appear (proves we kept the head, not just the tail).
+        assertTrue("First ignored entry must appear in the truncated head, got: " + result,
+            result.contains("ignored-dir/file0.txt"));
+        // The full list of 25 must NOT all appear — verify a late entry got dropped.
+        assertFalse("Late entry must have been truncated, got: " + result,
+            result.contains("ignored-dir/file24.txt"));
+    }
+
     // ── GitLogTool — additional format/filter tests ───────────────────────────────
 
     /**


### PR DESCRIPTION
Round of UI/UX polish based on user feedback on chat-panel screenshot (img_1.png).

## Changes

**Input / layout**
- Input frame (A+C) — rounded white frame now encloses side-button rail; outer grey margin reduced on bottom section.
- Shortcut hint overlay — shows only the next-relevant shortcut (`Send` when idle, `Stop && Send` when running).
- Send button styled as a primary (blue) action to match JetBrains conventions.

**Session & stats**
- Stat grid uses a 2-col right-aligned layout so Last turn and Session columns align.
- Hide zero-value stat rows in Session (e.g. `Premium req 0`).
- Graph top hairline removed / integrated.

**Project files**
- Suppress files with unrecognized file types (generic `?` icon) in the Project files section.

**Chat visuals (this follow-up batch)**
- Tool-chip kind colors remapped for semantic clarity: green = read/search (safe), amber = edit/write/move (local mutate), red = delete/execute (destructive/remote). New `--kind-destructive` var, `kind-delete` split with its own red hover.
- Session-divider renders as a full-width separator with its label centered.
- Per-bubble timestamps are collapsed when the previous message shares the same `HH:MM`. A session-divider boundary always re-shows the next timestamp. Wired through both live inserts (`ChatController._insertMsg`) and restore (`BatchRenderer.renderBatchFragment`).
- Markdown tables that overflow their horizontal bounds now show an "Open in editor" overlay button (visible on hover). Clicking opens the full table as a markdown scratch file via the existing `openScratch` bridge — same pipeline as code-block "Open in scratch file". Overflow is detected via ResizeObserver so tables that fit inline stay unobstructed.

## Out of scope (per user)
- Side button tooltips — existing tooltips are enough.
- Toolbar icons — current look is OK.

## Verification
- `./gradlew :plugin-core:compileJava :plugin-core:compileKotlin` — green (`Rebuild plugin-core (clean)`).
- `plugin-core/chat-ui` build green (`npm run build` produces `chat-components.js`, `web-app.js`, `sw.js`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>