### PR TITLE
fix: marshal unfocused notification to EDT

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ChatToolWindowContent.kt
@@ -2431,20 +2431,22 @@ class ChatToolWindowContent(
     }
 
     private fun notifyIfUnfocused(toolCallCount: Int) {
-        val frame = com.intellij.openapi.wm.WindowManager.getInstance().getFrame(project) ?: return
-        if (frame.isActive) return
-        val title = "Copilot Response Ready"
-        val content =
-            if (toolCallCount > 0) "Turn completed with $toolCallCount tool call${if (toolCallCount != 1) "s" else ""}"
-            else "Turn completed"
-        com.intellij.openapi.wm.ToolWindowManager.getInstance(project)
-            .notifyByBalloon(
-                "AgentBridge",
-                com.intellij.openapi.ui.MessageType.INFO,
-                "<b>$title</b><br>$content"
-            )
-        com.intellij.ui.SystemNotifications.getInstance().notify("AgentBridge Notifications", title, content)
-        com.intellij.ui.AppIcon.getInstance().requestAttention(project, false)
+        ApplicationManager.getApplication().invokeLater {
+            val frame = com.intellij.openapi.wm.WindowManager.getInstance().getFrame(project) ?: return@invokeLater
+            if (frame.isActive) return@invokeLater
+            val title = "Copilot Response Ready"
+            val content =
+                if (toolCallCount > 0) "Turn completed with $toolCallCount tool call${if (toolCallCount != 1) "s" else ""}"
+                else "Turn completed"
+            com.intellij.openapi.wm.ToolWindowManager.getInstance(project)
+                .notifyByBalloon(
+                    "AgentBridge",
+                    com.intellij.openapi.ui.MessageType.INFO,
+                    "<b>$title</b><br>$content"
+                )
+            com.intellij.ui.SystemNotifications.getInstance().notify("AgentBridge Notifications", title, content)
+            com.intellij.ui.AppIcon.getInstance().requestAttention(project, false)
+        }
     }
 
     private fun saveTurnStatistics(prompt: String, toolCalls: Int, modelId: String) {


### PR DESCRIPTION
> 🤖 Written by Copilot on behalf of @catatafishen.

## Summary

Wraps the unfocused-response notification path in `invokeLater {}` so AppIcon/balloon calls run on the EDT and no longer trip the `Assert: must be called on EDT` failure.