### PR TITLE
docs: ACP tool interception postmortem + document bug #2948

### DIFF
--- a/docs/ACP-TOOL-INTERCEPTION.md
+++ b/docs/ACP-TOOL-INTERCEPTION.md
@@ -1,0 +1,136 @@
+# ACP Tool Interception — Investigation Postmortem
+
+**Status: Investigated but not adopted**  
+**Date:** Apr 25, 2026  
+**Related PRs:** [#320](https://github.com/catatafishen/agentbridge/pull/320) (closed without merge)  
+**Root bug:** [copilot-cli#2948](https://github.com/github/copilot-cli/issues/2948)
+
+---
+
+## Background
+
+The Copilot CLI exposes native built-in tools (`view`, `grep`, `glob`, `edit`, `create`, `bash`,
+`task`, `web_fetch`, etc.) to the agent alongside the MCP tools registered by this plugin.
+CLI flags to control which tools are exposed (`--available-tools`, `--excluded-tools`) silently
+do nothing in ACP mode (bug [#556](https://github.com/github/copilot-cli/issues/556),
+root cause filed as [#2948](https://github.com/github/copilot-cli/issues/2948)).
+
+**The goal:** when native `grep`/`glob` tools are executed, redirect them so the agent reads
+IntelliJ's live editor buffers instead of the raw file system. This would fix the `read_file`
+buffer-vs-disk divergence for sub-agents and parallel edits.
+
+---
+
+## What We Tried
+
+### Approach 1 — `session/request_permission` denial
+
+Deny native tools at the permission layer so the agent falls back to MCP equivalents.
+
+**Result:** Only works for write/execute tools (`bash`, `edit`, `create`). Read-only tools
+(`view`, `grep`, `glob`) execute without any permission step — they bypass the
+`session/request_permission` protocol entirely. Permanently not fixable via this channel.
+
+### Approach 2 — PATH shim (PR #320)
+
+Intercept native `rg` and `glob` via a shell script injected into `PATH`. The shim inspects
+the arguments and either calls through to the real binary or rewrites the call.
+
+**Result:** Intercepted ~30% of invocations. Native `rg`/`glob` tools send `tool_call` /
+`tool_call_update` as JSON-RPC notifications (informational, not executable requests). For
+`view`/`grep` the CLI calls `rg` via `node-pty` internal spawn, which does NOT consult the
+agent's `PATH` — it uses an absolute path or the CLI's own bundled binary. PATH shim only
+fires for the subset of invocations that go through a real child shell (`execvp` + PATH lookup),
+which is the minority path.
+
+**Why this edge-case-only:** The Copilot CLI's native tools are implemented in JS using
+`node-pty` or direct filesystem APIs. They do not shell out through a user-visible `PATH`
+environment. The shim catches commands the model explicitly runs in a bash block (when a
+sub-agent runs `rg` literally), but not the CLI's own internal search calls.
+
+**Code added and later reverted:**
+
+- `CopilotClient.buildShimPath()` — created a temp bash script shadowing `rg` and `patch`
+- `ShimLauncher` service — lifecycle management for the shim binary
+- `AcpClient.interceptBuiltInToolCall()` — post-hoc notification handler (had no effect,
+  see Sub-Agent Limitations section of `CLI-BUG-556-WORKAROUND.md`)
+
+---
+
+## What We Kept
+
+### `patch` tool passthrough
+
+The `patch` tool is kept in `BUILTIN_TOOLS_TO_SUPPRESS` as a **denied tool** but we also pass
+`--deny-tool patch` so it is blocked at the permission layer. If the CLI ever exposes a `patch`
+native tool, we want it denied by default.
+
+### `--deny-tool` + `--excluded-tools` dual flags
+
+`CopilotClient.buildCommand()` now passes both:
+
+- `--deny-tool <list>` — works today at the permission layer (blocks execution)
+- `--excluded-tools <list>` — will hide tools from the model once bug #2948 is fixed
+
+This forward-compatibility ensures the fix lands automatically without a plugin release.
+
+---
+
+## Architecture: How Native Tool Calls Flow
+
+```
+Agent decides to call "grep"
+         │
+         ▼
+CLI intercepts in JS (not via ACP)
+         │
+         ├── Sends tool_call / tool_call_update NOTIFICATION to ACP client (informational only)
+         │   └── Plugin receives it but CANNOT block or redirect
+         │
+         ├── Spawns rg internally (node-pty or direct Node fs API)
+         │   └── Ignores agent PATH; uses CLI-bundled binary
+         │
+         └── Returns result directly to model context
+```
+
+```
+Agent runs "grep" inside a bash block
+         │
+         ▼
+CLI spawns bash shell (uses agent PATH)
+         │
+         └── bash PATH lookup → could hit a shim here ← limited interception window
+                  │
+                  └── Even if intercepted: result returned via bash stdout, not IntelliJ buffers
+```
+
+---
+
+## Interception Matrix
+
+| Tool        | Delivery                     | Permission step? | PATH shim works? | Blockable? |
+|-------------|------------------------------|------------------|------------------|------------|
+| `view`      | Native JS (node-pty)         | No               | No               | ❌          |
+| `grep`      | Native JS (node-pty)         | No               | No               | ❌          |
+| `glob`      | Native JS (node-pty)         | No               | No               | ❌          |
+| `edit`      | `session/request_permission` | Yes              | N/A              | ✅ deny     |
+| `create`    | `session/request_permission` | Yes              | N/A              | ✅ deny     |
+| `bash`      | `session/request_permission` | Yes              | N/A              | ✅ deny     |
+| `task`      | `session/request_permission` | Yes              | N/A              | ✅ deny     |
+| `web_fetch` | `session/request_permission` | Yes              | N/A              | ✅ deny     |
+
+---
+
+## Conclusion
+
+There is no viable interception hook for read-only native tools (`view`, `grep`, `glob`) in the
+current CLI architecture. The only reliable path is CLI-side filtering once bug #2948 is fixed.
+
+Until then:
+
+- Write/execute tools are blocked via `--deny-tool` (forces agent to use MCP alternatives)
+- Read-only tools remain unblockable (results come from disk, not IntelliJ buffers)
+- For saved files this is acceptable (disk = buffer for committed files)
+- For unsaved buffers it remains a known limitation
+
+See `docs/bugs/CLI-BUG-556-WORKAROUND.md` for the full workaround history.

--- a/docs/bugs/CLI-BUG-556-WORKAROUND.md
+++ b/docs/bugs/CLI-BUG-556-WORKAROUND.md
@@ -267,14 +267,14 @@ as case 6.
 
 All cases ran against Copilot CLI 1.0.31 in `--acp` mode.
 
-| # | Flag / agent                                                                   | Model              | Result                                        |
-|---|--------------------------------------------------------------------------------|--------------------|-----------------------------------------------|
-| 1 | (none, baseline)                                                               | claude-sonnet-4.5  | 34 tools — full built-in set exposed          |
-| 2 | `--excluded-tools view,edit,create,bash,grep,glob,task`                        | claude-sonnet-4.5  | Identical 34-tool list — **flag ignored**     |
-| 3 | `--available-tools web_search,report_intent`                                   | claude-sonnet-4.5  | Identical 34-tool list — **whitelist ignored**|
-| 4 | `--deny-tool view,grep,glob`                                                   | claude-sonnet-4.5  | Identical 34-tool list — **flag ignored**     |
-| 5 | `--agent test-agent` with valid `tools: [web_search, report_intent]` frontmatter| claude-sonnet-4.5 | Identical 34-tool list — **agent `tools:` ignored** |
-| 6 | `--excluded-tools view,edit,create,bash,grep,glob`                             | claude-opus-4.7    | Identical 34-tool list — flag still ignored   |
+| # | Flag / agent                                                                     | Model             | Result                                              |
+|---|----------------------------------------------------------------------------------|-------------------|-----------------------------------------------------|
+| 1 | (none, baseline)                                                                 | claude-sonnet-4.5 | 34 tools — full built-in set exposed                |
+| 2 | `--excluded-tools view,edit,create,bash,grep,glob,task`                          | claude-sonnet-4.5 | Identical 34-tool list — **flag ignored**           |
+| 3 | `--available-tools web_search,report_intent`                                     | claude-sonnet-4.5 | Identical 34-tool list — **whitelist ignored**      |
+| 4 | `--deny-tool view,grep,glob`                                                     | claude-sonnet-4.5 | Identical 34-tool list — **flag ignored**           |
+| 5 | `--agent test-agent` with valid `tools: [web_search, report_intent]` frontmatter | claude-sonnet-4.5 | Identical 34-tool list — **agent `tools:` ignored** |
+| 6 | `--excluded-tools view,edit,create,bash,grep,glob`                               | claude-opus-4.7   | Identical 34-tool list — flag still ignored         |
 
 **Conclusion:** No change vs. v1.0.3 GA. `--excluded-tools`, `--available-tools`, `--deny-tool`,
 and per-agent `tools:` whitelists are all silently no-ops in ACP mode on CLI 1.0.31. Opus 4.7
@@ -287,13 +287,13 @@ Evidence: `.agent-work/experiments/bug-556-retest-1.0.31-results.md` (raw probe 
 
 Summary of the GitHub issues we depend on, all still **open** with no merged fix:
 
-| Issue | Title / scope                                                                  | Last activity        | Impact on us |
-|-------|--------------------------------------------------------------------------------|----------------------|--------------|
-| [#556](https://github.com/github/copilot-cli/issues/556)   | ACP mode ignores `--excluded-tools`, `--available-tools`, and per-agent `tools:` | Maintainer assigned; last comment Jan 5 2026 ("will check today" — no follow-up) | Primary — blocks tool filtering entirely |
-| [#1574](https://github.com/github/copilot-cli/issues/1574) | Custom JSON-RPC `tools` in `session/new` params silently ignored                 | Open                 | Cannot filter via the ACP session-create extension |
-| [#1607](https://github.com/github/copilot-cli/issues/1607) | ACP spec has no session-level permission primitive                               | Upstream ACP spec    | Structural — `request_permission` is the only hook we have |
-| [#1969](https://github.com/github/copilot-cli/issues/1969) | No `systemPrompt` in `session/new`                                               | Open                 | Forces us to use `prependInstructionsTo` + MCP `initialize.instructions` |
-| [#2059](https://github.com/github/copilot-cli/issues/2059) | ACP mode ignores most CLI flags (`--model`, `--agent`, etc.)                     | Open                 | Agent-file `tools:` route is therefore also dead |
+| Issue                                                      | Title / scope                                                                    | Last activity                                                                    | Impact on us                                                             |
+|------------------------------------------------------------|----------------------------------------------------------------------------------|----------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| [#556](https://github.com/github/copilot-cli/issues/556)   | ACP mode ignores `--excluded-tools`, `--available-tools`, and per-agent `tools:` | Maintainer assigned; last comment Jan 5 2026 ("will check today" — no follow-up) | Primary — blocks tool filtering entirely                                 |
+| [#1574](https://github.com/github/copilot-cli/issues/1574) | Custom JSON-RPC `tools` in `session/new` params silently ignored                 | Open                                                                             | Cannot filter via the ACP session-create extension                       |
+| [#1607](https://github.com/github/copilot-cli/issues/1607) | ACP spec has no session-level permission primitive                               | Upstream ACP spec                                                                | Structural — `request_permission` is the only hook we have               |
+| [#1969](https://github.com/github/copilot-cli/issues/1969) | No `systemPrompt` in `session/new`                                               | Open                                                                             | Forces us to use `prependInstructionsTo` + MCP `initialize.instructions` |
+| [#2059](https://github.com/github/copilot-cli/issues/2059) | ACP mode ignores most CLI flags (`--model`, `--agent`, etc.)                     | Open                                                                             | Agent-file `tools:` route is therefore also dead                         |
 
 **Collateral:** Our own `BundledAgentDeployer.deployAgent()` writes an HTML comment before the
 YAML frontmatter, which Copilot's agent loader then rejects as "malformed YAML frontmatter".
@@ -317,9 +317,59 @@ exposes them, and a replacement mapping per capability. `InstructionsManager` wa
 upgraded to splice the block in-place so upgrades refresh existing installs rather than
 stacking duplicate blocks.
 
+## Bug Root Cause: `--available-tools` / `--excluded-tools` Silently Ignored in ACP Mode
+
+**GitHub Issue:** https://github.com/github/copilot-cli/issues/2948  
+**Title:** `--available-tools` and `--excluded-tools` are silently ignored when used with `--acp`  
+**Status:** OPEN  
+**Reported:** Apr 25, 2026
+
+### What We Found
+
+The ACP startup path in `index.js` branches on `Jpt.newSession()` / `Jpt.loadSession()` and
+returns early **before** calling `session.updateOptions({ availableTools, excludedTools })`.
+The interactive (`Mto`) and non-interactive (`Cul`) code paths both call `updateOptions`, but the
+ACP path does not.
+
+```
+ACP startup path:
+  session = await Jpt.newSession(...)   // or Jpt.loadSession(...)
+  return { session, ... }               // ← EARLY RETURN — options never applied
+
+Interactive path (Mto):
+  session = await Jpt.newSession(...)
+  session.updateOptions({ availableTools, excludedTools })  // ← applied
+
+Non-interactive path (Cul):
+  session = await Jpt.newSession(...)
+  session.updateOptions({ availableTools, excludedTools })  // ← applied
+```
+
+### What `--deny-tool` Does (Different Mechanism)
+
+`--deny-tool` operates at the **permission layer** (`rules.denied`), not the tool filtering layer.
+It auto-denies `session/request_permission` requests before they reach the ACP client.
+
+When tools have a permission step (`bash`, `edit`, `create`), `--deny-tool` does block them
+**even in ACP mode**. It does **not** hide the tools from the model's tool list (the model can
+see and attempt them; the attempt just fails). See the "Experiment: `--deny-tool` Flag" section below for the history of
+why it appeared
+broken in early tests (wrong argument ordering, not a bug in the mechanism itself).
+
+### Current Mitigation
+
+We pass both `--deny-tool` and `--excluded-tools` with the same tool list:
+
+- `--deny-tool` blocks tools at the permission layer today (works for permission-gated tools)
+- `--excluded-tools` will hide tools from the model entirely once bug #2948 is fixed
+
+See `CopilotClient.BUILTIN_TOOLS_TO_SUPPRESS` for the current list.
+
 ## References
 
-- CLI Bug: https://github.com/github/copilot-cli/issues/556
+- CLI Bug #556 (tool filtering ignored in ACP mode): https://github.com/github/copilot-cli/issues/556
+- CLI Bug #2948 (--available-tools/--excluded-tools silently ignored in ACP — root cause
+  found): https://github.com/github/copilot-cli/issues/2948
 - CLI `--deny-tool` flag: discovered in `copilot --help` output, not documented in bug #556
 - Retest evidence: `.agent-work/experiments/bug-556-retest-1.0.31-results.md`
 - Probe script: `.agent-work/experiments/acp-tool-filter-probe.mjs`


### PR DESCRIPTION
Documents the failed PATH shim investigation from PR #320 as a postmortem. Explains why native rg/glob tools bypass both ACP and PATH shim. Also documents the root cause of bug #2948 in CLI-BUG-556-WORKAROUND.md.