### PR TITLE
fix: infer tool chip kind from registry

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpMessageParser.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/AcpMessageParser.java
@@ -162,6 +162,11 @@ class AcpMessageParser {
             status = SessionUpdate.ToolCallStatus.fromString(params.get(KEY_STATUS).getAsString());
         }
 
+        SessionUpdate.ToolKind kind = null;
+        if (params.has("kind")) {
+            kind = SessionUpdate.ToolKind.fromString(params.get("kind").getAsString());
+        }
+
         String error = params.has("error") ? params.get("error").getAsString() : null;
         String description = params.has(KEY_DESCRIPTION) ? params.get(KEY_DESCRIPTION).getAsString() : null;
         String result = extractResultText(params);
@@ -172,7 +177,7 @@ class AcpMessageParser {
             arguments = params.get(KEY_RAW_INPUT).getAsJsonObject().toString();
         }
 
-        return new SessionUpdate.ToolCallUpdate(toolCallId, status, result, error, description, false, null, arguments);
+        return new SessionUpdate.ToolCallUpdate(toolCallId, status, result, error, description, false, null, arguments, kind);
     }
 
     private @Nullable String extractResultText(JsonObject params) {

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/model/SessionUpdate.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/model/SessionUpdate.java
@@ -245,6 +245,7 @@ public sealed interface SessionUpdate
      * @param autoDenied   true if the tool was automatically denied by the plugin (security/policy)
      * @param denialReason human-readable reason for the auto-denial, or null
      * @param arguments    raw tool arguments from the update (may be null) - used for re-correlation
+     * @param kind         tool kind for chip coloring (may be null if not provided by agent)
      */
     record ToolCallUpdate(
         @NotNull String toolCallId,
@@ -254,14 +255,15 @@ public sealed interface SessionUpdate
         @Nullable String description,
         boolean autoDenied,
         @Nullable String denialReason,
-        @Nullable String arguments
+        @Nullable String arguments,
+        @Nullable ToolKind kind
     ) implements SessionUpdate {
         public ToolCallUpdate(@NotNull String toolCallId, @NotNull ToolCallStatus status, @Nullable String result, @Nullable String error, @Nullable String description) {
-            this(toolCallId, status, result, error, description, false, null, null);
+            this(toolCallId, status, result, error, description, false, null, null, null);
         }
 
         public ToolCallUpdate(@NotNull String toolCallId, @NotNull ToolCallStatus status, @Nullable String result, @Nullable String error, @Nullable String description, boolean autoDenied, @Nullable String denialReason) {
-            this(toolCallId, status, result, error, description, autoDenied, denialReason, null);
+            this(toolCallId, status, result, error, description, autoDenied, denialReason, null, null);
         }
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -463,13 +463,15 @@ public final class PsiBridgeService implements Disposable {
             outputSize = result.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
             ToolChipRegistry.getInstance(project).storeMcpResult(req.toolName(), req.arguments(), result);
             return result;
-        } catch (com.intellij.openapi.application.ex.ApplicationUtil.CannotRunReadActionException e) {
-            success = false;
-            errorMessage = "Error: IDE is busy, please retry. " + e.getMessage();
-            ToolChipRegistry.getInstance(project).storeMcpResult(req.toolName(), req.arguments(), errorMessage);
-            return errorMessage;
         } catch (com.intellij.openapi.progress.ProcessCanceledException e) {
-            // Must not be swallowed — signals IDE shutdown or project disposal.
+            if (e instanceof com.intellij.openapi.application.ex.ApplicationUtil.CannotRunReadActionException) {
+                // IDE was temporarily busy — not a shutdown signal; return a retryable error.
+                success = false;
+                errorMessage = "Error: IDE is busy, please retry. " + e.getMessage();
+                ToolChipRegistry.getInstance(project).storeMcpResult(req.toolName(), req.arguments(), errorMessage);
+                return errorMessage;
+            }
+            // All other PCE variants signal IDE shutdown or project disposal — must rethrow.
             throw e;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
@@ -56,6 +56,13 @@ public abstract class FileTool extends Tool {
 
     // ── Deferred auto-format (per-project) ────────────────────────────────────
 
+    /**
+     * Maximum number of files to process in a single auto-format flush.
+     * Prevents EDT saturation when many files are queued: each file's format
+     * runs inside a WriteCommandAction (blocking EDT). Overflow is requeued.
+     */
+    private static final int MAX_AUTO_FORMAT_FILES = 10;
+
     private static final ConcurrentHashMap<Project, Set<String>> PENDING_AUTO_FORMAT =
         new ConcurrentHashMap<>();
 
@@ -70,6 +77,21 @@ public abstract class FileTool extends Tool {
 
         List<String> paths = new ArrayList<>(pathSet);
 
+        // Safety cap: if too many files are queued, process only the first batch and requeue
+        // the rest. This prevents EDT saturation from blocking the editor for 30+ seconds.
+        if (paths.size() > MAX_AUTO_FORMAT_FILES) {
+            LOG.warn("Auto-format batch capped at " + MAX_AUTO_FORMAT_FILES + " of " + paths.size()
+                + " files; requeueing overflow for the next turn");
+            List<String> overflow = paths.subList(MAX_AUTO_FORMAT_FILES, paths.size());
+            PENDING_AUTO_FORMAT.merge(project,
+                Collections.synchronizedSet(new LinkedHashSet<>(overflow)),
+                (existing, added) -> {
+                    existing.addAll(added);
+                    return existing;
+                });
+            paths = new ArrayList<>(paths.subList(0, MAX_AUTO_FORMAT_FILES));
+        }
+
         if (com.intellij.openapi.application.ApplicationManager.getApplication().isDispatchThread()) {
             for (String pathStr : paths) {
                 formatSingleFile(project, pathStr);
@@ -79,26 +101,50 @@ public abstract class FileTool extends Tool {
         }
 
         java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
-        java.util.concurrent.atomic.AtomicInteger remaining = new java.util.concurrent.atomic.AtomicInteger(paths.size());
+        AtomicBoolean cancelled = new AtomicBoolean(false);
 
-        for (String pathStr : paths) {
-            EdtUtil.invokeLater(() -> {
-                formatSingleFile(project, pathStr);
-                if (remaining.decrementAndGet() == 0) {
-                    saveAllDocuments();
-                    latch.countDown();
-                }
-            });
-        }
+        scheduleNextFormat(project, paths, 0, latch, cancelled);
 
         try {
             if (!latch.await(30, java.util.concurrent.TimeUnit.SECONDS)) {
+                // Stop the EDT chain — without this, remaining invokeLater tasks would keep running
+                // after we return, blocking the EDT and causing subsequent invokeAndWait calls to time out.
+                cancelled.set(true);
                 LOG.warn("flushPendingAutoFormat timed out after 30 seconds");
             }
         } catch (InterruptedException e) {
+            cancelled.set(true);
             Thread.currentThread().interrupt();
             LOG.warn("flushPendingAutoFormat interrupted");
         }
+    }
+
+    /**
+     * Chains auto-format operations sequentially via {@code invokeLater}, one file per EDT event.
+     * <p>
+     * Unlike bulk-dispatching all files at once, chaining allows the EDT to process paint and
+     * input events between each file — keeping the editor responsive during multi-file formatting.
+     * The {@code cancelled} flag is checked before each step so that a background-thread timeout
+     * in {@link #flushPendingAutoFormat} immediately stops further scheduling.
+     */
+    private static void scheduleNextFormat(Project project, List<String> paths, int index,
+                                           java.util.concurrent.CountDownLatch latch,
+                                           AtomicBoolean cancelled) {
+        if (cancelled.get() || project.isDisposed()) {
+            latch.countDown(); // no-op if background thread already timed out
+            return;
+        }
+        if (index >= paths.size()) {
+            saveAllDocuments();
+            latch.countDown();
+            return;
+        }
+        EdtUtil.invokeLater(() -> {
+            if (!cancelled.get() && !project.isDisposed()) {
+                formatSingleFile(project, paths.get(index));
+            }
+            scheduleNextFormat(project, paths, index + 1, latch, cancelled);
+        });
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/KiroClientConfigurable.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/settings/KiroClientConfigurable.java
@@ -22,7 +22,7 @@ import java.awt.*;
 
 public final class KiroClientConfigurable implements Configurable {
 
-    public static final int DEFAULT_CONTEXT_LIMIT_CHARS = 600_000;
+    public static final int DEFAULT_CONTEXT_LIMIT_CHARS = 300_000;
 
     private static final String AGENT_ID = "kiro";
 
@@ -56,7 +56,7 @@ public final class KiroClientConfigurable implements Configurable {
             0, 2_000_000, 50_000));
         contextLimitSpinner.setToolTipText(
             "<html>Maximum characters of conversation history exported to Kiro's session file.<br>"
-                + "0 = unlimited. Reduce if Kiro reports context overflow. Default: 600 000.</html>");
+                + "0 = unlimited. Reduce if Kiro reports context overflow. Default: 300 000.</html>");
 
         HyperlinkLabel docsLink = new HyperlinkLabel("Kiro CLI documentation at kiro.dev/docs/cli/acp");
         docsLink.setHyperlinkTarget("https://kiro.dev/docs/cli/acp/");

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -434,7 +434,9 @@ class ChatConsolePanel(
         }
 
         finalizeCurrentText()
-        val resolvedKind = kind ?: "other"
+        val resolvedKind = kind?.takeIf { it != "other" }
+            ?: toolRegistry?.findById(cleanTitle)?.kind()?.value()
+            ?: "other"
 
         // Extract file path from arguments for edit tools
         val filePath = extractFilePathFromArgs(arguments)
@@ -583,8 +585,10 @@ class ChatConsolePanel(
         kind: String?
     ) {
         val saDid = domId(subAgentId)
-        val resolvedKind = kind ?: "other"
         val cleanTitle = title.trim('\'', '"')
+        val resolvedKind = kind?.takeIf { it != "other" }
+            ?: toolRegistry?.findById(cleanTitle)?.kind()?.value()
+            ?: "other"
 
         val reg = registerToolChip(cleanTitle, arguments, resolvedKind, toolId)
         val isExternal = !reg.isMcpHandled

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatConsolePanel.kt
@@ -483,13 +483,15 @@ class ChatConsolePanel(
             )
         )
 
+        // Update kind if provided (OpenCode sends kind in tool_call_update with status=completed)
+        if (update.kind != null) {
+            val jsKind = update.kind.replace("'", "\\'")
+            executeJs("ChatController.updateToolCallKind('$did','$jsKind')")
+        }
+
         // For intermediate running state, update DOM immediately
         if (status == "running") {
             executeJs("ChatController.setToolChipState('$did','running')")
-            if (update.kind != null) {
-                val jsKind = update.kind.replace("'", "\\'")
-                executeJs("ChatController.updateToolCallKind('$did','$jsKind')")
-            }
             return
         }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -90,6 +90,8 @@ class ChatToolWindowContent(
     private var restartSessionGroup: RestartSessionGroup? = null
     private lateinit var promptTextArea: EditorTextField
     private lateinit var shortcutHintPanel: PromptShortcutHintPanel
+    private lateinit var shortcutHintBar: JPanel
+    private lateinit var shortcutHintRightGroup: JPanel
     private val queuedTexts = ArrayDeque<String>()
 
     @Volatile
@@ -761,9 +763,8 @@ class ChatToolWindowContent(
         }
         inputSection.isOpaque = false
         // 8px top inset doubles as the resize drag zone (see resizeHandler below).
-        // Bottom inset is 2 (not 4) so the model selector / send button sit close
-        // to the rounded bottom border instead of leaving a wide empty band.
-        inputSection.border = JBUI.Borders.empty(8, 0, 2, 4)
+        // The surrounding padding is kept tight so the footer reads as one compact unit.
+        inputSection.border = JBUI.Borders.empty(6, 0, 1, 2)
         inputSection.add(sideButtonsPanel, BorderLayout.WEST)
         inputSection.add(inputRow, BorderLayout.CENTER)
 
@@ -772,14 +773,8 @@ class ChatToolWindowContent(
 
         val bottomSection = JBPanel<JBPanel<*>>(BorderLayout())
         bottomSection.isOpaque = false
-        // 8px left padding aligns the input-frame edge with the chat-message bubbles
-        // above (chat-container's 8px CSS left padding = 8px from the tool-window edge).
-        // The right side keeps an 8px gap too — the chat scrollbar sits flush against
-        // the tool-window right edge, but symmetric padding here prevents the input
-        // frame from overlapping that vertical scrollbar lane visually.
-        // 2px bottom keeps the frame close to the tool-window bottom without touching
-        // the IDE status bar.
-        bottomSection.border = JBUI.Borders.empty(0, 8, 2, 8)
+        // Keep the footer close to the tool window edges without adding dead space.
+        bottomSection.border = JBUI.Borders.empty(0, 6, 1, 6)
         bottomSection.add(inputSection, BorderLayout.CENTER)
 
         // Drag-to-resize: the user drags the top border of inputSection to adjust the split.
@@ -993,8 +988,10 @@ class ChatToolWindowContent(
         val innerBar = JBPanel<JBPanel<*>>().apply {
             layout = GridBagLayout()
             isOpaque = false
-            border = JBUI.Borders.empty(0, 2, 0, 2)
+            border = JBUI.Borders.empty(0, 1)
         }
+        shortcutHintBar = innerBar
+        shortcutHintRightGroup = rightGroup
         innerBar.add(shortcutHintPanel, GridBagConstraints().apply {
             gridx = 0; gridy = 0
             weightx = 1.0; weighty = 0.0
@@ -1007,9 +1004,15 @@ class ChatToolWindowContent(
             fill = GridBagConstraints.NONE
             anchor = GridBagConstraints.EAST
         })
+        innerBar.addComponentListener(object : java.awt.event.ComponentAdapter() {
+            override fun componentResized(e: java.awt.event.ComponentEvent) {
+                updateShortcutHintVisibility()
+            }
+        })
         row.add(innerBar, BorderLayout.SOUTH)
 
         refreshShortcutHints()
+        updateShortcutHintVisibility()
 
         return row
     }
@@ -1132,9 +1135,8 @@ class ChatToolWindowContent(
 
     fun setShortcutHintsVisible() {
         if (!::shortcutHintPanel.isInitialized) return
-        shortcutHintPanel.isVisible =
-            com.github.catatafishen.agentbridge.settings.ChatInputSettings.getInstance().isShowShortcutHints
         refreshShortcutHints()
+        updateShortcutHintVisibility()
     }
 
     /**
@@ -1148,7 +1150,6 @@ class ChatToolWindowContent(
      */
     private fun refreshShortcutHints() {
         if (!::shortcutHintPanel.isInitialized) return
-        if (!shortcutHintPanel.isVisible) return
         val list = mutableListOf<Pair<KeyStroke, String>>()
         if (isSending) {
             list += PromptShortcutAction.resolveKeystroke(
@@ -1186,6 +1187,26 @@ class ChatToolWindowContent(
             list += KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_UP, 0) to "Edit last"
         }
         shortcutHintPanel.setShortcuts(list)
+        updateShortcutHintVisibility()
+    }
+
+    private fun updateShortcutHintVisibility() {
+        if (!::shortcutHintPanel.isInitialized || !::shortcutHintBar.isInitialized || !::shortcutHintRightGroup.isInitialized) {
+            return
+        }
+        val settingsVisible =
+            com.github.catatafishen.agentbridge.settings.ChatInputSettings.getInstance().isShowShortcutHints
+        val availableWidth = shortcutHintBar.width
+        if (availableWidth <= 0) return
+        val gap = JBUI.scale(8)
+        val requiredWidth = shortcutHintRightGroup.preferredSize.width +
+            if (settingsVisible) shortcutHintPanel.preferredSize.width + gap else 0
+        val showHints = settingsVisible && availableWidth >= requiredWidth
+        if (shortcutHintPanel.isVisible != showHints) {
+            shortcutHintPanel.isVisible = showHints
+            shortcutHintBar.revalidate()
+            shortcutHintBar.repaint()
+        }
     }
 
     private fun setSendingState(sending: Boolean) {
@@ -1306,14 +1327,13 @@ class ChatToolWindowContent(
         override fun getActionUpdateThread() = ActionUpdateThread.EDT
 
         override fun createCustomComponent(presentation: Presentation, place: String): JComponent {
-            // Primary-styled labeled button so the Send action reads as the dominant CTA.
-            // Icon on the left, "Send" text on the right. The label stays "Send" in all
-            // states; the button's behavior (direct send vs. nudge/queue/stop dropdown)
-            // depends on isSending and is handled in the action listener below.
-            val button = JButton(presentation.text ?: "Send", sendIcon)
+            // Compact icon-only button keeps the footer from growing taller than the
+            // dropdowns beside it while still exposing the action through the tooltip.
+            val button = JButton(sendIcon)
             button.putClientProperty("JButton.buttonType", "primary")
             button.isFocusable = false
-            button.margin = JBUI.insets(2, 8)
+            button.margin = JBUI.insets(0, 6)
+            button.iconTextGap = 0
             button.toolTipText = presentation.description
             // Direct routing avoids the deprecated AnActionEvent.createFromAnAction.
             button.addActionListener {
@@ -1330,7 +1350,8 @@ class ChatToolWindowContent(
         override fun updateCustomComponent(component: JComponent, presentation: Presentation) {
             (component as? JButton)?.let { btn ->
                 btn.isEnabled = presentation.isEnabled
-                btn.text = presentation.text
+                btn.text = ""
+                btn.icon = presentation.icon ?: sendIcon
                 btn.toolTipText = presentation.description
             }
         }
@@ -1340,12 +1361,12 @@ class ChatToolWindowContent(
             val hasText = promptTextArea.text.trim().isNotEmpty()
             if (isSending && !consolePanel.hasPendingAskUserRequest()) {
                 e.presentation.icon = sendIcon
-                e.presentation.text = "Send"
+                e.presentation.text = ""
                 e.presentation.description = "Nudge, queue, or stop and send"
                 e.presentation.isEnabled = hasText
             } else {
                 e.presentation.icon = sendIcon
-                e.presentation.text = "Send"
+                e.presentation.text = ""
                 e.presentation.description = if (isLoggedIn) "Send prompt (Enter)" else "Sign in to Copilot first"
                 e.presentation.isEnabled = isLoggedIn && hasText
             }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/KeyBadge.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/KeyBadge.kt
@@ -17,7 +17,7 @@ class KeyBadge(text: String) : JBLabel(text) {
     init {
         font = JBUI.Fonts.smallFont()
         foreground = UIUtil.getLabelForeground()
-        border = JBUI.Borders.empty(2, 6, 2, 6)
+        border = JBUI.Borders.empty(2, 6)
         isOpaque = false
     }
 
@@ -72,6 +72,7 @@ class KeyBadge(text: String) : JBLabel(text) {
                         KeyEvent.VK_BACK_SPACE -> "⌫"
                         KeyEvent.VK_ESCAPE -> "Esc"
                         KeyEvent.VK_TAB -> "⇥"
+                        KeyEvent.VK_UP -> "↑"
                         else -> KeyEvent.getKeyText(stroke.keyCode)
                     }
                 )

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptOrchestrator.kt
@@ -649,6 +649,7 @@ class PromptOrchestrator(
         val autoDenied = update.autoDenied()
         val denialReason = update.denialReason()
         val arguments = update.arguments() // raw arguments from tool_call_update
+        val kind = update.kind()?.value() // tool kind from tool_call_update (may be null)
 
         // Store arguments for potential re-correlation
         if (arguments != null) {
@@ -686,7 +687,7 @@ class PromptOrchestrator(
                 result = result, description = description,
                 isSubAgent = isSubAgent, isInternal = isInternal,
                 autoDenied = autoDenied, denialReason = denialReason,
-                arguments = arguments, title = callType
+                arguments = arguments, title = callType, kind = kind
             )
         )
 
@@ -699,7 +700,7 @@ class PromptOrchestrator(
         val result: String?, val description: String?,
         val isSubAgent: Boolean, val isInternal: Boolean,
         val autoDenied: Boolean = false, val denialReason: String? = null,
-        val arguments: String? = null, val title: String? = null
+        val arguments: String? = null, val title: String? = null, val kind: String? = null
     )
 
     private fun updateToolCallUi(toolCallId: String, uiStatus: String, update: ToolCallUiUpdate) {
@@ -746,7 +747,8 @@ class PromptOrchestrator(
                     autoDenied = update.autoDenied,
                     denialReason = update.denialReason,
                     arguments = update.arguments,
-                    title = update.title
+                    title = update.title,
+                    kind = update.kind
                 )
             )
         }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutHintPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutHintPanel.kt
@@ -30,7 +30,7 @@ class PromptShortcutHintPanel : JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.LEFT, 
 
     init {
         isOpaque = false
-        border = JBUI.Borders.empty(0, 4, 0, 4)
+        border = JBUI.Borders.empty()
     }
 
     /**


### PR DESCRIPTION
OpenCode ACP tool_call events can omit kind, which previously forced chips to render as \'other\' (grey).\n\nThis PR falls back to ToolRegistry metadata when ACP omits the kind so agentbridge tools keep their intended color.