### PR TITLE
chore: fix oss-fuzz script references

### DIFF
--- a/oss-fuzz/Dockerfile
+++ b/oss-fuzz/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/oss-fuzz/build.sh
+++ b/oss-fuzz/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Trivial oss-fuzz housekeeping: updates 2 script files in `oss-fuzz/` with corrected references.

No functional changes to the plugin.