### PR TITLE
Merge PR #318 fix into master

### DIFF
--- a/docs/bugs/SCREEN-TEARING-BUG.md
+++ b/docs/bugs/SCREEN-TEARING-BUG.md
@@ -1,6 +1,6 @@
 # Screen Tearing Bug — JCEF OSR
 
-**Status**: Fix 4 applied — forced OSR invalidation removed (pending user verification on Win/Linux)  
+**Status**: Fix 5 applied — synchronous `scrollIfNeeded()` removed from `upsertToolChip()`
 **Scope**: JCEF Off-Screen Rendering (OSR) mode in the chat panel  
 **Affected area**: `ChatConsolePanel.kt`, `ChatContainer.ts`, `ChatController.ts`, `MessageBubble.ts`
 
@@ -119,11 +119,11 @@ scroll is re-enabled after streaming. During streaming this is a noop since beha
    `_setupCodeBlocks()` which processed `<pre>` elements inside streaming bubbles. The selector
    `pre:not(.streaming)` checked for a `.streaming` CSS class on `<pre>`, but the streaming
    attribute is on `<message-bubble>`, not `<pre>`. So during streaming:
-   - rAF renders markdown → creates `<pre>` elements
-   - `_copyObs` fires → `_setupCodeBlocks()` adds copy/wrap/scratch buttons
-   - Next token → `renderMarkdown()` replaces innerHTML → destroys buttons
-   - `_copyObs` fires again → re-adds buttons
-   - This mutation loop created continuous DOM churn and layout thrashing.
+    - rAF renders markdown → creates `<pre>` elements
+    - `_copyObs` fires → `_setupCodeBlocks()` adds copy/wrap/scratch buttons
+    - Next token → `renderMarkdown()` replaces innerHTML → destroys buttons
+    - `_copyObs` fires again → re-adds buttons
+    - This mutation loop created continuous DOM churn and layout thrashing.
 
    **Fix**: Changed selector to skip any `<pre>` inside `message-bubble[streaming]` using
    `pre.closest('message-bubble[streaming]')`. Buttons are only added after `finalize()`.
@@ -143,6 +143,8 @@ scroll is re-enabled after streaming. During streaming this is a noop since beha
    **Fix**: Added throttled per-`executeJs` `cef.invalidate()` during streaming (50ms throttle
    window). The repaintTimer remains as a 200ms safety net; the per-executeJs invalidation catches
    rapid bursts of JS updates.
+
+<<<<<<< HEAD
 
 ### Fix 4 — Remove forced OSR invalidation (this commit)
 
@@ -172,26 +174,43 @@ load), smooth-scroll suppression during streaming, the `_scrollRAF` debounce gat
 `_setupCodeBlocks()` streaming-bubble skip, and the `_scrollToInstant()` autoscroll
 helper.
 
+### Fix 5 — Remove synchronous `scrollIfNeeded()` from `upsertToolChip()` (this commit)
+
+**Observation**: Tearing persisted specifically when tool chips were added to the chat panel during
+streaming.
+
+**Root cause**: `upsertToolChip()` in `ChatController.ts` called `this._container()?.scrollIfNeeded()`
+synchronously immediately after `ctx.meta!.appendChild(chip)`. This writes `scrollTop = scrollHeight`,
+which forces a synchronous layout reflow. In JCEF OSR, a forced reflow during streaming can trigger an
+intermediate OSR paint that captures the DOM in a half-rendered state (chip appended, but its
+`connectedCallback` layout is not yet computed). The `scrollHeight` is also stale at this point for the
+same reason. The `MutationObserver` + `ResizeObserver` on `ChatContainer` already schedule a
+rAF-debounced `scrollIfNeeded()` for the same mutation, so the synchronous call was redundant.
+
+**Fix**: Removed the synchronous `scrollIfNeeded()` call from `upsertToolChip()`. The observers handle
+auto-scroll via rAF after layout is computed, identical to the Fix 3 fix for `appendAgentText()`.
+
 ---
 
 ## Code Locations
 
-| File | Component | Purpose |
-|---|---|---|
-| `ChatConsolePanel.kt` | `startStreaming()` | Sets 60fps, marks `streaming=true`, disables smooth scroll |
-| `ChatConsolePanel.kt` | `finishResponse()` | Sets 30fps, marks `streaming=false`, restores smooth scroll |
-| `ChatConsolePanel.kt` | `executeJs()` | Plain `executeJavaScript` — no manual `invalidate()` (Fix 4) |
-| `ChatConsolePanel.kt` | `setFrameRate()` | Wraps `setWindowlessFrameRate()` |
-| `ChatContainer.ts` | `_scrollRAF` | rAF debounce gate for scroll writes |
-| `ChatContainer.ts` | `ResizeObserver` | Debounced via `_scrollRAF` — never writes scrollTop directly |
-| `ChatContainer.ts` | `MutationObserver` | Auto-scroll trigger — debounced via `_scrollRAF` |
-| `ChatContainer.ts` | `_copyObs` | Code block buttons — skips streaming bubbles |
-| `ChatContainer.ts` | `_setupCodeBlocks()` | Checks `pre.closest('message-bubble[streaming]')` |
-| `ChatContainer.ts` | `setStreaming()` | Toggles CSS smooth-scroll policy between streaming and idle |
-| `ChatContainer.ts` | `_scrollToInstant()` | Temporarily forces `scroll-behavior: auto` for scroll |
-| `ChatController.ts` | `appendAgentText()` | No longer calls synchronous `scrollIfNeeded()` |
-| `MessageBubble.ts` | `appendStreamingText()` | rAF-debounced markdown re-render |
-| `MonitorSwitchRecovery.kt` | `triggerRecovery()` | Refreshes OSR and asks the chat panel to replay DOM state after monitor changes |
+| File                       | Component               | Purpose                                                                         |
+|----------------------------|-------------------------|---------------------------------------------------------------------------------|
+| `ChatConsolePanel.kt`      | `startStreaming()`      | Sets 60fps, marks `streaming=true`, disables smooth scroll                      |
+| `ChatConsolePanel.kt`      | `finishResponse()`      | Sets 30fps, marks `streaming=false`, restores smooth scroll                     |
+| `ChatConsolePanel.kt`      | `executeJs()`           | Plain `executeJavaScript` — no manual `invalidate()` (Fix 4)                    |
+| `ChatConsolePanel.kt`      | `setFrameRate()`        | Wraps `setWindowlessFrameRate()`                                                |
+| `ChatContainer.ts`         | `_scrollRAF`            | rAF debounce gate for scroll writes                                             |
+| `ChatContainer.ts`         | `ResizeObserver`        | Debounced via `_scrollRAF` — never writes scrollTop directly                    |
+| `ChatContainer.ts`         | `MutationObserver`      | Auto-scroll trigger — debounced via `_scrollRAF`                                |
+| `ChatContainer.ts`         | `_copyObs`              | Code block buttons — skips streaming bubbles                                    |
+| `ChatContainer.ts`         | `_setupCodeBlocks()`    | Checks `pre.closest('message-bubble[streaming]')`                               |
+| `ChatContainer.ts`         | `setStreaming()`        | Toggles CSS smooth-scroll policy between streaming and idle                     |
+| `ChatContainer.ts`         | `_scrollToInstant()`    | Temporarily forces `scroll-behavior: auto` for scroll                           |
+| `ChatController.ts`        | `appendAgentText()`     | No longer calls synchronous `scrollIfNeeded()` (Fix 3)                          |
+| `ChatController.ts`        | `upsertToolChip()`      | No longer calls synchronous `scrollIfNeeded()` (Fix 5)                          |
+| `MessageBubble.ts`         | `appendStreamingText()` | rAF-debounced markdown re-render                                                |
+| `MonitorSwitchRecovery.kt` | `triggerRecovery()`     | Refreshes OSR and asks the chat panel to replay DOM state after monitor changes |
 
 ---
 

--- a/plugin-core/chat-ui/src/ChatController.ts
+++ b/plugin-core/chat-ui/src/ChatController.ts
@@ -372,7 +372,9 @@ const ChatController = {
             chip.dataset.chipFor = id;
             ctx.meta!.appendChild(chip);
             ctx.meta!.classList.add('show');
-            this._container()?.scrollIfNeeded();
+            // scrollIfNeeded() removed — chip hasn't laid out yet (connectedCallback pending),
+            // so scrollHeight is stale. MutationObserver + ResizeObserver on ChatContainer
+            // already handle post-render auto-scroll via rAF. Same rationale as appendAgentText().
         }
         chip.setAttribute('label', title);
         chip.setAttribute('status', options?.status || 'pending');


### PR DESCRIPTION
Merge the screen tearing fix (PR #318) into master without merge commits.

This cherry-picks the fix commit that removes the synchronous scrollIfNeeded() call from upsertToolChip() which was causing JCEF OSR tearing during tool chip streaming.