### PR TITLE
feat(acp): intercept built-in agent tools and route fall-through commands to a visible IDE terminal

### DIFF
--- a/docs/ACP-TOOL-INTERCEPTION.md
+++ b/docs/ACP-TOOL-INTERCEPTION.md
@@ -1,0 +1,232 @@
+# ACP Tool Interception
+
+> Redirect built-in agent tools (`view`, `edit`, `bash`, …) to MCP equivalents
+> at the ACP layer, **before** they execute. Solves long-standing pain points
+> that `--excluded-tools` and friends could never fix.
+
+**Status:** shipped in PR #319 on branch `feat/acp-tool-interception-v2`.
+**Applies to:** every ACP client we ship (Copilot, Junie, Kiro, OpenCode).
+**Not applicable to:** Claude / Codex (non-ACP — they call MCP directly).
+
+---
+
+## Why
+
+For months we tried to make ACP agents stop using their built-in tools because
+those tools (a) read stale disk files instead of unsaved editor buffers and
+(b) bypass the IDE's VCS/undo plumbing. Every approach failed:
+
+| Mechanism | Result |
+|---|---|
+| `--excluded-tools` / `--available-tools` (Copilot) | Ignored in ACP mode — bug [copilot-cli#556](https://github.com/github/copilot-cli/issues/556). Still broken in v1.0.31. |
+| `excludedTools` in `session/new` (custom ACP extension) | Ignored by Copilot, OpenCode. Junie ≥ v888.212 honours it. |
+| `--deny-tool` (Copilot) | Ignored in ACP mode. |
+| Per-agent `tools:` frontmatter | Ignored in ACP mode. |
+| Permission denial (`DENIED_PERMISSION_KINDS`) | Only catches *write* tools — `view`, `grep`, `glob` auto-execute with no permission step. |
+| Reprimand: auto-approve + inject "[System notice]" into next prompt | Lets the wrong action happen first; only corrects future turns. |
+| Junie pre-launch `.junie/allowlist.json` | Works only for Junie ≥ v888.212. |
+
+See [`docs/bugs/CLI-BUG-556-WORKAROUND.md`](bugs/CLI-BUG-556-WORKAROUND.md)
+and [`docs/JUNIE-TOOL-WORKAROUND.md`](JUNIE-TOOL-WORKAROUND.md) for the full
+history.
+
+## The insight
+
+Built-in agent tools **don't execute inside the agent process**. When Copilot
+runs `view`, `edit`, or `bash`, it round-trips back to us as the standard ACP
+methods `fs/read_text_file`, `fs/write_text_file`, and `terminal/create`.
+
+We already dispatch those in `AcpClient.handleAgentRequest()`. So the fix is
+not to filter, deny, or reprimand — it is simply to **redirect** at the ACP
+layer before dispatching. No PTY proxy, no shell hijacking, no agent
+cooperation needed.
+
+## Architecture
+
+```
+Agent calls a built-in tool (e.g. bash "cat foo.txt")
+  └── ACP: terminal/create
+        → AcpClient.handleAgentRequest()
+            ├── AcpToolInterceptor.tryInterceptTerminalCreate(...)
+            │     ├── matched + MCP succeeded
+            │     │     → synthetic terminalId, return immediately
+            │     └── unmatched OR MCP error
+            │           → return null (fall through)
+            └── falls through to AcpTerminalHandler
+                  → VisibleProcessRunner
+                        ├── Project + Application present
+                        │     → OSProcessHandler + ConsoleViewImpl
+                        │     → registered in IDE Run tool window
+                        └── headless / test
+                              → daemon thread reading process stdout
+```
+
+The same pattern wraps `fs/read_text_file` and `fs/write_text_file`. On any
+MCP error the interceptor returns `null`, and `AcpClient` falls back to the
+real `fsHandler` — so a bug in our MCP layer never breaks the agent.
+
+## What gets intercepted (1:1, no shell parsing risk)
+
+| ACP method | Built-in trigger | Redirected to | Win |
+|---|---|---|---|
+| `fs/read_text_file` | `view` / `read` | MCP `read_file` | Sees unsaved editor edits |
+| `fs/write_text_file` | `edit` / `write` / `create` | MCP `write_file` | Undo stack + format + VCS sync |
+| `terminal/create cat <file>` | `bash cat` | MCP `read_file` | Editor buffer sync |
+| `terminal/create head <file>` | `bash head` | MCP `read_file` (lines 1..10) | Same |
+| `terminal/create git status` | `bash git status` | MCP `git_status` | Branch context, no shell parse |
+
+## What deliberately falls through
+
+Anything we cannot precisely emulate runs as a real OS process via the visible
+runner:
+
+- Any shell metacharacter: `|`, `;`, `&&`, `||`, `$( )`, `<`, `>`, backticks, …
+- Any flag we don't replicate: `cat -n`, `tail` without explicit `-n N`, …
+- Mutating git ops: `commit`, `push`, `rebase`, `merge`, `reset`, …
+- Build tools, package managers, network, anything else.
+
+`ShellCommandSplitter` is the gatekeeper — it returns `null` for any input
+containing a metacharacter we haven't whitelisted, which forces fall-through.
+
+## Visible fall-through terminal
+
+Per the original request, fall-through commands no longer hide in a sub-shell.
+`VisibleProcessRunner` mirrors stdout/stderr to a tab in the IDE **Run** tool
+window, so the user can watch the command live and kill it with the standard
+stop button. Headless test contexts (no `Application` / no `Project`) fall
+back transparently to a daemon stream-reader thread.
+
+## Files
+
+| Path | Role |
+|---|---|
+| `acp/client/intercept/AcpToolInterceptor.java` | Central interception logic. `@Nullable` returns so AcpClient can fall back to `fsHandler`. |
+| `acp/client/intercept/ShellCommandSplitter.java` | Argv tokenizer rejecting unsafe metacharacters; supports single/double quotes and backslash escapes. |
+| `acp/client/intercept/VisibleProcessRunner.java` | Wraps `OSProcessHandler` + `ConsoleViewImpl` + `RunContentDescriptor`; degrades to daemon reader when no `Application`/`Project`. |
+| `acp/client/AcpTerminalHandler.java` | Always uses `VisibleProcessRunner`. `ManagedTerminal` no longer owns its own reader thread. |
+| `acp/client/AcpClient.java` | Holds the interceptor; `handleAgentRequest()` switch uses `redirected != null ? redirected : fsHandler.xxx()`. |
+
+## Tests
+
+- 14 `ShellCommandSplitterTest` cases covering quoting, escaping, every
+  rejected metacharacter, blank input, and trailing whitespace.
+- 3 `AcpToolInterceptorTest` cases for `isMcpError`.
+- All 622 ACP tests pass; full plugin-core suite unchanged (one pre-existing
+  flaky `EmbeddingServiceTest` on master, unrelated).
+
+---
+
+## Follow-ups
+
+These are split between (1) **dead-code removal** that becomes possible *because*
+interception exists, and (2) **expansion** of the interception surface itself.
+
+### A. Dead-code removal (this is now ~~obsolete~~ logic)
+
+Interception happens *before* the built-in tool runs. The previous defenses ran
+*after* it ran and tried to retroactively undo or correct the damage. With
+interception in place these layers are largely (sometimes wholly) obsolete:
+
+- **`CopilotClient.misusedBuiltInTools` + `beforeSendPrompt()` reprimand**
+  (`CopilotClient.java:113, 535–567`).
+  Records intercepted built-in tool calls and prepends a "[System notice] use
+  MCP instead" block to the next prompt. Since the offending call now resolves
+  via MCP transparently, there is nothing to reprimand. **Candidate for full
+  removal** once we confirm telemetry shows zero misused-built-in events.
+
+- **`PsiBridgeService.setPendingNudge` / `addOnNudgeConsumed` plumbing**
+  used only by the reprimand path above. Once the reprimand is gone, these
+  hooks have no other call sites — search and delete.
+
+- **`AcpClient.handleBlockedTool` ⇒ `excludeAgentBuiltInTools` denial**
+  (`AcpClient.java:1611–1652`).
+  This denies built-in tools at the permission layer. With interception, the
+  built-in tool *succeeds* via MCP rather than being denied — which is what
+  the user actually wanted in the first place. **Decision needed:** keep
+  denial as a "strict mode" for tools we explicitly *don't* want intercepted
+  (e.g. dangerous `bash`), or remove and rely entirely on interception +
+  fall-through-to-visible-terminal.
+
+- **`AgentProfile.excludeAgentBuiltInTools` setting** (`AgentProfile.java:95`).
+  The whole point of this knob was "stop the agent using its built-in tools".
+  Interception achieves that automatically and silently. The setting can either
+  be (a) removed, (b) re-purposed as "force fall-through to visible terminal
+  even for intercept-eligible commands" (rare, but useful for debugging), or
+  (c) left as a kill-switch that disables interception itself for users who
+  hit a regression.
+
+- **`JunieClient` `.junie/allowlist.json` writer** (`JunieClient.java:149–180`).
+  Pre-launch deny-list for Junie ≥ v888.212. Still useful as belt-and-braces
+  defense (it stops the agent even *trying* the tool, saving a network round
+  trip), but no longer load-bearing. Keep, but stop documenting it as the
+  primary mitigation.
+
+- **`default-startup-instructions.md` tool-policy block.**
+  The aggressive "NEVER use these tools" prompt block was the only thing
+  bending Opus 4.7. With interception, an agent that ignores the policy gets
+  the right answer anyway. The block can be downgraded from "critical" to a
+  short "note: built-in tools are silently redirected to MCP equivalents,
+  prefer MCP names for clarity" so the model still emits useful tool names in
+  its plans.
+
+- **`detectSubAgentWriteTool` / `detectSubAgentGitWrite`** (Copilot sub-agent
+  guards). These exist because sub-agents don't see the policy file. With
+  interception, sub-agents calling `edit` / `bash git commit` succeed via MCP
+  / `git_*` and the guards become moot for the safe cases. They should remain
+  for the *destructive* fall-through cases (e.g. `bash rm -rf`) but can drop
+  the per-tool name list.
+
+- **`CopilotClient.EXCLUDED_BUILTIN_TOOLS` + the `--excluded-tools` flag.**
+  No longer load-bearing. Can be deleted or kept as forward-compat for the
+  day [#556](https://github.com/github/copilot-cli/issues/556) finally lands.
+
+- **External-tool warning emoji (⚠ on tool chips).** Currently signals "the
+  agent ignored our prompt and used a built-in tool". With interception the
+  built-in tool *was* intercepted, so the chip should either (a) suppress the
+  badge entirely or (b) flip to a different visual (e.g. ↻ "redirected") to
+  show the user we caught it.
+
+> **Process note:** none of the removals should land in this PR. They each
+> need a separate PR with a few sessions of telemetry / sandbox runs to
+> confirm the safety net was no longer doing real work.
+
+### B. Expanding the interception surface
+
+- **More git read ops:** `git log`, `git diff`, `git show`, `git branch`,
+  `git remote`, `git tag`, `git stash list`, `git status --short`. Each maps
+  cleanly to an existing MCP `git_*` tool.
+- **`grep` / `rg` → MCP `search_text`.** Needs a small flag-parser (the agent
+  passes `-i`, `-n`, `-C`, glob via `--include`, etc.). Higher payoff than
+  `cat` because it gives us regex + IDE indexing.
+- **`find` / `fd` → MCP `list_project_files` (glob).** Trickier flag surface;
+  start with `find <dir> -name <pattern>`.
+- **`ls` → MCP `list_directory_tree`.** Only intercept the no-flag form.
+- **`tail -n N <file>` → MCP `read_file` (last N lines).** Currently falls
+  through because there's no sensible default; with `-n N` it's a 1:1 mapping.
+- **`wc -l <file>` → MCP `read_file` + linecount.** Marginal.
+- **OpenCode validation.** OpenCode's ACP semantics are slightly different
+  (its agents auto-execute more eagerly). Run the four-client matrix to
+  confirm interception fires for OpenCode's `view`/`edit`/`bash` analogues.
+- **Junie validation.** Junie's `read`/`write`/`bash` should already flow
+  through `fs/read_text_file` / `fs/write_text_file` / `terminal/create`,
+  but verify before dropping the prompt-engineering safety net.
+- **Telemetry:** emit a counter per `(client, intercepted_tool, outcome)`
+  so we can quantify how often interception fires per session. Required
+  before removing any of the layers in section A.
+- **Sub-agent reach:** confirm interception fires for *sub-agent* tool calls
+  too (Copilot's `task` tool spawns isolated sub-agents). The dispatch path
+  is the same `handleAgentRequest()`, so it should — but verify.
+
+## References
+
+- PR: [#319](https://github.com/catatafishen/agentbridge/pull/319)
+- Branch: `feat/acp-tool-interception-v2`
+- Related docs:
+  - [`docs/bugs/CLI-BUG-556-WORKAROUND.md`](bugs/CLI-BUG-556-WORKAROUND.md)
+  - [`docs/JUNIE-TOOL-WORKAROUND.md`](JUNIE-TOOL-WORKAROUND.md)
+  - [`docs/JUNIE-CLI-TOOL-FILTERING.md`](JUNIE-CLI-TOOL-FILTERING.md)
+  - [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) — overall ACP/MCP layering
+- Upstream issues this sidesteps: copilot-cli
+  [#556](https://github.com/github/copilot-cli/issues/556),
+  [#1574](https://github.com/github/copilot-cli/issues/1574),
+  [#2059](https://github.com/github/copilot-cli/issues/2059).

--- a/docs/ACP-TOOL-INTERCEPTION.md
+++ b/docs/ACP-TOOL-INTERCEPTION.md
@@ -72,8 +72,22 @@ real `fsHandler` — so a bug in our MCP layer never breaks the agent.
 | `fs/read_text_file` | `view` / `read` | MCP `read_file` | Sees unsaved editor edits |
 | `fs/write_text_file` | `edit` / `write` / `create` | MCP `write_file` | Undo stack + format + VCS sync |
 | `terminal/create cat <file>` | `bash cat` | MCP `read_file` | Editor buffer sync |
-| `terminal/create head <file>` | `bash head` | MCP `read_file` (lines 1..10) | Same |
+| `terminal/create head [-n N] <file>` | `bash head` | MCP `read_file` (lines 1..N, default 10) | Same |
+| `terminal/create grep -F/-E <pat> [file]`, `egrep`, `fgrep` | `bash grep` | MCP `search_text` | Regex + IDE index, POSIX exit codes |
+| `terminal/create rg <pat>` (with `-F`/`-i`/`--glob`) | `bash rg` | MCP `search_text` | Same |
 | `terminal/create git status` | `bash git status` | MCP `git_status` | Branch context, no shell parse |
+| `terminal/create git diff [--staged] [--stat] [path]` | `bash git diff` | MCP `git_diff` | Auto-fetch on `origin/*` refs |
+| `terminal/create git log [--oneline] [-n N] [path]` | `bash git log` | MCP `git_log` | Same |
+| `terminal/create git branch [-a]` | `bash git branch` | MCP `git_branch` | List remote/local |
+
+Plain `grep` (without `-F` or `-E`) is **not** intercepted — POSIX BRE has
+incompatible semantics with Java regex (used by `search_text`). Agents that
+run plain `grep` get the real OS process via the visible terminal.
+
+`ls`, `find`, and `tail` are **not** intercepted: `list_project_files` is
+recursive and file-only (can't model `ls file`), `find` has a huge flag
+surface, and `tail` would need a 2-step read (file length, then range)
+because `read_file` truncates large files. All three fall through cleanly.
 
 ## What deliberately falls through
 
@@ -100,8 +114,10 @@ back transparently to a daemon stream-reader thread.
 
 | Path | Role |
 |---|---|
-| `acp/client/intercept/AcpToolInterceptor.java` | Central interception logic. `@Nullable` returns so AcpClient can fall back to `fsHandler`. |
-| `acp/client/intercept/ShellCommandSplitter.java` | Argv tokenizer rejecting unsafe metacharacters; supports single/double quotes and backslash escapes. |
+| `acp/client/intercept/AcpToolInterceptor.java` | Central interception logic. `@Nullable` returns so AcpClient can fall back to `fsHandler`. Uses ACP `args[]` array directly when present (no re-tokenization). |
+| `acp/client/intercept/ShellRedirectPlanner.java` | Pure static classifier: `argv → RedirectPlan?`. All per-command flag parsing lives here. Project-free for testability. |
+| `acp/client/intercept/RedirectPlan.java` | Immutable record carrying tool name, args, optional post-processor (e.g. strip `search_text` header), and exit-code function (e.g. grep returns 1 on no matches). |
+| `acp/client/intercept/ShellCommandSplitter.java` | Argv tokenizer rejecting unsafe metacharacters; supports single/double quotes and backslash escapes. Used as fallback when ACP only sends `command` (no `args[]`). |
 | `acp/client/intercept/VisibleProcessRunner.java` | Wraps `OSProcessHandler` + `ConsoleViewImpl` + `RunContentDescriptor`; degrades to daemon reader when no `Application`/`Project`. |
 | `acp/client/AcpTerminalHandler.java` | Always uses `VisibleProcessRunner`. `ManagedTerminal` no longer owns its own reader thread. |
 | `acp/client/AcpClient.java` | Holds the interceptor; `handleAgentRequest()` switch uses `redirected != null ? redirected : fsHandler.xxx()`. |
@@ -111,7 +127,10 @@ back transparently to a daemon stream-reader thread.
 - 14 `ShellCommandSplitterTest` cases covering quoting, escaping, every
   rejected metacharacter, blank input, and trailing whitespace.
 - 3 `AcpToolInterceptorTest` cases for `isMcpError`.
-- All 622 ACP tests pass; full plugin-core suite unchanged (one pre-existing
+- 51 `ShellRedirectPlannerTest` cases covering happy paths, fall-throughs,
+  flag-parsing edge cases (combined short flags, `--lines=N`, `--glob=`,
+  `--` separator), exit-code semantics, and `search_text` header stripping.
+- All ACP tests pass; full plugin-core suite unchanged (one pre-existing
   flaky `EmbeddingServiceTest` on master, unrelated).
 
 ---
@@ -192,17 +211,27 @@ interception in place these layers are largely (sometimes wholly) obsolete:
 
 ### B. Expanding the interception surface
 
-- **More git read ops:** `git log`, `git diff`, `git show`, `git branch`,
-  `git remote`, `git tag`, `git stash list`, `git status --short`. Each maps
-  cleanly to an existing MCP `git_*` tool.
-- **`grep` / `rg` → MCP `search_text`.** Needs a small flag-parser (the agent
-  passes `-i`, `-n`, `-C`, glob via `--include`, etc.). Higher payoff than
-  `cat` because it gives us regex + IDE indexing.
+Already shipped in the follow-up commit:
+- ✅ `git diff`, `git log`, `git branch` (read-only forms)
+- ✅ `head -n N <file>`
+- ✅ `grep -F/-E`, `egrep`, `fgrep`, `rg` → `search_text`
+
+Still on the list:
+- **More git read ops:** `git show`, `git remote -v`, `git tag`,
+  `git stash list`, `git status --short`. Each maps cleanly to an existing
+  MCP `git_*` tool.
+- **`rg <pat> <path>`** — currently rejected because `search_text` doesn't
+  accept a directory scope. Could map `<path>` to a `file_pattern` glob like
+  `<path>/**` if telemetry shows agents commonly write the path form.
+- **Plain `grep`** — needs BRE → Java-regex translation (`\(` → `(`, `+`/`?`
+  literal vs metachar). Doable but brittle; defer until we see a real demand.
 - **`find` / `fd` → MCP `list_project_files` (glob).** Trickier flag surface;
   start with `find <dir> -name <pattern>`.
-- **`ls` → MCP `list_directory_tree`.** Only intercept the no-flag form.
-- **`tail -n N <file>` → MCP `read_file` (last N lines).** Currently falls
-  through because there's no sensible default; with `-n N` it's a 1:1 mapping.
+- **`ls` → MCP `list_directory_tree`.** Only the no-flag form, and only when
+  the target is a directory (semantics differ for `ls file`).
+- **`tail -n N <file>` → MCP `read_file` (last N lines).** Requires a
+  2-step approach because `read_file` truncates large files to the first
+  ~2000 lines; need to fetch the line count first, then request the range.
 - **`wc -l <file>` → MCP `read_file` + linecount.** Marginal.
 - **OpenCode validation.** OpenCode's ACP semantics are slightly different
   (its agents auto-execute more eagerly). Run the four-client matrix to

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpClient.java
@@ -98,6 +98,7 @@ public abstract class AcpClient extends AbstractAgentClient {
     protected final Project project;
     private final AcpFileSystemHandler fsHandler;
     private final AcpTerminalHandler terminalHandler;
+    private final com.github.catatafishen.agentbridge.acp.client.intercept.AcpToolInterceptor interceptor;
 
     private @Nullable Process agentProcess;
     private @Nullable InitializeResponse capabilities;
@@ -167,6 +168,7 @@ public abstract class AcpClient extends AbstractAgentClient {
         this.project = project;
         this.fsHandler = new AcpFileSystemHandler(project);
         this.terminalHandler = new AcpTerminalHandler(project);
+        this.interceptor = new com.github.catatafishen.agentbridge.acp.client.intercept.AcpToolInterceptor(project);
     }
 
     // ═══════════════════════════════════════════════════
@@ -308,6 +310,7 @@ public abstract class AcpClient extends AbstractAgentClient {
             availableConfigOptions.clear();
             pendingPermissionRequests.clear();
             terminalHandler.releaseAll();
+            interceptor.releaseAll();
             loadedSessionHistory = null;
             updateConsumer = null;
         }
@@ -1488,14 +1491,42 @@ public abstract class AcpClient extends AbstractAgentClient {
     protected void handleAgentRequest(JsonElement id, JsonRpcTransport.IncomingRequest request) {
         switch (request.method()) {
             case "session/request_permission" -> handlePermissionRequest(id, request.params());
-            case "fs/read_text_file" -> handleFsRequest(id, () -> fsHandler.readTextFile(request.params()));
-            case "fs/write_text_file" -> handleFsRequest(id, () -> fsHandler.writeTextFile(request.params()));
-            case "terminal/create" -> handleTerminalRequest(id, () -> terminalHandler.create(request.params()));
-            case "terminal/output" -> handleTerminalRequest(id, () -> terminalHandler.output(request.params()));
-            case "terminal/wait_for_exit" ->
-                handleTerminalRequest(id, () -> terminalHandler.waitForExit(request.params()));
-            case "terminal/kill" -> handleTerminalRequest(id, () -> terminalHandler.kill(request.params()));
-            case "terminal/release" -> handleTerminalRequest(id, () -> terminalHandler.release(request.params()));
+            case "fs/read_text_file" -> handleFsRequest(id, () -> {
+                JsonObject redirected = interceptor.interceptRead(request.params());
+                return redirected != null ? redirected : fsHandler.readTextFile(request.params());
+            });
+            case "fs/write_text_file" -> handleFsRequest(id, () -> {
+                JsonObject redirected = interceptor.interceptWrite(request.params());
+                return redirected != null ? redirected : fsHandler.writeTextFile(request.params());
+            });
+            case "terminal/create" -> handleTerminalRequest(id, () -> {
+                JsonObject intercepted = interceptor.tryInterceptTerminalCreate(request.params());
+                return intercepted != null ? intercepted : terminalHandler.create(request.params());
+            });
+            case "terminal/output" -> handleTerminalRequest(id, () -> {
+                String tid = request.params().get("terminalId").getAsString();
+                return interceptor.ownsTerminal(tid)
+                    ? interceptor.output(tid)
+                    : terminalHandler.output(request.params());
+            });
+            case "terminal/wait_for_exit" -> handleTerminalRequest(id, () -> {
+                String tid = request.params().get("terminalId").getAsString();
+                return interceptor.ownsTerminal(tid)
+                    ? interceptor.waitForExit(tid)
+                    : terminalHandler.waitForExit(request.params());
+            });
+            case "terminal/kill" -> handleTerminalRequest(id, () -> {
+                String tid = request.params().get("terminalId").getAsString();
+                return interceptor.ownsTerminal(tid)
+                    ? interceptor.kill(tid)
+                    : terminalHandler.kill(request.params());
+            });
+            case "terminal/release" -> handleTerminalRequest(id, () -> {
+                String tid = request.params().get("terminalId").getAsString();
+                return interceptor.ownsTerminal(tid)
+                    ? interceptor.release(tid)
+                    : terminalHandler.release(request.params());
+            });
             default -> {
                 LOG.warn("Unknown agent request: " + request.method());
                 transport.sendError(id, JsonRpcErrorCodes.METHOD_NOT_FOUND, "Method not found: " + request.method());

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpTerminalHandler.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpTerminalHandler.java
@@ -1,17 +1,18 @@
 package com.github.catatafishen.agentbridge.acp.client;
 
+import com.github.catatafishen.agentbridge.acp.client.intercept.VisibleProcessRunner;
 import com.github.catatafishen.agentbridge.settings.ShellEnvironment;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.UUID;
@@ -20,10 +21,14 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Handles ACP terminal methods: {@code terminal/create}, {@code terminal/output},
  * {@code terminal/wait_for_exit}, {@code terminal/kill}, and {@code terminal/release}.
- * <p>
- * Per the ACP spec, terminals represent shell command executions that the agent
+ *
+ * <p>Per the ACP spec, terminals represent shell command executions that the agent
  * can create and manage. Each terminal has a unique ID, captures output, and
  * tracks exit status.
+ *
+ * <p>Fall-through commands (those not redirected to MCP equivalents by
+ * {@code AcpToolInterceptor}) are launched via {@link VisibleProcessRunner} so the
+ * user can see them live in the Run tool window — there is no hidden execution path.
  *
  * @see <a href="https://agentclientprotocol.com/protocol/terminals">ACP Terminals</a>
  */
@@ -33,14 +38,19 @@ final class AcpTerminalHandler {
     private static final int DEFAULT_OUTPUT_BYTE_LIMIT = 1_048_576; // 1 MB
 
     private final Project project;
+    private final VisibleProcessRunner visibleRunner;
     private final Map<String, ManagedTerminal> terminals = new ConcurrentHashMap<>();
 
     AcpTerminalHandler(Project project) {
         this.project = project;
+        this.visibleRunner = new VisibleProcessRunner(project);
     }
 
     /**
-     * {@code terminal/create} — start a command in a new terminal.
+     * {@code terminal/create} — start a command in a new terminal that the user can see in
+     * the IDE Run tool window. Output is mirrored to both the visible console and the ACP
+     * output buffer so the agent observes a normal stdout stream while the user can watch
+     * the process run.
      *
      * @return result with {@code terminalId}
      */
@@ -52,20 +62,8 @@ final class AcpTerminalHandler {
         int outputByteLimit = params.has("outputByteLimit") && params.get("outputByteLimit").isJsonPrimitive()
             ? params.get("outputByteLimit").getAsInt() : DEFAULT_OUTPUT_BYTE_LIMIT;
 
-        // Build command line: [command, ...args]
-        String[] cmdArray = new String[1 + args.length];
-        cmdArray[0] = command;
-        System.arraycopy(args, 0, cmdArray, 1, args.length);
-
-        ProcessBuilder pb = new ProcessBuilder(cmdArray);
-        pb.redirectErrorStream(true);
-        if (cwd != null) {
-            pb.directory(new File(cwd));
-        }
-
-        // Apply environment variables from params
+        Map<String, String> env = new HashMap<>(ShellEnvironment.getEnvironment());
         if (params.has("env") && params.get("env").isJsonArray()) {
-            Map<String, String> env = pb.environment();
             for (JsonElement el : params.getAsJsonArray("env")) {
                 if (el.isJsonObject()) {
                     JsonObject envVar = el.getAsJsonObject();
@@ -78,22 +76,30 @@ final class AcpTerminalHandler {
             }
         }
 
-        // Merge shell environment for PATH resolution
-        pb.environment().putAll(
-            ShellEnvironment.getEnvironment());
-
         String terminalId = "term_" + UUID.randomUUID().toString().substring(0, 12);
-        Process process = pb.start();
+        ManagedTerminal terminal = new ManagedTerminal(terminalId, outputByteLimit);
 
-        ManagedTerminal terminal = new ManagedTerminal(terminalId, process, outputByteLimit);
-        terminal.startOutputCapture();
+        GeneralCommandLine cmd = VisibleProcessRunner.buildCommandLine(command, args, cwd, env);
+
+        String tabTitle = "Agent: " + truncate(command + " " + String.join(" ", args), 60);
+        Process process;
+        try {
+            process = visibleRunner.start(cmd, tabTitle, terminal::appendOutput);
+        } catch (ExecutionException e) {
+            throw new IOException("Failed to start terminal command: " + e.getMessage(), e);
+        }
+        terminal.attachProcess(process);
         terminals.put(terminalId, terminal);
 
-        LOG.info("Created terminal " + terminalId + ": " + String.join(" ", cmdArray));
+        LOG.info("Created visible terminal " + terminalId + ": " + cmd.getCommandLineString());
 
         JsonObject result = new JsonObject();
         result.addProperty("terminalId", terminalId);
         return result;
+    }
+
+    private static String truncate(String s, int max) {
+        return s.length() <= max ? s : s.substring(0, max - 1) + "…";
     }
 
     /**
@@ -131,7 +137,6 @@ final class AcpTerminalHandler {
         boolean exited = terminal.process.waitFor(WAIT_FOR_EXIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         if (!exited) {
             terminal.process.destroyForcibly();
-            terminal.stopOutputCapture();
             terminals.remove(terminalId);
             LOG.warn("terminal/wait_for_exit timed out after " + WAIT_FOR_EXIT_TIMEOUT_SECONDS
                 + "s for terminal " + terminalId + " — process forcibly destroyed and resources released");
@@ -173,7 +178,6 @@ final class AcpTerminalHandler {
         if (terminal.process.isAlive()) {
             terminal.process.destroyForcibly();
         }
-        terminal.stopOutputCapture();
         LOG.info("Released terminal " + terminalId);
 
         return new JsonObject();
@@ -188,7 +192,6 @@ final class AcpTerminalHandler {
             if (terminal.process.isAlive()) {
                 terminal.process.destroyForcibly();
             }
-            terminal.stopOutputCapture();
         }
         terminals.clear();
     }
@@ -233,54 +236,32 @@ final class AcpTerminalHandler {
     // ── Managed terminal ─────────────────────────────────────────────────
 
     /**
-     * Tracks a running process with its captured output.
+     * Tracks a running process with its captured output. Output is fed in by
+     * {@link VisibleProcessRunner}'s {@code OutputSink} so there is exactly one
+     * reader on the process input stream (the {@link com.intellij.execution.process.OSProcessHandler}
+     * inside the runner).
      */
     private static final class ManagedTerminal {
         final String id;
-        final Process process;
         final int outputByteLimit;
+        volatile Process process;
 
         private final StringBuilder outputBuffer = new StringBuilder();
         private volatile boolean truncated;
-        private volatile Thread captureThread;
 
-        ManagedTerminal(String id, Process process, int outputByteLimit) {
+        ManagedTerminal(String id, int outputByteLimit) {
             this.id = id;
-            this.process = process;
             this.outputByteLimit = outputByteLimit;
         }
 
-        void startOutputCapture() {
-            captureThread = Thread.ofVirtual().name("acp-terminal-" + id).start(() -> {
-                try (InputStream is = process.getInputStream()) {
-                    byte[] buf = new byte[4096];
-                    int n;
-                    while ((n = is.read(buf)) != -1) {
-                        String chunk = new String(buf, 0, n, StandardCharsets.UTF_8);
-                        appendOutput(chunk);
-                    }
-                } catch (IOException e) {
-                    if (process.isAlive()) {
-                        LOG.warn("Output capture error for terminal " + id + ": " + e.getMessage());
-                    }
-                }
-            });
-        }
-
-        void stopOutputCapture() {
-            Thread t = captureThread;
-            if (t != null) {
-                t.interrupt();
-                captureThread = null;
-            }
+        void attachProcess(Process process) {
+            this.process = process;
         }
 
         synchronized void appendOutput(String chunk) {
             outputBuffer.append(chunk);
-            // Truncate from beginning if over limit (per ACP spec)
             if (outputBuffer.length() > outputByteLimit) {
                 int excess = outputBuffer.length() - outputByteLimit;
-                // Find next character boundary (ensure valid UTF-8)
                 outputBuffer.delete(0, excess);
                 truncated = true;
             }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/intercept/AcpToolInterceptor.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/intercept/AcpToolInterceptor.java
@@ -1,0 +1,276 @@
+package com.github.catatafishen.agentbridge.acp.client.intercept;
+
+import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Intercepts ACP file system and terminal requests, redirecting them to equivalent
+ * MCP tools when a safe 1:1 mapping exists.
+ *
+ * <p><b>Why this exists:</b> ACP agents (Copilot, Junie, Kiro, OpenCode) execute their
+ * built-in tools by sending {@code fs/read_text_file}, {@code fs/write_text_file}, and
+ * {@code terminal/create} requests <em>back</em> to the client. Some agents ignore tool
+ * exclusion lists (Copilot bug #556) or have no exclusion mechanism at all (Junie).
+ * By intercepting these requests at the client, we transparently redirect them to our
+ * MCP equivalents — getting editor-buffer reads/writes, undo stack, VCS sync, etc. —
+ * regardless of how the agent decides to call the tool.
+ *
+ * <p>For commands that don't map cleanly, the request falls through to the original
+ * handler so the user can still see the command run in a visible IDE terminal.
+ */
+public final class AcpToolInterceptor {
+
+    private static final Logger LOG = Logger.getInstance(AcpToolInterceptor.class);
+    private static final String SYNTHETIC_TERMINAL_PREFIX = "intercept_";
+
+    private final @Nullable Project project;
+    private final Map<String, InterceptedTerminal> terminals = new ConcurrentHashMap<>();
+
+    /**
+     * Cached tool result + exit code for a synthesized terminal.
+     */
+    private record InterceptedTerminal(String output, int exitCode) {
+    }
+
+    public AcpToolInterceptor(@Nullable Project project) {
+        this.project = project;
+    }
+
+    // ─── fs/read_text_file ────────────────────────────────────────────────
+
+    /**
+     * Tries to intercept {@code fs/read_text_file} by routing it through the
+     * {@code read_file} MCP tool. The two are 1:1 in semantics, so this gives
+     * the agent editor-buffer reads (with unsaved changes) and proper line-range
+     * support for free.
+     *
+     * @return the synthesized response, or {@code null} when the MCP tool failed
+     * and the caller should fall back to the original handler
+     */
+    public @Nullable JsonObject interceptRead(@NotNull JsonObject params) {
+        JsonObject mcpArgs = new JsonObject();
+        if (params.has("path")) mcpArgs.add("path", params.get("path"));
+        if (params.has("line")) mcpArgs.addProperty("start_line", params.get("line").getAsInt());
+        if (params.has("limit")) {
+            int start = params.has("line") ? params.get("line").getAsInt() : 1;
+            int end = start + params.get("limit").getAsInt() - 1;
+            mcpArgs.addProperty("end_line", end);
+        }
+
+        String result = callMcp("read_file", mcpArgs);
+        if (isMcpError(result)) {
+            LOG.warn("read_file MCP redirect failed, falling back to direct VFS read: " + result);
+            return null;
+        }
+
+        JsonObject response = new JsonObject();
+        response.addProperty("content", result);
+        return response;
+    }
+
+    // ─── fs/write_text_file ───────────────────────────────────────────────
+
+    /**
+     * Tries to intercept {@code fs/write_text_file} by routing it through the
+     * {@code write_file} MCP tool. This adds undo support, deferred auto-format,
+     * and VFS notifications that direct file writes bypass.
+     *
+     * @return an empty response on success (ACP returns null but the dispatch layer
+     * treats an empty {@link JsonObject} the same), or {@code null} when the
+     * MCP tool failed and the caller should fall back to the original handler
+     */
+    public @Nullable JsonObject interceptWrite(@NotNull JsonObject params) {
+        JsonObject mcpArgs = new JsonObject();
+        if (params.has("path")) mcpArgs.add("path", params.get("path"));
+        if (params.has("content")) mcpArgs.add("content", params.get("content"));
+
+        String result = callMcp("write_file", mcpArgs);
+        if (isMcpError(result)) {
+            LOG.warn("write_file MCP redirect failed, falling back to direct VFS write: " + result);
+            return null;
+        }
+        return new JsonObject();
+    }
+
+    // ─── terminal/create ──────────────────────────────────────────────────
+
+    /**
+     * Try to redirect a {@code terminal/create} request to an MCP tool.
+     *
+     * @return a synthetic {@code {terminalId}} response when the command was redirected
+     * (the result is buffered and served by {@link #output}/{@link #waitForExit}),
+     * or {@code null} when the command should run in a real terminal
+     */
+    public @Nullable JsonObject tryInterceptTerminalCreate(@NotNull JsonObject params) {
+        String command = params.has("command") && params.get("command").isJsonPrimitive()
+            ? params.get("command").getAsString() : null;
+        if (command == null || command.isBlank()) return null;
+
+        // Build full argv: [command, ...args] then re-join for tokenization safety.
+        // Agents pass either {command: "git status"} or {command: "git", args: ["status"]}.
+        StringBuilder full = new StringBuilder(command);
+        if (params.has("args") && params.get("args").isJsonArray()) {
+            for (var el : params.getAsJsonArray("args")) {
+                if (el.isJsonPrimitive()) full.append(' ').append(el.getAsString());
+            }
+        }
+
+        List<String> tokens = ShellCommandSplitter.tokenize(full.toString());
+        if (tokens == null || tokens.isEmpty()) {
+            // Shell metacharacters present, or unbalanced quotes — too risky to redirect
+            return null;
+        }
+
+        String redirectResult = tryRedirect(tokens);
+        if (redirectResult == null) return null;
+
+        String terminalId = SYNTHETIC_TERMINAL_PREFIX + UUID.randomUUID().toString().substring(0, 12);
+        int exitCode = isMcpError(redirectResult) ? 1 : 0;
+        terminals.put(terminalId, new InterceptedTerminal(redirectResult, exitCode));
+        LOG.info("Intercepted terminal/create: '" + full + "' -> synthetic " + terminalId);
+
+        JsonObject result = new JsonObject();
+        result.addProperty("terminalId", terminalId);
+        return result;
+    }
+
+    /**
+     * Resolve {@code argv} to an MCP tool result, or {@code null} if no safe mapping exists.
+     * Each redirect must be unambiguous — the tokens before the file/path/refspec arguments
+     * must exactly identify a single MCP tool.
+     */
+    private @Nullable String tryRedirect(@NotNull List<String> argv) {
+        String head = argv.get(0).toLowerCase(Locale.ROOT);
+
+        // Strip leading "/usr/bin/" or "./" style prefixes from the binary name
+        int slash = head.lastIndexOf('/');
+        if (slash >= 0 && slash + 1 < head.length()) head = head.substring(slash + 1);
+
+        return switch (head) {
+            case "cat", "head", "tail" -> redirectFileRead(argv, head);
+            // Git is well-defined; we only redirect the simplest read-only forms here. Mutating
+            // git operations (commit, push, rebase) are deliberately left to the visible terminal
+            // so the user sees them and the existing GitCommitTool review-gate behaviour is not
+            // bypassed for agent-issued commits.
+            case "git" -> redirectGit(argv);
+            default -> null;
+        };
+    }
+
+    private @Nullable String redirectFileRead(@NotNull List<String> argv, @NotNull String head) {
+        // Only redirect the simple `cat <file>` form. Any flag (-n, --number, -A, ...) means
+        // the agent wants formatting we don't replicate; let it run in the real terminal.
+        if (argv.size() != 2) return null;
+        String path = argv.get(1);
+        if (path.startsWith("-")) return null;
+
+        JsonObject mcpArgs = new JsonObject();
+        mcpArgs.addProperty("path", path);
+        if ("head".equals(head)) {
+            mcpArgs.addProperty("start_line", 1);
+            mcpArgs.addProperty("end_line", 10);
+        }
+        // tail: without a default line count it would behave like cat; let it through to terminal
+        if ("tail".equals(head)) return null;
+        return callMcp("read_file", mcpArgs);
+    }
+
+    private @Nullable String redirectGit(@NotNull List<String> argv) {
+        if (argv.size() < 2) return null;
+        String sub = argv.get(1).toLowerCase(Locale.ROOT);
+
+        // Read-only operations only — see comment in tryRedirect. Each entry must accept no
+        // extra positional args (or the args we forward must be safe for the matching MCP tool).
+        return switch (sub) {
+            case "status" -> callMcp("git_status", new JsonObject());
+            // git log / git diff / git show / git branch / git remote / git tag / git stash list
+            // could be added here once we have a clean argument-mapping helper. Holding off in this
+            // first pass to keep the surface area small and predictable.
+            default -> null;
+        };
+    }
+
+    // ─── synthetic terminal lifecycle ────────────────────────────────────
+
+    public boolean ownsTerminal(@NotNull String terminalId) {
+        return terminals.containsKey(terminalId);
+    }
+
+    public @NotNull JsonObject output(@NotNull String terminalId) {
+        InterceptedTerminal t = requireTerminal(terminalId);
+        JsonObject result = new JsonObject();
+        result.addProperty("output", t.output());
+        result.addProperty("truncated", false);
+        JsonObject exitStatus = new JsonObject();
+        exitStatus.addProperty("exitCode", t.exitCode());
+        exitStatus.add("signal", null);
+        result.add("exitStatus", exitStatus);
+        return result;
+    }
+
+    public @NotNull JsonObject waitForExit(@NotNull String terminalId) {
+        InterceptedTerminal t = requireTerminal(terminalId);
+        JsonObject result = new JsonObject();
+        result.addProperty("exitCode", t.exitCode());
+        result.add("signal", null);
+        return result;
+    }
+
+    public @NotNull JsonObject kill(@NotNull String terminalId) {
+        requireTerminal(terminalId);
+        // Synthetic terminals complete synchronously during create; nothing to kill.
+        return new JsonObject();
+    }
+
+    public @NotNull JsonObject release(@NotNull String terminalId) {
+        if (terminals.remove(terminalId) == null) {
+            throw new IllegalArgumentException("Unknown terminal: " + terminalId);
+        }
+        return new JsonObject();
+    }
+
+    public void releaseAll() {
+        terminals.clear();
+    }
+
+    private @NotNull InterceptedTerminal requireTerminal(@NotNull String terminalId) {
+        InterceptedTerminal t = terminals.get(terminalId);
+        if (t == null) {
+            throw new IllegalArgumentException("Unknown terminal: " + terminalId);
+        }
+        return t;
+    }
+
+    // ─── MCP plumbing ────────────────────────────────────────────────────
+
+    private @NotNull String callMcp(@NotNull String toolName, @NotNull JsonObject args) {
+        if (project == null) {
+            return "Error: AcpToolInterceptor has no Project — MCP redirection unavailable";
+        }
+        try {
+            String result = PsiBridgeService.getInstance(project).callTool(toolName, args);
+            return result != null ? result : "";
+        } catch (Exception e) {
+            LOG.warn("MCP tool '" + toolName + "' threw during ACP interception", e);
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Returns true when an MCP tool result represents a failure. MCP tools signal errors
+     * by prefixing the result with {@code "Error"} (see {@code McpProtocolHandler}).
+     */
+    static boolean isMcpError(@Nullable String result) {
+        return result != null && result.startsWith("Error");
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/intercept/AcpToolInterceptor.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/intercept/AcpToolInterceptor.java
@@ -1,12 +1,14 @@
 package com.github.catatafishen.agentbridge.acp.client.intercept;
 
 import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -32,6 +34,10 @@ public final class AcpToolInterceptor {
 
     private static final Logger LOG = Logger.getInstance(AcpToolInterceptor.class);
     private static final String SYNTHETIC_TERMINAL_PREFIX = "intercept_";
+
+    // Repeated JSON property names — extracted to avoid duplicate-literal warnings.
+    private static final String FIELD_CONTENT = "content";
+    private static final String FIELD_COMMAND = "command";
 
     private final @Nullable Project project;
     private final Map<String, InterceptedTerminal> terminals = new ConcurrentHashMap<>();
@@ -74,7 +80,7 @@ public final class AcpToolInterceptor {
         }
 
         JsonObject response = new JsonObject();
-        response.addProperty("content", result);
+        response.addProperty(FIELD_CONTENT, result);
         return response;
     }
 
@@ -92,7 +98,7 @@ public final class AcpToolInterceptor {
     public @Nullable JsonObject interceptWrite(@NotNull JsonObject params) {
         JsonObject mcpArgs = new JsonObject();
         if (params.has("path")) mcpArgs.add("path", params.get("path"));
-        if (params.has("content")) mcpArgs.add("content", params.get("content"));
+        if (params.has(FIELD_CONTENT)) mcpArgs.add(FIELD_CONTENT, params.get(FIELD_CONTENT));
 
         String result = callMcp("write_file", mcpArgs);
         if (isMcpError(result)) {
@@ -104,40 +110,22 @@ public final class AcpToolInterceptor {
 
     // ─── terminal/create ──────────────────────────────────────────────────
 
-    /**
-     * Try to redirect a {@code terminal/create} request to an MCP tool.
-     *
-     * @return a synthetic {@code {terminalId}} response when the command was redirected
-     * (the result is buffered and served by {@link #output}/{@link #waitForExit}),
-     * or {@code null} when the command should run in a real terminal
-     */
     public @Nullable JsonObject tryInterceptTerminalCreate(@NotNull JsonObject params) {
-        String command = params.has("command") && params.get("command").isJsonPrimitive()
-            ? params.get("command").getAsString() : null;
-        if (command == null || command.isBlank()) return null;
+        List<String> argv = argvFromParams(params);
+        if (argv == null || argv.isEmpty()) return null;
 
-        // Build full argv: [command, ...args] then re-join for tokenization safety.
-        // Agents pass either {command: "git status"} or {command: "git", args: ["status"]}.
-        StringBuilder full = new StringBuilder(command);
-        if (params.has("args") && params.get("args").isJsonArray()) {
-            for (var el : params.getAsJsonArray("args")) {
-                if (el.isJsonPrimitive()) full.append(' ').append(el.getAsString());
-            }
-        }
+        RedirectPlan plan = ShellRedirectPlanner.plan(argv);
+        if (plan == null) return null;
 
-        List<String> tokens = ShellCommandSplitter.tokenize(full.toString());
-        if (tokens == null || tokens.isEmpty()) {
-            // Shell metacharacters present, or unbalanced quotes — too risky to redirect
-            return null;
-        }
-
-        String redirectResult = tryRedirect(tokens);
-        if (redirectResult == null) return null;
+        String raw = callMcp(plan.toolName(), plan.args());
+        boolean isError = isMcpError(raw);
+        String processed = isError ? raw : plan.postProcess().apply(raw);
+        int exitCode = isError ? 1 : plan.exitCodeFor().applyAsInt(processed);
 
         String terminalId = SYNTHETIC_TERMINAL_PREFIX + UUID.randomUUID().toString().substring(0, 12);
-        int exitCode = isMcpError(redirectResult) ? 1 : 0;
-        terminals.put(terminalId, new InterceptedTerminal(redirectResult, exitCode));
-        LOG.info("Intercepted terminal/create: '" + full + "' -> synthetic " + terminalId);
+        terminals.put(terminalId, new InterceptedTerminal(processed, exitCode));
+        LOG.info("Intercepted terminal/create: " + String.join(" ", argv) + " -> " + plan.toolName()
+            + " (synthetic " + terminalId + ", exit=" + exitCode + ")");
 
         JsonObject result = new JsonObject();
         result.addProperty("terminalId", terminalId);
@@ -145,58 +133,45 @@ public final class AcpToolInterceptor {
     }
 
     /**
-     * Resolve {@code argv} to an MCP tool result, or {@code null} if no safe mapping exists.
-     * Each redirect must be unambiguous — the tokens before the file/path/refspec arguments
-     * must exactly identify a single MCP tool.
+     * Build the argv list for an ACP {@code terminal/create} request.
+     *
+     * <p>When the agent passes an explicit {@code args} array we use it as-is — the
+     * arguments have already been split, so re-tokenizing through
+     * {@link ShellCommandSplitter} would corrupt quoted/space-containing values.
+     * We still refuse to redirect when the binary is a shell wrapper (where the args
+     * would be re-interpreted by the spawned shell).
+     *
+     * <p>When only {@code command} is present we fall back to the splitter, which
+     * also rejects shell metacharacters that would change semantics.
+     *
+     * @return argv-style tokens, or {@code null} when redirection is unsafe
      */
-    private @Nullable String tryRedirect(@NotNull List<String> argv) {
-        String head = argv.get(0).toLowerCase(Locale.ROOT);
+    private static @Nullable List<String> argvFromParams(@NotNull JsonObject params) {
+        String command = params.has(FIELD_COMMAND) && params.get(FIELD_COMMAND).isJsonPrimitive()
+            ? params.get(FIELD_COMMAND).getAsString() : null;
+        if (command == null || command.isBlank()) return null;
 
-        // Strip leading "/usr/bin/" or "./" style prefixes from the binary name
-        int slash = head.lastIndexOf('/');
-        if (slash >= 0 && slash + 1 < head.length()) head = head.substring(slash + 1);
-
-        return switch (head) {
-            case "cat", "head", "tail" -> redirectFileRead(argv, head);
-            // Git is well-defined; we only redirect the simplest read-only forms here. Mutating
-            // git operations (commit, push, rebase) are deliberately left to the visible terminal
-            // so the user sees them and the existing GitCommitTool review-gate behaviour is not
-            // bypassed for agent-issued commits.
-            case "git" -> redirectGit(argv);
-            default -> null;
-        };
-    }
-
-    private @Nullable String redirectFileRead(@NotNull List<String> argv, @NotNull String head) {
-        // Only redirect the simple `cat <file>` form. Any flag (-n, --number, -A, ...) means
-        // the agent wants formatting we don't replicate; let it run in the real terminal.
-        if (argv.size() != 2) return null;
-        String path = argv.get(1);
-        if (path.startsWith("-")) return null;
-
-        JsonObject mcpArgs = new JsonObject();
-        mcpArgs.addProperty("path", path);
-        if ("head".equals(head)) {
-            mcpArgs.addProperty("start_line", 1);
-            mcpArgs.addProperty("end_line", 10);
+        if (params.has("args") && params.get("args").isJsonArray()) {
+            if (looksLikeShellWrapper(command)) return null;
+            List<String> argv = new ArrayList<>();
+            argv.add(command);
+            for (JsonElement el : params.getAsJsonArray("args")) {
+                if (!el.isJsonPrimitive()) return null;
+                argv.add(el.getAsString());
+            }
+            return argv;
         }
-        // tail: without a default line count it would behave like cat; let it through to terminal
-        if ("tail".equals(head)) return null;
-        return callMcp("read_file", mcpArgs);
+
+        return ShellCommandSplitter.tokenize(command);
     }
 
-    private @Nullable String redirectGit(@NotNull List<String> argv) {
-        if (argv.size() < 2) return null;
-        String sub = argv.get(1).toLowerCase(Locale.ROOT);
-
-        // Read-only operations only — see comment in tryRedirect. Each entry must accept no
-        // extra positional args (or the args we forward must be safe for the matching MCP tool).
-        return switch (sub) {
-            case "status" -> callMcp("git_status", new JsonObject());
-            // git log / git diff / git show / git branch / git remote / git tag / git stash list
-            // could be added here once we have a clean argument-mapping helper. Holding off in this
-            // first pass to keep the surface area small and predictable.
-            default -> null;
+    private static boolean looksLikeShellWrapper(@NotNull String command) {
+        String base = command;
+        int slash = base.lastIndexOf('/');
+        if (slash >= 0 && slash + 1 < base.length()) base = base.substring(slash + 1);
+        return switch (base.toLowerCase(Locale.ROOT)) {
+            case "sh", "bash", "zsh", "ksh", "dash", "fish", "csh", "tcsh", "pwsh", "powershell" -> true;
+            default -> false;
         };
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/intercept/RedirectPlan.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/intercept/RedirectPlan.java
@@ -1,0 +1,37 @@
+package com.github.catatafishen.agentbridge.acp.client.intercept;
+
+import com.google.gson.JsonObject;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.ToIntFunction;
+import java.util.function.UnaryOperator;
+
+/**
+ * Result of classifying an ACP terminal command for MCP redirection.
+ *
+ * @param toolName    MCP tool to invoke
+ * @param args        arguments for the MCP tool
+ * @param postProcess transformation applied to the raw MCP result before it is
+ *                    handed back to the agent (e.g. stripping IntelliJ-specific
+ *                    headers so the output looks more like the original CLI tool)
+ * @param exitCodeFor computes the exit code reported to the agent based on the
+ *                    processed output. Allows {@code grep}/{@code rg} to return
+ *                    {@code 1} when there are no matches, matching POSIX semantics.
+ *                    Only consulted on success — MCP errors always force exit
+ *                    code {@code 1} regardless.
+ */
+public record RedirectPlan(
+    @NotNull String toolName,
+    @NotNull JsonObject args,
+    @NotNull UnaryOperator<String> postProcess,
+    @NotNull ToIntFunction<String> exitCodeFor
+) {
+
+    /**
+     * Convenience for the common case: pass the MCP result through unchanged with
+     * exit code {@code 0} on success.
+     */
+    public static @NotNull RedirectPlan of(@NotNull String tool, @NotNull JsonObject args) {
+        return new RedirectPlan(tool, args, UnaryOperator.identity(), output -> 0);
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/intercept/ShellCommandSplitter.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/intercept/ShellCommandSplitter.java
@@ -1,0 +1,97 @@
+package com.github.catatafishen.agentbridge.acp.client.intercept;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Lightweight shell-like tokenizer used to decide whether an ACP {@code terminal/create}
+ * command is safe to intercept and redirect to an MCP tool.
+ *
+ * <p><b>Conservative by design:</b> any command that contains shell metacharacters
+ * (pipes, redirects, command substitution, subshells, chaining, env-var expansion)
+ * returns {@code null} from {@link #tokenize(String)} so the caller falls back to
+ * the original (visible) terminal path.
+ *
+ * <p>Supported quoting: single quotes (literal) and double quotes (no expansion —
+ * we never run an actual shell, so {@code $VAR} inside double quotes is left as the
+ * literal string for the agent to pick up if needed). Backslash escapes a single
+ * following character.
+ */
+public final class ShellCommandSplitter {
+
+    private static final String UNSAFE_CHARS = "|<>;&`$()";
+
+    private ShellCommandSplitter() {
+    }
+
+    /**
+     * Split {@code command} into tokens, or return {@code null} when the command contains
+     * shell metacharacters that make safe redirection impossible.
+     *
+     * @param command the raw command line (as passed to {@code terminal/create})
+     * @return list of argv-style tokens, or {@code null} if the command is too complex to redirect
+     */
+    public static @Nullable List<String> tokenize(@NotNull String command) {
+        String trimmed = command.trim();
+        if (trimmed.isEmpty()) return null;
+
+        List<String> tokens = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        int i = 0;
+        int len = trimmed.length();
+        boolean inSingle = false;
+        boolean inDouble = false;
+        boolean hasContent = false;
+
+        while (i < len) {
+            char c = trimmed.charAt(i);
+
+            if (!inSingle && !inDouble && UNSAFE_CHARS.indexOf(c) >= 0) {
+                return null;
+            }
+
+            if (c == '\\' && !inSingle && i + 1 < len) {
+                current.append(trimmed.charAt(i + 1));
+                hasContent = true;
+                i += 2;
+                continue;
+            }
+
+            if (c == '\'' && !inDouble) {
+                inSingle = !inSingle;
+                hasContent = true;
+                i++;
+                continue;
+            }
+
+            if (c == '"' && !inSingle) {
+                inDouble = !inDouble;
+                hasContent = true;
+                i++;
+                continue;
+            }
+
+            if (Character.isWhitespace(c) && !inSingle && !inDouble) {
+                if (hasContent) {
+                    tokens.add(current.toString());
+                    current.setLength(0);
+                    hasContent = false;
+                }
+                i++;
+                continue;
+            }
+
+            current.append(c);
+            hasContent = true;
+            i++;
+        }
+
+        if (inSingle || inDouble) return null;
+        if (hasContent) tokens.add(current.toString());
+
+        return tokens.isEmpty() ? null : tokens;
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/intercept/ShellRedirectPlanner.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/intercept/ShellRedirectPlanner.java
@@ -1,0 +1,413 @@
+package com.github.catatafishen.agentbridge.acp.client.intercept;
+
+import com.google.gson.JsonObject;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Pure (Project-free) classifier that maps a tokenized shell command to a
+ * {@link RedirectPlan}, or returns {@code null} when no safe MCP equivalent exists.
+ *
+ * <p><b>Design constraints:</b>
+ * <ul>
+ *   <li>Conservative — when in doubt, return {@code null} so the command runs in the
+ *       visible IDE terminal where the user can see it.</li>
+ *   <li>No I/O, no Project, no service lookups — keeps unit tests trivial.</li>
+ *   <li>Each redirect must preserve semantics. We accept format drift in the output
+ *       (agents adapt) but never accept wrong results.</li>
+ * </ul>
+ *
+ * <p><b>Currently supported:</b>
+ * <ul>
+ *   <li>{@code cat FILE} → {@code read_file}</li>
+ *   <li>{@code head [-n N|--lines=N] FILE} → {@code read_file} with line range</li>
+ *   <li>{@code grep -F/-E/-i/-r/-n PATTERN [GLOB]} → {@code search_text}.
+ *       Note: plain {@code grep} (BRE regex) is intentionally not intercepted because
+ *       BRE differs subtly from Java regex. Use {@code -F} (literal) or {@code -E}
+ *       (extended) for explicit semantics.</li>
+ *   <li>{@code egrep} ≡ {@code grep -E}, {@code fgrep} ≡ {@code grep -F}</li>
+ *   <li>{@code rg [-F] [-i] [-g GLOB|--glob GLOB] PATTERN} → {@code search_text}</li>
+ *   <li>{@code git status} → {@code git_status}</li>
+ *   <li>{@code git diff [--staged] [--stat]} → {@code git_diff}</li>
+ *   <li>{@code git log [--oneline] [-n N]} → {@code git_log}</li>
+ *   <li>{@code git branch} → {@code git_branch}</li>
+ * </ul>
+ *
+ * <p><b>Deliberately not intercepted</b> (see commit history for rationale):
+ * <ul>
+ *   <li>{@code ls} — recursion semantics differ from {@code list_project_files}</li>
+ *   <li>{@code find} — requires file-vs-directory disambiguation we cannot do without I/O</li>
+ *   <li>{@code tail} — {@code read_file} truncates large files, breaking tail semantics</li>
+ *   <li>Plain {@code grep} — BRE regex not equivalent to Java regex</li>
+ *   <li>Mutating git operations — must remain visible so {@code GitCommitTool}'s review
+ *       gate is not bypassed</li>
+ * </ul>
+ */
+public final class ShellRedirectPlanner {
+
+    private ShellRedirectPlanner() {
+    }
+
+    /**
+     * Classify the given argv. Returns {@code null} when the command should fall through
+     * to the visible terminal.
+     */
+    public static @Nullable RedirectPlan plan(@NotNull List<String> argv) {
+        if (argv.isEmpty()) return null;
+
+        String head = stripPath(argv.getFirst()).toLowerCase(Locale.ROOT);
+
+        return switch (head) {
+            case "cat" -> planCat(argv);
+            case "head" -> planHead(argv);
+            case "grep" -> planGrep(argv, /* defaultRegex = */ null);
+            case "egrep" -> planGrep(argv, /* defaultRegex = */ true);
+            case "fgrep" -> planGrep(argv, /* defaultRegex = */ false);
+            case "rg" -> planRg(argv);
+            case "git" -> planGit(argv);
+            default -> null;
+        };
+    }
+
+    private static @NotNull String stripPath(@NotNull String binary) {
+        int slash = binary.lastIndexOf('/');
+        return (slash >= 0 && slash + 1 < binary.length()) ? binary.substring(slash + 1) : binary;
+    }
+
+    // ─── cat ──────────────────────────────────────────────────────────────
+
+    private static @Nullable RedirectPlan planCat(@NotNull List<String> argv) {
+        // Only redirect the bare `cat <file>` form. Any flag (-n, -A, ...) means the
+        // agent wants formatting we don't reproduce; let it run in the real terminal.
+        if (argv.size() != 2) return null;
+        String path = argv.get(1);
+        if (path.startsWith("-")) return null;
+
+        JsonObject args = new JsonObject();
+        args.addProperty("path", path);
+        return RedirectPlan.of("read_file", args);
+    }
+
+    // ─── head ─────────────────────────────────────────────────────────────
+
+    private static @Nullable RedirectPlan planHead(@NotNull List<String> argv) {
+        int n = 10;
+        String path = null;
+        boolean afterDoubleDash = false;
+
+        int i = 1;
+        while (i < argv.size()) {
+            String tok = argv.get(i);
+            if (afterDoubleDash) {
+                if (path != null) return null;
+                path = tok;
+                i++;
+                continue;
+            }
+            if (tok.equals("--")) {
+                afterDoubleDash = true;
+                i++;
+                continue;
+            }
+            if (tok.equals("-n") || tok.equals("--lines")) {
+                if (i + 1 >= argv.size()) return null;
+                Integer parsed = parsePositiveInt(argv.get(i + 1));
+                if (parsed == null) return null;
+                n = parsed;
+                i += 2;
+                continue;
+            }
+            if (tok.startsWith("--lines=")) {
+                Integer parsed = parsePositiveInt(tok.substring("--lines=".length()));
+                if (parsed == null) return null;
+                n = parsed;
+                i++;
+                continue;
+            }
+            if (tok.startsWith("-n") && tok.length() > 2) {
+                Integer parsed = parsePositiveInt(tok.substring(2));
+                if (parsed == null) return null;
+                n = parsed;
+                i++;
+                continue;
+            }
+            if (tok.startsWith("-") && tok.length() > 1) {
+                return null; // unknown flag
+            }
+            if (path != null) return null; // multiple files unsupported
+            path = tok;
+            i++;
+        }
+
+        if (path == null) return null;
+
+        JsonObject args = new JsonObject();
+        args.addProperty("path", path);
+        args.addProperty("start_line", 1);
+        args.addProperty("end_line", n);
+        return RedirectPlan.of("read_file", args);
+    }
+
+    // ─── grep family ──────────────────────────────────────────────────────
+
+    /**
+     * @param defaultRegex {@code null} to refuse interception when the form is ambiguous
+     *                     (plain {@code grep}), {@code true} for {@code egrep},
+     *                     {@code false} for {@code fgrep}. Plain {@code grep} would map
+     *                     to BRE which is not equivalent to Java regex.
+     */
+    private static @Nullable RedirectPlan planGrep(@NotNull List<String> argv, @Nullable Boolean defaultRegex) {
+        boolean caseSensitive = true;
+        Boolean regexExplicit = null;
+        String fileGlob = null;
+        List<String> positional = new ArrayList<>();
+        boolean afterDoubleDash = false;
+
+        int i = 1;
+        while (i < argv.size()) {
+            String tok = argv.get(i);
+            if (afterDoubleDash) {
+                positional.add(tok);
+                i++;
+                continue;
+            }
+            if (tok.equals("--")) {
+                afterDoubleDash = true;
+                i++;
+                continue;
+            }
+            if (tok.startsWith("-") && tok.length() > 1) {
+                // Bundled short flags like -rin
+                for (int j = 1; j < tok.length(); j++) {
+                    char c = tok.charAt(j);
+                    switch (c) {
+                        case 'i' -> caseSensitive = false;
+                        case 'E' -> regexExplicit = true;
+                        case 'F' -> regexExplicit = false;
+                        case 'r', 'R', 'n', 'H', 'I' -> {
+                            // -r/-R: recursion is implicit in search_text
+                            // -n: search_text always returns line numbers
+                            // -H: search_text always shows file names
+                            // -I: search_text already skips binary files
+                        }
+                        default -> {
+                            return null; // unknown flag
+                        }
+                    }
+                }
+                i++;
+                continue;
+            }
+            positional.add(tok);
+            i++;
+        }
+
+        if (positional.isEmpty() || positional.size() > 2) return null;
+        String pattern = positional.get(0);
+        // Reject leading-dash patterns unless escaped via `--` separator
+        if (pattern.startsWith("-") && !afterDoubleDash) return null;
+
+        if (positional.size() == 2) {
+            String secondArg = positional.get(1);
+            // Only accept when the second positional is clearly a glob — directories or
+            // single files don't translate to search_text's file_pattern (filename glob).
+            if (!secondArg.contains("*") && !secondArg.contains("?")) return null;
+            fileGlob = secondArg;
+        }
+
+        boolean regex;
+        if (regexExplicit != null) {
+            regex = regexExplicit;
+        } else if (defaultRegex != null) {
+            regex = defaultRegex;
+        } else {
+            // Plain `grep` without -F or -E — BRE semantics, refuse.
+            return null;
+        }
+
+        JsonObject args = new JsonObject();
+        args.addProperty("query", pattern);
+        args.addProperty("regex", regex);
+        args.addProperty("case_sensitive", caseSensitive);
+        if (fileGlob != null) args.addProperty("file_pattern", fileGlob);
+
+        return new RedirectPlan(
+            "search_text",
+            args,
+            ShellRedirectPlanner::stripSearchTextHeader,
+            output -> output.startsWith("No matches found") ? 1 : 0
+        );
+    }
+
+    private static @Nullable RedirectPlan planRg(@NotNull List<String> argv) {
+        boolean caseSensitive = true;
+        boolean regex = true; // ripgrep default
+        String fileGlob = null;
+        List<String> positional = new ArrayList<>();
+        boolean afterDoubleDash = false;
+
+        int i = 1;
+        while (i < argv.size()) {
+            String tok = argv.get(i);
+            if (afterDoubleDash) {
+                positional.add(tok);
+                i++;
+                continue;
+            }
+            if (tok.equals("--")) {
+                afterDoubleDash = true;
+                i++;
+                continue;
+            }
+            if (tok.equals("-g") || tok.equals("--glob")) {
+                if (i + 1 >= argv.size()) return null;
+                fileGlob = argv.get(i + 1);
+                i += 2;
+                continue;
+            }
+            if (tok.startsWith("--glob=")) {
+                fileGlob = tok.substring("--glob=".length());
+                i++;
+                continue;
+            }
+            if (tok.startsWith("-") && tok.length() > 1) {
+                for (int j = 1; j < tok.length(); j++) {
+                    char c = tok.charAt(j);
+                    switch (c) {
+                        case 'i' -> caseSensitive = false;
+                        case 'F' -> regex = false;
+                        case 'n', 'H' -> {
+                            // search_text already includes line numbers and file names
+                        }
+                        default -> {
+                            return null; // unknown flag
+                        }
+                    }
+                }
+                i++;
+                continue;
+            }
+            positional.add(tok);
+            i++;
+        }
+
+        // ripgrep can take an optional path arg, but search_text doesn't take a directory.
+        // Accept only the single-pattern form to stay safe.
+        if (positional.size() != 1) return null;
+        String pattern = positional.get(0);
+        if (pattern.startsWith("-") && !afterDoubleDash) return null;
+
+        JsonObject args = new JsonObject();
+        args.addProperty("query", pattern);
+        args.addProperty("regex", regex);
+        args.addProperty("case_sensitive", caseSensitive);
+        if (fileGlob != null) args.addProperty("file_pattern", fileGlob);
+
+        return new RedirectPlan(
+            "search_text",
+            args,
+            ShellRedirectPlanner::stripSearchTextHeader,
+            output -> output.startsWith("No matches found") ? 1 : 0
+        );
+    }
+
+    /**
+     * Strip the leading {@code "N matches:"} line that {@code search_text} emits — the
+     * raw match lines below it are already in {@code path:line:text} form, which is
+     * close enough to grep/rg output for agents that parse it.
+     */
+    static @NotNull String stripSearchTextHeader(@NotNull String result) {
+        int newline = result.indexOf('\n');
+        if (newline < 0) return result;
+        String first = result.substring(0, newline);
+        if (first.matches("\\d+ match(?:es)?:")) {
+            return result.substring(newline + 1);
+        }
+        return result;
+    }
+
+    // ─── git read-only subcommands ────────────────────────────────────────
+
+    private static @Nullable RedirectPlan planGit(@NotNull List<String> argv) {
+        if (argv.size() < 2) return null;
+        String sub = argv.get(1).toLowerCase(Locale.ROOT);
+        return switch (sub) {
+            case "status" -> argv.size() == 2 ? RedirectPlan.of("git_status", new JsonObject()) : null;
+            case "diff" -> planGitDiff(argv);
+            case "log" -> planGitLog(argv);
+            case "branch" -> argv.size() == 2 ? RedirectPlan.of("git_branch", new JsonObject()) : null;
+            default -> null;
+        };
+    }
+
+    private static @Nullable RedirectPlan planGitDiff(@NotNull List<String> argv) {
+        boolean staged = false;
+        boolean statOnly = false;
+        for (int i = 2; i < argv.size(); i++) {
+            String tok = argv.get(i);
+            switch (tok) {
+                case "--staged", "--cached" -> staged = true;
+                case "--stat" -> statOnly = true;
+                default -> {
+                    return null; // unknown / positional path arg / commit ref — fall through
+                }
+            }
+        }
+        JsonObject args = new JsonObject();
+        if (staged) args.addProperty("staged", true);
+        if (statOnly) args.addProperty("stat_only", true);
+        return RedirectPlan.of("git_diff", args);
+    }
+
+    private static @Nullable RedirectPlan planGitLog(@NotNull List<String> argv) {
+        JsonObject args = new JsonObject();
+        int i = 2;
+        while (i < argv.size()) {
+            String tok = argv.get(i);
+            if (tok.equals("--oneline")) {
+                args.addProperty("format", "oneline");
+                i++;
+                continue;
+            }
+            if (tok.equals("-n") || tok.equals("--max-count")) {
+                if (i + 1 >= argv.size()) return null;
+                Integer parsed = parsePositiveInt(argv.get(i + 1));
+                if (parsed == null) return null;
+                args.addProperty("max_count", parsed);
+                i += 2;
+                continue;
+            }
+            if (tok.startsWith("-n") && tok.length() > 2) {
+                Integer parsed = parsePositiveInt(tok.substring(2));
+                if (parsed == null) return null;
+                args.addProperty("max_count", parsed);
+                i++;
+                continue;
+            }
+            if (tok.startsWith("--max-count=")) {
+                Integer parsed = parsePositiveInt(tok.substring("--max-count=".length()));
+                if (parsed == null) return null;
+                args.addProperty("max_count", parsed);
+                i++;
+                continue;
+            }
+            return null; // unknown flag / commit ref / path filter
+        }
+        return RedirectPlan.of("git_log", args);
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────────────
+
+    private static @Nullable Integer parsePositiveInt(@NotNull String s) {
+        try {
+            int n = Integer.parseInt(s);
+            return n > 0 ? n : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/intercept/VisibleProcessRunner.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/intercept/VisibleProcessRunner.java
@@ -1,0 +1,156 @@
+package com.github.catatafishen.agentbridge.acp.client.intercept;
+
+import com.github.catatafishen.agentbridge.psi.EdtUtil;
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.executors.DefaultRunExecutor;
+import com.intellij.execution.filters.TextConsoleBuilderFactory;
+import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.execution.process.ProcessEvent;
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.execution.ui.ConsoleView;
+import com.intellij.execution.ui.RunContentDescriptor;
+import com.intellij.execution.ui.RunContentManager;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.JComponent;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Runs a fall-through ACP {@code terminal/create} command as a real OS process,
+ * mirroring its output to a tab in the IDE Run tool window so the user can watch
+ * the command live (and kill it via the standard stop button) while the agent
+ * still sees a clean stdout/exit-code stream over the ACP protocol.
+ *
+ * <p>Wraps {@link OSProcessHandler} with a {@link ConsoleView} attached for visibility,
+ * plus a {@link ProcessListener} that forwards stdout/stderr into a caller-supplied
+ * {@link OutputSink}. The result returned to the caller is a live {@link Process} the
+ * existing ACP terminal handler already knows how to manage for ACP lifecycle methods
+ * ({@code terminal/output}, {@code terminal/wait_for_exit}, etc.).
+ */
+public final class VisibleProcessRunner {
+
+    private static final Logger LOG = Logger.getInstance(VisibleProcessRunner.class);
+
+    /** Receives raw output text exactly as the underlying process emits it. */
+    @FunctionalInterface
+    public interface OutputSink {
+        void append(@NotNull String chunk);
+    }
+
+    private final @Nullable Project project;
+
+    public VisibleProcessRunner(@Nullable Project project) {
+        this.project = project;
+    }
+
+    /**
+     * Start {@code commandLine} as a visible process. The console tab is registered with
+     * the Run tool window on the EDT; the underlying process starts immediately on the
+     * caller's thread so callers can operate on the returned {@link Process} synchronously.
+     *
+     * @param commandLine pre-configured command line (cwd/env already set)
+     * @param tabTitle    title for the Run tool window tab
+     * @param sink        receives every stdout/stderr chunk the process emits
+     * @return the live {@link Process}; never {@code null}
+     * @throws ExecutionException if the process could not be started
+     */
+    public @NotNull Process start(@NotNull GeneralCommandLine commandLine,
+                                  @NotNull String tabTitle,
+                                  @NotNull OutputSink sink) throws ExecutionException {
+        Process process = commandLine.createProcess();
+
+        // In headless test contexts (no Application) or when no Project is available,
+        // fall back to plain stream-reader threads — the IDE Run-tool-window plumbing
+        // requires a live Application to register services.
+        if (project == null || ApplicationManager.getApplication() == null) {
+            startHeadlessReaders(process, sink);
+            return process;
+        }
+
+        OSProcessHandler handler = new OSProcessHandler(process, commandLine.getCommandLineString());
+        handler.addProcessListener(new ProcessListener() {
+            @Override
+            public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
+                String text = event.getText();
+                if (text != null && !text.isEmpty()) sink.append(text);
+            }
+        });
+
+        try {
+            ConsoleView console = TextConsoleBuilderFactory.getInstance()
+                .createBuilder(project)
+                .getConsole();
+            console.attachToProcess(handler);
+
+            // Register on the EDT — RunContentManager mutates Swing state.
+            EdtUtil.invokeLater(() -> registerInRunToolWindow(console, handler, tabTitle));
+        } catch (Exception e) {
+            LOG.warn("Failed to attach visible console for '" + tabTitle + "' — process will still run", e);
+        }
+
+        handler.startNotify();
+        return process;
+    }
+
+    /**
+     * Pumps the process's stdout into the sink on a daemon thread. Used only when no
+     * IntelliJ Application is available (unit tests). Stderr is folded into stdout via
+     * {@link GeneralCommandLine#setRedirectErrorStream(boolean)}.
+     */
+    private static void startHeadlessReaders(@NotNull Process process, @NotNull OutputSink sink) {
+        Thread t = new Thread(() -> {
+            try (java.io.InputStream in = process.getInputStream()) {
+                byte[] buf = new byte[4096];
+                int n;
+                while ((n = in.read(buf)) != -1) {
+                    sink.append(new String(buf, 0, n, StandardCharsets.UTF_8));
+                }
+            } catch (Exception ignore) {
+                // process closed or interrupted — nothing actionable
+            }
+        }, "VisibleProcessRunner-headless-reader");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    private void registerInRunToolWindow(@NotNull ConsoleView console,
+                                         @NotNull OSProcessHandler handler,
+                                         @NotNull String tabTitle) {
+        try {
+            assert project != null; // guarded by caller — non-null when we reach here
+            JComponent component = console.getComponent();
+            RunContentDescriptor descriptor = new RunContentDescriptor(
+                console, handler, component, tabTitle);
+            descriptor.setActivateToolWindowWhenAdded(false);
+            RunContentManager.getInstance(project)
+                .showRunContent(DefaultRunExecutor.getRunExecutorInstance(), descriptor);
+        } catch (Exception e) {
+            LOG.warn("Could not show ACP terminal in Run tool window: " + tabTitle, e);
+        }
+    }
+
+    /**
+     * Convenience builder so the calling ACP terminal handler stays focused on protocol plumbing.
+     */
+    public static @NotNull GeneralCommandLine buildCommandLine(@NotNull String command,
+                                                               @NotNull String[] args,
+                                                               @Nullable String cwd,
+                                                               @NotNull Map<String, String> env) {
+        GeneralCommandLine cl = new GeneralCommandLine();
+        cl.setExePath(command);
+        for (String arg : args) cl.addParameter(arg);
+        if (cwd != null) cl.setWorkDirectory(new File(cwd));
+        cl.withEnvironment(env);
+        cl.setCharset(StandardCharsets.UTF_8);
+        cl.setRedirectErrorStream(true);
+        return cl;
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/intercept/AcpToolInterceptorTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/intercept/AcpToolInterceptorTest.java
@@ -1,0 +1,35 @@
+package com.github.catatafishen.agentbridge.acp.client.intercept;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Focused tests for the pure helpers on {@link AcpToolInterceptor}. The redirect
+ * classification and synthetic terminal lifecycle are exercised end-to-end through
+ * the {@link ShellCommandSplitter} tests and (eventually) manual ACP runs against
+ * Copilot/Junie/Kiro/OpenCode in a sandbox — they require a live {@code Project}
+ * and {@code PsiBridgeService} which are out of scope for unit tests.
+ */
+class AcpToolInterceptorTest {
+
+    @Test
+    void isMcpErrorRecognizesErrorPrefix() {
+        assertTrue(AcpToolInterceptor.isMcpError("Error: file not found"));
+        assertTrue(AcpToolInterceptor.isMcpError("Error (exit 1): nope"));
+    }
+
+    @Test
+    void isMcpErrorReturnsFalseForSuccess() {
+        assertFalse(AcpToolInterceptor.isMcpError("file contents here"));
+        assertFalse(AcpToolInterceptor.isMcpError(""));
+        assertFalse(AcpToolInterceptor.isMcpError(null));
+    }
+
+    @Test
+    void isMcpErrorIsCaseSensitive() {
+        // MCP convention is uppercase "Error" — lowercase "error" must not be treated as failure
+        assertFalse(AcpToolInterceptor.isMcpError("error message"));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/intercept/ShellCommandSplitterTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/intercept/ShellCommandSplitterTest.java
@@ -1,0 +1,88 @@
+package com.github.catatafishen.agentbridge.acp.client.intercept;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ShellCommandSplitterTest {
+
+    @Test
+    void simpleArgvTokenizes() {
+        assertEquals(List.of("git", "status"), ShellCommandSplitter.tokenize("git status"));
+        assertEquals(List.of("cat", "README.md"), ShellCommandSplitter.tokenize("cat README.md"));
+    }
+
+    @Test
+    void leadingAndTrailingWhitespaceIgnored() {
+        assertEquals(List.of("ls", "-la"), ShellCommandSplitter.tokenize("   ls   -la   "));
+    }
+
+    @Test
+    void doubleQuotesGroupTokens() {
+        assertEquals(List.of("echo", "hello world"), ShellCommandSplitter.tokenize("echo \"hello world\""));
+    }
+
+    @Test
+    void singleQuotesGroupTokens() {
+        assertEquals(List.of("echo", "hello world"), ShellCommandSplitter.tokenize("echo 'hello world'"));
+    }
+
+    @Test
+    void backslashEscapesSpaces() {
+        assertEquals(List.of("cat", "my file.txt"), ShellCommandSplitter.tokenize("cat my\\ file.txt"));
+    }
+
+    @Test
+    void rejectsPipe() {
+        assertNull(ShellCommandSplitter.tokenize("ls | grep foo"));
+    }
+
+    @Test
+    void rejectsRedirect() {
+        assertNull(ShellCommandSplitter.tokenize("ls > out.txt"));
+        assertNull(ShellCommandSplitter.tokenize("cat < in.txt"));
+    }
+
+    @Test
+    void rejectsCommandSeparators() {
+        assertNull(ShellCommandSplitter.tokenize("ls; rm -rf /"));
+        assertNull(ShellCommandSplitter.tokenize("ls && echo done"));
+        assertNull(ShellCommandSplitter.tokenize("ls || echo failed"));
+    }
+
+    @Test
+    void rejectsBackgroundOperator() {
+        assertNull(ShellCommandSplitter.tokenize("sleep 100 &"));
+    }
+
+    @Test
+    void rejectsCommandSubstitution() {
+        assertNull(ShellCommandSplitter.tokenize("echo $(date)"));
+        assertNull(ShellCommandSplitter.tokenize("echo `date`"));
+    }
+
+    @Test
+    void rejectsSubshell() {
+        assertNull(ShellCommandSplitter.tokenize("(cd /tmp && ls)"));
+    }
+
+    @Test
+    void rejectsUnbalancedQuotes() {
+        assertNull(ShellCommandSplitter.tokenize("echo \"hello"));
+        assertNull(ShellCommandSplitter.tokenize("echo 'hello"));
+    }
+
+    @Test
+    void emptyStringReturnsNull() {
+        assertNull(ShellCommandSplitter.tokenize(""));
+        assertNull(ShellCommandSplitter.tokenize("   "));
+    }
+
+    @Test
+    void quotedMetacharsAreNotShellMetachars() {
+        // A pipe inside quotes is just literal text
+        assertEquals(List.of("echo", "a|b"), ShellCommandSplitter.tokenize("echo \"a|b\""));
+    }
+}

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/intercept/ShellRedirectPlannerTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/acp/client/intercept/ShellRedirectPlannerTest.java
@@ -1,0 +1,373 @@
+package com.github.catatafishen.agentbridge.acp.client.intercept;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the pure classification logic in {@link ShellRedirectPlanner}. These tests
+ * never touch a {@code Project} or invoke MCP — they only verify that argv is mapped
+ * to the correct tool name + arguments.
+ */
+class ShellRedirectPlannerTest {
+
+    // ─── cat ──────────────────────────────────────────────────────────────
+
+    @Test
+    void catSimpleFile() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("cat", "README.md"));
+        assertNotNull(plan);
+        assertEquals("read_file", plan.toolName());
+        assertEquals("README.md", plan.args().get("path").getAsString());
+    }
+
+    @Test
+    void catWithFlagFallsThrough() {
+        assertNull(ShellRedirectPlanner.plan(List.of("cat", "-n", "file.txt")));
+    }
+
+    @Test
+    void catMultipleFilesFallsThrough() {
+        assertNull(ShellRedirectPlanner.plan(List.of("cat", "a.txt", "b.txt")));
+    }
+
+    @Test
+    void catWithAbsoluteBinaryPathStillWorks() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("/usr/bin/cat", "x.md"));
+        assertNotNull(plan);
+        assertEquals("read_file", plan.toolName());
+    }
+
+    // ─── head ─────────────────────────────────────────────────────────────
+
+    @Test
+    void headDefaults() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("head", "build.gradle.kts"));
+        assertNotNull(plan);
+        assertEquals("read_file", plan.toolName());
+        assertEquals(1, plan.args().get("start_line").getAsInt());
+        assertEquals(10, plan.args().get("end_line").getAsInt());
+    }
+
+    @Test
+    void headDashNSpaceCount() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("head", "-n", "25", "x.txt"));
+        assertNotNull(plan);
+        assertEquals(25, plan.args().get("end_line").getAsInt());
+    }
+
+    @Test
+    void headDashNAttachedCount() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("head", "-n50", "x.txt"));
+        assertNotNull(plan);
+        assertEquals(50, plan.args().get("end_line").getAsInt());
+    }
+
+    @Test
+    void headLongFlagWithEquals() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("head", "--lines=15", "x.txt"));
+        assertNotNull(plan);
+        assertEquals(15, plan.args().get("end_line").getAsInt());
+    }
+
+    @Test
+    void headWithoutFileFallsThrough() {
+        assertNull(ShellRedirectPlanner.plan(List.of("head", "-n", "5")));
+    }
+
+    @Test
+    void headWithUnknownFlagFallsThrough() {
+        assertNull(ShellRedirectPlanner.plan(List.of("head", "-c", "100", "x.txt")));
+    }
+
+    @Test
+    void headWithNegativeCountFallsThrough() {
+        assertNull(ShellRedirectPlanner.plan(List.of("head", "-n", "-5", "x.txt")));
+    }
+
+    // ─── grep / egrep / fgrep ────────────────────────────────────────────
+
+    @Test
+    void plainGrepFallsThrough() {
+        // BRE semantics differ from Java regex — refuse so the user sees real grep behaviour.
+        assertNull(ShellRedirectPlanner.plan(List.of("grep", "foo")));
+    }
+
+    @Test
+    void grepFLiteral() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("grep", "-F", "needle"));
+        assertNotNull(plan);
+        assertEquals("search_text", plan.toolName());
+        assertEquals("needle", plan.args().get("query").getAsString());
+        assertEquals(false, plan.args().get("regex").getAsBoolean());
+        assertEquals(true, plan.args().get("case_sensitive").getAsBoolean());
+    }
+
+    @Test
+    void grepEExtended() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("grep", "-E", "fo+"));
+        assertNotNull(plan);
+        assertEquals(true, plan.args().get("regex").getAsBoolean());
+    }
+
+    @Test
+    void grepCombinedFlagsRin() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("grep", "-rinE", "todo"));
+        assertNotNull(plan);
+        assertEquals(false, plan.args().get("case_sensitive").getAsBoolean());
+        assertEquals(true, plan.args().get("regex").getAsBoolean());
+    }
+
+    @Test
+    void grepWithGlobSecondArg() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("grep", "-F", "foo", "*.kt"));
+        assertNotNull(plan);
+        assertEquals("*.kt", plan.args().get("file_pattern").getAsString());
+    }
+
+    @Test
+    void grepWithDirectorySecondArgFallsThrough() {
+        // Directory paths don't translate to search_text's filename glob.
+        assertNull(ShellRedirectPlanner.plan(List.of("grep", "-F", "foo", "src")));
+    }
+
+    @Test
+    void grepWithThreePositionalsFallsThrough() {
+        assertNull(ShellRedirectPlanner.plan(List.of("grep", "-F", "foo", "*.kt", "*.java")));
+    }
+
+    @Test
+    void grepUnknownFlagFallsThrough() {
+        assertNull(ShellRedirectPlanner.plan(List.of("grep", "-Fz", "foo")));
+    }
+
+    @Test
+    void grepLeadingDashPatternFallsThrough() {
+        assertNull(ShellRedirectPlanner.plan(List.of("grep", "-F", "-something")));
+    }
+
+    @Test
+    void grepDoubleDashAllowsLeadingDashPattern() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("grep", "-F", "--", "-something"));
+        assertNotNull(plan);
+        assertEquals("-something", plan.args().get("query").getAsString());
+    }
+
+    @Test
+    void egrepIsImplicitlyExtendedRegex() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("egrep", "fo+"));
+        assertNotNull(plan);
+        assertEquals(true, plan.args().get("regex").getAsBoolean());
+    }
+
+    @Test
+    void fgrepIsImplicitlyLiteral() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("fgrep", "literal.string"));
+        assertNotNull(plan);
+        assertEquals(false, plan.args().get("regex").getAsBoolean());
+    }
+
+    @Test
+    void grepNoMatchesReportsExitOne() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("grep", "-F", "x"));
+        assertNotNull(plan);
+        assertEquals(1, plan.exitCodeFor().applyAsInt("No matches found for 'x'"));
+        assertEquals(0, plan.exitCodeFor().applyAsInt("3 matches:\nfile:1: x\n"));
+    }
+
+    @Test
+    void grepStripsMatchesHeader() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("grep", "-F", "x"));
+        assertNotNull(plan);
+        String stripped = plan.postProcess().apply("3 matches:\nfile.kt:1: x found\nfile.kt:2: x again\n");
+        assertTrue(stripped.startsWith("file.kt:1: x found"), "Header should be stripped, got: " + stripped);
+    }
+
+    @Test
+    void grepKeepsNoMatchesOutputAsIs() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("grep", "-F", "x"));
+        assertNotNull(plan);
+        String out = plan.postProcess().apply("No matches found for 'x'");
+        assertEquals("No matches found for 'x'", out);
+    }
+
+    // ─── rg ───────────────────────────────────────────────────────────────
+
+    @Test
+    void rgDefaultsToRegex() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("rg", "fo+"));
+        assertNotNull(plan);
+        assertEquals(true, plan.args().get("regex").getAsBoolean());
+    }
+
+    @Test
+    void rgFFlagDisablesRegex() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("rg", "-F", "literal.dot"));
+        assertNotNull(plan);
+        assertEquals(false, plan.args().get("regex").getAsBoolean());
+    }
+
+    @Test
+    void rgGlobShortFormSpaceSeparated() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("rg", "-g", "*.kt", "TODO"));
+        assertNotNull(plan);
+        assertEquals("*.kt", plan.args().get("file_pattern").getAsString());
+        assertEquals("TODO", plan.args().get("query").getAsString());
+    }
+
+    @Test
+    void rgGlobLongFormWithEquals() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("rg", "--glob=*.java", "foo"));
+        assertNotNull(plan);
+        assertEquals("*.java", plan.args().get("file_pattern").getAsString());
+    }
+
+    @Test
+    void rgWithPathPositionalFallsThrough() {
+        // search_text takes no directory — refuse rather than ignore the path.
+        assertNull(ShellRedirectPlanner.plan(List.of("rg", "TODO", "src")));
+    }
+
+    @Test
+    void rgUnknownFlagFallsThrough() {
+        assertNull(ShellRedirectPlanner.plan(List.of("rg", "--multiline", "foo")));
+    }
+
+    // ─── git ──────────────────────────────────────────────────────────────
+
+    @Test
+    void gitStatusBare() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("git", "status"));
+        assertNotNull(plan);
+        assertEquals("git_status", plan.toolName());
+    }
+
+    @Test
+    void gitStatusWithFlagFallsThrough() {
+        assertNull(ShellRedirectPlanner.plan(List.of("git", "status", "--short")));
+    }
+
+    @Test
+    void gitDiffBare() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("git", "diff"));
+        assertNotNull(plan);
+        assertEquals("git_diff", plan.toolName());
+    }
+
+    @Test
+    void gitDiffStaged() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("git", "diff", "--staged"));
+        assertNotNull(plan);
+        assertEquals(true, plan.args().get("staged").getAsBoolean());
+    }
+
+    @Test
+    void gitDiffStat() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("git", "diff", "--stat"));
+        assertNotNull(plan);
+        assertEquals(true, plan.args().get("stat_only").getAsBoolean());
+    }
+
+    @Test
+    void gitDiffWithCommitRefFallsThrough() {
+        assertNull(ShellRedirectPlanner.plan(List.of("git", "diff", "HEAD~1")));
+    }
+
+    @Test
+    void gitLogBare() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("git", "log"));
+        assertNotNull(plan);
+        assertEquals("git_log", plan.toolName());
+    }
+
+    @Test
+    void gitLogOneline() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("git", "log", "--oneline"));
+        assertNotNull(plan);
+        assertEquals("oneline", plan.args().get("format").getAsString());
+    }
+
+    @Test
+    void gitLogMaxCount() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("git", "log", "-n", "5"));
+        assertNotNull(plan);
+        assertEquals(5, plan.args().get("max_count").getAsInt());
+    }
+
+    @Test
+    void gitLogWithBranchRefFallsThrough() {
+        assertNull(ShellRedirectPlanner.plan(List.of("git", "log", "main")));
+    }
+
+    @Test
+    void gitBranchBare() {
+        RedirectPlan plan = ShellRedirectPlanner.plan(List.of("git", "branch"));
+        assertNotNull(plan);
+        assertEquals("git_branch", plan.toolName());
+    }
+
+    @Test
+    void gitCommitFallsThrough() {
+        // Mutating ops must remain visible — never intercept.
+        assertNull(ShellRedirectPlanner.plan(List.of("git", "commit", "-m", "wip")));
+    }
+
+    @Test
+    void gitPushFallsThrough() {
+        assertNull(ShellRedirectPlanner.plan(List.of("git", "push")));
+    }
+
+    // ─── unknown commands ─────────────────────────────────────────────────
+
+    @Test
+    void unknownBinaryFallsThrough() {
+        assertNull(ShellRedirectPlanner.plan(List.of("ls")));
+        assertNull(ShellRedirectPlanner.plan(List.of("find", ".", "-name", "*.kt")));
+        assertNull(ShellRedirectPlanner.plan(List.of("tail", "x.log")));
+        assertNull(ShellRedirectPlanner.plan(List.of("curl", "https://example.com")));
+    }
+
+    @Test
+    void emptyArgvReturnsNull() {
+        assertNull(ShellRedirectPlanner.plan(List.of()));
+    }
+
+    // ─── header-stripping helper ──────────────────────────────────────────
+
+    @Test
+    void stripSearchTextHeaderRemovesSingleMatchHeader() {
+        assertEquals("file:1: hit\n",
+            ShellRedirectPlanner.stripSearchTextHeader("1 match:\nfile:1: hit\n"));
+    }
+
+    @Test
+    void stripSearchTextHeaderRemovesPluralHeader() {
+        assertEquals("a:1: x\nb:2: x\n",
+            ShellRedirectPlanner.stripSearchTextHeader("2 matches:\na:1: x\nb:2: x\n"));
+    }
+
+    @Test
+    void stripSearchTextHeaderLeavesNonHeaderUnchanged() {
+        assertEquals("No matches found for 'x'",
+            ShellRedirectPlanner.stripSearchTextHeader("No matches found for 'x'"));
+        assertEquals("file:1: line",
+            ShellRedirectPlanner.stripSearchTextHeader("file:1: line"));
+    }
+
+    // ─── RedirectPlan defaults ────────────────────────────────────────────
+
+    @Test
+    void redirectPlanOfDefaults() {
+        JsonObject args = new JsonObject();
+        RedirectPlan plan = RedirectPlan.of("read_file", args);
+        assertEquals("read_file", plan.toolName());
+        assertEquals("hello", plan.postProcess().apply("hello"));
+        assertEquals(0, plan.exitCodeFor().applyAsInt("anything"));
+    }
+}


### PR DESCRIPTION
## Why

Several ACP-based agents have no working way to disable their built-in tools, so they keep using them even when this plugin offers better MCP equivalents:

- **Copilot CLI** ignores `--excluded-tools` ([copilot-cli#556](https://github.com/github/copilot-cli/issues/556)).
- **Junie** has no exclusion mechanism — currently we deny built-in tool calls and the model fails.
- **Kiro** can be configured but hangs on permission prompts.

The previous workaround was to auto-approve the built-in tool then inject a "[System notice] use MCP instead" reprimand into the *next* prompt — by which point the wrong action already happened (stale read, VCS desync, etc.).

## The insight

Built-in agent tools (`view`, `edit`, `bash`, …) **don't execute inside the agent process** — they round-trip through ACP back to us as `fs/read_text_file`, `fs/write_text_file`, and `terminal/create`. We already dispatch these in `AcpClient.handleAgentRequest()`. So we can simply **redirect them to MCP equivalents before dispatching** — no PTY proxy, no shell hijacking, no agent cooperation needed.

## What gets intercepted (1:1, no shell parsing risk)

| ACP method | Built-in trigger | Redirected to | Win |
|---|---|---|---|
| \`fs/read_text_file\` | \`view\` / \`read\` | MCP \`read_file\` | Sees unsaved editor edits |
| \`fs/write_text_file\` | \`edit\` / \`write\` / \`create\` | MCP \`write_file\` | Undo stack + format + VCS sync |
| \`terminal/create cat <f>\` | \`bash cat\` | MCP \`read_file\` | Editor buffer sync |
| \`terminal/create head <f>\` | \`bash head\` | MCP \`read_file\` (lines 1..10) | Same |
| \`terminal/create git status\` | \`bash git status\` | MCP \`git_status\` | Branch context, no shell parse |

## What deliberately falls through

Conservative policy — anything we can't precisely emulate runs as a real OS process:

- Any shell metacharacter: \`|\`, \`;\`, \`&&\`, \`||\`, \`\$()\`, \`<\`, \`>\`, …
- Any flag we don't replicate: \`cat -n\`, \`tail\` without explicit \`-n N\`, …
- Mutating git ops: \`commit\`, \`push\`, \`rebase\`, …
- Build tools, package managers, network, anything else.

## Visible fall-through terminal

Per the request, fall-through commands no longer run in a hidden subprocess. \`VisibleProcessRunner\` mirrors stdout/stderr to a tab in the IDE **Run** tool window so the user can watch the command live and kill it with the standard stop button. Headless test contexts (no Application / no Project) transparently fall back to plain stream-reader threads.

## Architecture

\`\`\`
Agent calls built-in tool (e.g. bash \"cat foo.txt\")
  └── ACP: terminal/create → AcpClient.handleAgentRequest()
              ├── AcpToolInterceptor.tryInterceptTerminalCreate(...)
              │     ├── matched? → MCP read_file via PsiBridgeService → synthetic terminal
              │     └── unmatched OR MCP error → return null
              └── falls through to AcpTerminalHandler → VisibleProcessRunner
                    ├── Project present → OSProcessHandler + Run tool window tab
                    └── Project null    → daemon thread reading process stdout
\`\`\`

## New files

- \`intercept/ShellCommandSplitter.java\` — argv tokenizer rejecting unsafe metacharacters; supports single/double quotes and backslash escapes.
- \`intercept/AcpToolInterceptor.java\` — central interception logic with \`@Nullable\` returns so AcpClient falls back to \`fsHandler\` on MCP error.
- \`intercept/VisibleProcessRunner.java\` — wraps \`OSProcessHandler\` + \`ConsoleViewImpl\` + \`RunContentDescriptor\`; degrades gracefully when no Application/Project is available.

## Modified

- \`AcpTerminalHandler\` — now always uses \`VisibleProcessRunner\`; \`ManagedTerminal\` no longer owns its own reader thread.
- \`AcpClient\` — wires the interceptor into \`handleAgentRequest()\` with a \`redirected != null ? redirected : fsHandler.xxx()\` fallback so any MCP error degrades to the previous behavior instead of breaking.

## Tests

- 14 \`ShellCommandSplitter\` unit tests covering quoting, escaping, and every rejected metacharacter.
- 3 \`AcpToolInterceptor.isMcpError\` tests.
- All 622 ACP tests pass; full plugin-core suite unchanged (one pre-existing flaky \`EmbeddingServiceTest\` on master, unrelated).

## Which clients benefit

All ACP clients we ship: **Copilot, Junie, Kiro, OpenCode**. Non-ACP clients (Claude/Codex) call MCP directly and are unaffected.

## Follow-ups for a future PR

- Expand git interception to \`log\`/\`diff\`/\`show\`/\`branch\`/\`remote\`/\`tag\`/\`stash list\`.
- Add \`grep\`/\`rg\` → \`search_text\` interception.
- Verify each of Copilot/Junie/Kiro/OpenCode in the sandbox.