### PR TITLE
fix(ui): tighten chat footer layout

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PsiBridgeService.java
@@ -463,13 +463,15 @@ public final class PsiBridgeService implements Disposable {
             outputSize = result.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
             ToolChipRegistry.getInstance(project).storeMcpResult(req.toolName(), req.arguments(), result);
             return result;
-        } catch (com.intellij.openapi.application.ex.ApplicationUtil.CannotRunReadActionException e) {
-            success = false;
-            errorMessage = "Error: IDE is busy, please retry. " + e.getMessage();
-            ToolChipRegistry.getInstance(project).storeMcpResult(req.toolName(), req.arguments(), errorMessage);
-            return errorMessage;
         } catch (com.intellij.openapi.progress.ProcessCanceledException e) {
-            // Must not be swallowed — signals IDE shutdown or project disposal.
+            if (e instanceof com.intellij.openapi.application.ex.ApplicationUtil.CannotRunReadActionException) {
+                // IDE was temporarily busy — not a shutdown signal; return a retryable error.
+                success = false;
+                errorMessage = "Error: IDE is busy, please retry. " + e.getMessage();
+                ToolChipRegistry.getInstance(project).storeMcpResult(req.toolName(), req.arguments(), errorMessage);
+                return errorMessage;
+            }
+            // All other PCE variants signal IDE shutdown or project disposal — must rethrow.
             throw e;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/file/FileTool.java
@@ -56,6 +56,13 @@ public abstract class FileTool extends Tool {
 
     // ── Deferred auto-format (per-project) ────────────────────────────────────
 
+    /**
+     * Maximum number of files to process in a single auto-format flush.
+     * Prevents EDT saturation when many files are queued: each file's format
+     * runs inside a WriteCommandAction (blocking EDT). Overflow is requeued.
+     */
+    private static final int MAX_AUTO_FORMAT_FILES = 10;
+
     private static final ConcurrentHashMap<Project, Set<String>> PENDING_AUTO_FORMAT =
         new ConcurrentHashMap<>();
 
@@ -70,6 +77,21 @@ public abstract class FileTool extends Tool {
 
         List<String> paths = new ArrayList<>(pathSet);
 
+        // Safety cap: if too many files are queued, process only the first batch and requeue
+        // the rest. This prevents EDT saturation from blocking the editor for 30+ seconds.
+        if (paths.size() > MAX_AUTO_FORMAT_FILES) {
+            LOG.warn("Auto-format batch capped at " + MAX_AUTO_FORMAT_FILES + " of " + paths.size()
+                + " files; requeueing overflow for the next turn");
+            List<String> overflow = paths.subList(MAX_AUTO_FORMAT_FILES, paths.size());
+            PENDING_AUTO_FORMAT.merge(project,
+                Collections.synchronizedSet(new LinkedHashSet<>(overflow)),
+                (existing, added) -> {
+                    existing.addAll(added);
+                    return existing;
+                });
+            paths = new ArrayList<>(paths.subList(0, MAX_AUTO_FORMAT_FILES));
+        }
+
         if (com.intellij.openapi.application.ApplicationManager.getApplication().isDispatchThread()) {
             for (String pathStr : paths) {
                 formatSingleFile(project, pathStr);
@@ -79,26 +101,50 @@ public abstract class FileTool extends Tool {
         }
 
         java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
-        java.util.concurrent.atomic.AtomicInteger remaining = new java.util.concurrent.atomic.AtomicInteger(paths.size());
+        AtomicBoolean cancelled = new AtomicBoolean(false);
 
-        for (String pathStr : paths) {
-            EdtUtil.invokeLater(() -> {
-                formatSingleFile(project, pathStr);
-                if (remaining.decrementAndGet() == 0) {
-                    saveAllDocuments();
-                    latch.countDown();
-                }
-            });
-        }
+        scheduleNextFormat(project, paths, 0, latch, cancelled);
 
         try {
             if (!latch.await(30, java.util.concurrent.TimeUnit.SECONDS)) {
+                // Stop the EDT chain — without this, remaining invokeLater tasks would keep running
+                // after we return, blocking the EDT and causing subsequent invokeAndWait calls to time out.
+                cancelled.set(true);
                 LOG.warn("flushPendingAutoFormat timed out after 30 seconds");
             }
         } catch (InterruptedException e) {
+            cancelled.set(true);
             Thread.currentThread().interrupt();
             LOG.warn("flushPendingAutoFormat interrupted");
         }
+    }
+
+    /**
+     * Chains auto-format operations sequentially via {@code invokeLater}, one file per EDT event.
+     * <p>
+     * Unlike bulk-dispatching all files at once, chaining allows the EDT to process paint and
+     * input events between each file — keeping the editor responsive during multi-file formatting.
+     * The {@code cancelled} flag is checked before each step so that a background-thread timeout
+     * in {@link #flushPendingAutoFormat} immediately stops further scheduling.
+     */
+    private static void scheduleNextFormat(Project project, List<String> paths, int index,
+                                           java.util.concurrent.CountDownLatch latch,
+                                           AtomicBoolean cancelled) {
+        if (cancelled.get() || project.isDisposed()) {
+            latch.countDown(); // no-op if background thread already timed out
+            return;
+        }
+        if (index >= paths.size()) {
+            saveAllDocuments();
+            latch.countDown();
+            return;
+        }
+        EdtUtil.invokeLater(() -> {
+            if (!cancelled.get() && !project.isDisposed()) {
+                formatSingleFile(project, paths.get(index));
+            }
+            scheduleNextFormat(project, paths, index + 1, latch, cancelled);
+        });
     }
 
     /**

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -90,6 +90,8 @@ class ChatToolWindowContent(
     private var restartSessionGroup: RestartSessionGroup? = null
     private lateinit var promptTextArea: EditorTextField
     private lateinit var shortcutHintPanel: PromptShortcutHintPanel
+    private lateinit var shortcutHintBar: JPanel
+    private lateinit var shortcutHintRightGroup: JPanel
     private val queuedTexts = ArrayDeque<String>()
 
     @Volatile
@@ -761,9 +763,8 @@ class ChatToolWindowContent(
         }
         inputSection.isOpaque = false
         // 8px top inset doubles as the resize drag zone (see resizeHandler below).
-        // Bottom inset is 2 (not 4) so the model selector / send button sit close
-        // to the rounded bottom border instead of leaving a wide empty band.
-        inputSection.border = JBUI.Borders.empty(8, 0, 2, 4)
+        // The surrounding padding is kept tight so the footer reads as one compact unit.
+        inputSection.border = JBUI.Borders.empty(6, 0, 1, 2)
         inputSection.add(sideButtonsPanel, BorderLayout.WEST)
         inputSection.add(inputRow, BorderLayout.CENTER)
 
@@ -772,14 +773,8 @@ class ChatToolWindowContent(
 
         val bottomSection = JBPanel<JBPanel<*>>(BorderLayout())
         bottomSection.isOpaque = false
-        // 8px left padding aligns the input-frame edge with the chat-message bubbles
-        // above (chat-container's 8px CSS left padding = 8px from the tool-window edge).
-        // The right side keeps an 8px gap too — the chat scrollbar sits flush against
-        // the tool-window right edge, but symmetric padding here prevents the input
-        // frame from overlapping that vertical scrollbar lane visually.
-        // 2px bottom keeps the frame close to the tool-window bottom without touching
-        // the IDE status bar.
-        bottomSection.border = JBUI.Borders.empty(0, 8, 2, 8)
+        // Keep the footer close to the tool window edges without adding dead space.
+        bottomSection.border = JBUI.Borders.empty(0, 6, 1, 6)
         bottomSection.add(inputSection, BorderLayout.CENTER)
 
         // Drag-to-resize: the user drags the top border of inputSection to adjust the split.
@@ -993,8 +988,10 @@ class ChatToolWindowContent(
         val innerBar = JBPanel<JBPanel<*>>().apply {
             layout = GridBagLayout()
             isOpaque = false
-            border = JBUI.Borders.empty(0, 2, 0, 2)
+            border = JBUI.Borders.empty(0, 1)
         }
+        shortcutHintBar = innerBar
+        shortcutHintRightGroup = rightGroup
         innerBar.add(shortcutHintPanel, GridBagConstraints().apply {
             gridx = 0; gridy = 0
             weightx = 1.0; weighty = 0.0
@@ -1007,9 +1004,15 @@ class ChatToolWindowContent(
             fill = GridBagConstraints.NONE
             anchor = GridBagConstraints.EAST
         })
+        innerBar.addComponentListener(object : java.awt.event.ComponentAdapter() {
+            override fun componentResized(e: java.awt.event.ComponentEvent) {
+                updateShortcutHintVisibility()
+            }
+        })
         row.add(innerBar, BorderLayout.SOUTH)
 
         refreshShortcutHints()
+        updateShortcutHintVisibility()
 
         return row
     }
@@ -1132,9 +1135,8 @@ class ChatToolWindowContent(
 
     fun setShortcutHintsVisible() {
         if (!::shortcutHintPanel.isInitialized) return
-        shortcutHintPanel.isVisible =
-            com.github.catatafishen.agentbridge.settings.ChatInputSettings.getInstance().isShowShortcutHints
         refreshShortcutHints()
+        updateShortcutHintVisibility()
     }
 
     /**
@@ -1148,7 +1150,6 @@ class ChatToolWindowContent(
      */
     private fun refreshShortcutHints() {
         if (!::shortcutHintPanel.isInitialized) return
-        if (!shortcutHintPanel.isVisible) return
         val list = mutableListOf<Pair<KeyStroke, String>>()
         if (isSending) {
             list += PromptShortcutAction.resolveKeystroke(
@@ -1186,6 +1187,26 @@ class ChatToolWindowContent(
             list += KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_UP, 0) to "Edit last"
         }
         shortcutHintPanel.setShortcuts(list)
+        updateShortcutHintVisibility()
+    }
+
+    private fun updateShortcutHintVisibility() {
+        if (!::shortcutHintPanel.isInitialized || !::shortcutHintBar.isInitialized || !::shortcutHintRightGroup.isInitialized) {
+            return
+        }
+        val settingsVisible =
+            com.github.catatafishen.agentbridge.settings.ChatInputSettings.getInstance().isShowShortcutHints
+        val availableWidth = shortcutHintBar.width
+        if (availableWidth <= 0) return
+        val gap = JBUI.scale(8)
+        val requiredWidth = shortcutHintRightGroup.preferredSize.width +
+            if (settingsVisible) shortcutHintPanel.preferredSize.width + gap else 0
+        val showHints = settingsVisible && availableWidth >= requiredWidth
+        if (shortcutHintPanel.isVisible != showHints) {
+            shortcutHintPanel.isVisible = showHints
+            shortcutHintBar.revalidate()
+            shortcutHintBar.repaint()
+        }
     }
 
     private fun setSendingState(sending: Boolean) {
@@ -1306,14 +1327,13 @@ class ChatToolWindowContent(
         override fun getActionUpdateThread() = ActionUpdateThread.EDT
 
         override fun createCustomComponent(presentation: Presentation, place: String): JComponent {
-            // Primary-styled labeled button so the Send action reads as the dominant CTA.
-            // Icon on the left, "Send" text on the right. The label stays "Send" in all
-            // states; the button's behavior (direct send vs. nudge/queue/stop dropdown)
-            // depends on isSending and is handled in the action listener below.
-            val button = JButton(presentation.text ?: "Send", sendIcon)
+            // Compact icon-only button keeps the footer from growing taller than the
+            // dropdowns beside it while still exposing the action through the tooltip.
+            val button = JButton(sendIcon)
             button.putClientProperty("JButton.buttonType", "primary")
             button.isFocusable = false
-            button.margin = JBUI.insets(2, 8)
+            button.margin = JBUI.insets(0, 6)
+            button.iconTextGap = 0
             button.toolTipText = presentation.description
             // Direct routing avoids the deprecated AnActionEvent.createFromAnAction.
             button.addActionListener {
@@ -1330,7 +1350,8 @@ class ChatToolWindowContent(
         override fun updateCustomComponent(component: JComponent, presentation: Presentation) {
             (component as? JButton)?.let { btn ->
                 btn.isEnabled = presentation.isEnabled
-                btn.text = presentation.text
+                btn.text = ""
+                btn.icon = presentation.icon ?: sendIcon
                 btn.toolTipText = presentation.description
             }
         }
@@ -1340,12 +1361,12 @@ class ChatToolWindowContent(
             val hasText = promptTextArea.text.trim().isNotEmpty()
             if (isSending && !consolePanel.hasPendingAskUserRequest()) {
                 e.presentation.icon = sendIcon
-                e.presentation.text = "Send"
+                e.presentation.text = ""
                 e.presentation.description = "Nudge, queue, or stop and send"
                 e.presentation.isEnabled = hasText
             } else {
                 e.presentation.icon = sendIcon
-                e.presentation.text = "Send"
+                e.presentation.text = ""
                 e.presentation.description = if (isLoggedIn) "Send prompt (Enter)" else "Sign in to Copilot first"
                 e.presentation.isEnabled = isLoggedIn && hasText
             }

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/KeyBadge.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/KeyBadge.kt
@@ -17,7 +17,7 @@ class KeyBadge(text: String) : JBLabel(text) {
     init {
         font = JBUI.Fonts.smallFont()
         foreground = UIUtil.getLabelForeground()
-        border = JBUI.Borders.empty(2, 6, 2, 6)
+        border = JBUI.Borders.empty(2, 6)
         isOpaque = false
     }
 
@@ -72,6 +72,7 @@ class KeyBadge(text: String) : JBLabel(text) {
                         KeyEvent.VK_BACK_SPACE -> "⌫"
                         KeyEvent.VK_ESCAPE -> "Esc"
                         KeyEvent.VK_TAB -> "⇥"
+                        KeyEvent.VK_UP -> "↑"
                         else -> KeyEvent.getKeyText(stroke.keyCode)
                     }
                 )

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutHintPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/PromptShortcutHintPanel.kt
@@ -30,7 +30,7 @@ class PromptShortcutHintPanel : JBPanel<JBPanel<*>>(FlowLayout(FlowLayout.LEFT, 
 
     init {
         isOpaque = false
-        border = JBUI.Borders.empty(0, 4, 0, 4)
+        border = JBUI.Borders.empty()
     }
 
     /**


### PR DESCRIPTION
Make the shortcut hints collapse first on narrow widths, keep the model selector and send button visible, shrink the send button to an icon-only control, show the up-arrow hint as a symbol, and reduce footer padding.