### PR TITLE
refactor(review): hide agent-edit banner from agent + rename to 'Edited by agent'

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProvider.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProvider.java
@@ -80,7 +80,7 @@ public final class AgentEditNotificationProvider implements EditorNotificationPr
 
     /**
      * Builds the banner text with file and change counters.
-     * Example: "Review pending: File 3/7 · 5 changes"
+     * Example: "Edited by agent: File 3/7 · 5 changes"
      */
     private static @NotNull String buildStatusText(@NotNull Project project,
                                                    @NotNull VirtualFile file) {
@@ -104,7 +104,7 @@ public final class AgentEditNotificationProvider implements EditorNotificationPr
     }
 
     static @NotNull String formatBannerText(int fileIndex, int fileTotal, int changeCount) {
-        StringBuilder sb = new StringBuilder("Review pending: ");
+        StringBuilder sb = new StringBuilder("Edited by agent: ");
         if (fileTotal > 0) {
             sb.append("File ").append(Math.max(fileIndex, 1)).append('/').append(fileTotal);
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetHighlightsTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetHighlightsTool.java
@@ -29,9 +29,17 @@ import java.util.concurrent.TimeoutException;
 public final class GetHighlightsTool extends QualityTool {
 
     private static final Logger LOG = Logger.getInstance(GetHighlightsTool.class);
-    private static final String REVIEW_PENDING_AGENT_NOTE =
-        "[REVIEW_PENDING] User review is still pending for this file. "
-            + "Agent git commit/push/amend must wait for approval or rejection in the Review panel.";
+    /**
+     * Editor banners that are produced by AgentBridge itself (e.g. the agent-edit review
+     * banner) are noise for the agent — the agent generated the edit and the human-facing
+     * banner exists purely so the user can review later. Filter them out by prefix.
+     * Git-side gates (AgentEditSession.isGateActive) still enforce commit/push blocking
+     * when there are pending changes, so the agent doesn't need the banner to behave correctly.
+     */
+    static final String[] AGENT_EDIT_BANNER_PREFIXES = {
+        "[BANNER] Review pending:",
+        "[BANNER] Edited by agent:",
+    };
 
     private static final String PARAM_INCLUDE_UNINDEXED = "include_unindexed";
 
@@ -305,7 +313,7 @@ public final class GetHighlightsTool extends QualityTool {
                 var editor = editors[0];
                 List<String> notifications = PlatformApiCompat.collectEditorNotificationTexts(project, vf, editor)
                     .stream()
-                    .map(GetHighlightsTool::formatEditorNotificationForAgent)
+                    .filter(GetHighlightsTool::isVisibleToAgent)
                     .toList();
 
                 future.complete(notifications);
@@ -316,10 +324,14 @@ public final class GetHighlightsTool extends QualityTool {
         return future.get(10, TimeUnit.SECONDS);
     }
 
-    static @NotNull String formatEditorNotificationForAgent(@NotNull String notification) {
-        if (!notification.startsWith("[BANNER] Review pending:")) {
-            return notification;
+    /**
+     * Filters editor notifications to those the agent should actually see.
+     * AgentBridge's own agent-edit review banner is suppressed — see AGENT_EDIT_BANNER_PREFIXES.
+     */
+    static boolean isVisibleToAgent(@NotNull String notification) {
+        for (String prefix : AGENT_EDIT_BANNER_PREFIXES) {
+            if (notification.startsWith(prefix)) return false;
         }
-        return notification + "\n" + REVIEW_PENDING_AGENT_NOTE;
+        return true;
     }
 }

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProviderTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/review/AgentEditNotificationProviderTest.java
@@ -8,11 +8,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class AgentEditNotificationProviderTest {
 
     @Test
-    void bannerTextLeadsWithReviewPendingState() {
+    void bannerTextLeadsWithEditedByAgent() {
         String msg = AgentEditNotificationProvider.formatBannerText(1, 3, 2);
 
-        assertTrue(msg.startsWith("Review pending:"),
-            "Banner should lead with the pending-review state: " + msg);
+        assertTrue(msg.startsWith("Edited by agent:"),
+            "Banner should lead with the agent-edit state: " + msg);
         assertTrue(msg.contains("File 1/3"),
             "Banner should still include the file counter: " + msg);
         assertTrue(msg.contains("2 changes"),

--- a/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetHighlightsToolNotificationFormatTest.java
+++ b/plugin-core/src/test/java/com/github/catatafishen/agentbridge/psi/tools/quality/GetHighlightsToolNotificationFormatTest.java
@@ -2,26 +2,29 @@ package com.github.catatafishen.agentbridge.psi.tools.quality;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GetHighlightsToolNotificationFormatTest {
 
     @Test
-    void reviewBannerGetsAgentOnlyReviewNote() {
-        String formatted = GetHighlightsTool.formatEditorNotificationForAgent(
-            "[BANNER] Review pending: File 1/2 · 3 changes");
-
-        assertTrue(formatted.contains("[REVIEW_PENDING]"),
-            "Review banners should be expanded with an agent-only review note: " + formatted);
-        assertTrue(formatted.contains("must wait for approval or rejection"),
-            "The note should explicitly block agent-side git operations: " + formatted);
+    void agentEditReviewBannerIsHiddenFromAgent() {
+        // The "Edited by agent" banner exists for the human reviewer; surfacing it back to
+        // the agent that produced the edit is noise. The git-side gate still blocks
+        // commit/push when there are pending changes — see AgentEditSession.isGateActive.
+        assertFalse(GetHighlightsTool.isVisibleToAgent(
+            "[BANNER] Edited by agent: File 1/2 · 3 changes"));
     }
 
     @Test
-    void nonReviewNotificationsPassThroughUnchanged() {
-        String notification = "[BANNER] SDK mismatch";
+    void legacyReviewPendingBannerIsAlsoHiddenFromAgent() {
+        // Defensive: older snapshots / cached editors may still render the previous wording.
+        assertFalse(GetHighlightsTool.isVisibleToAgent(
+            "[BANNER] Review pending: File 1/2 · 3 changes"));
+    }
 
-        assertEquals(notification, GetHighlightsTool.formatEditorNotificationForAgent(notification));
+    @Test
+    void unrelatedNotificationsArePassedToAgent() {
+        assertTrue(GetHighlightsTool.isVisibleToAgent("[BANNER] SDK mismatch"));
     }
 }


### PR DESCRIPTION
Hides the 'Edited by agent' review banner from agent views and renames it for clarity.