### PR TITLE
fix: detect unregistered subfolder git repos & stop nudge double-delivery

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/acp/client/CopilotClient.java
@@ -557,6 +557,12 @@ public final class CopilotClient extends AcpClient {
         java.util.Set<String> tools = new java.util.LinkedHashSet<>(misusedBuiltInTools);
         misusedBuiltInTools.clear();
 
+        // The same reprimand is also queued in pendingNudge for mid-turn delivery via tool
+        // results. If the previous turn ended without any MCP tool call, that nudge is still
+        // pending — clear it so the agent doesn't see the same notice TWICE in this turn
+        // (once prepended to the prompt, once appended to the next tool result).
+        PsiBridgeService.getInstance(project).setPendingNudge(null);
+
         String reprimand = buildToolReprimand(tools);
         LOG.info(displayName() + ": prepending tool reprimand for: " + tools);
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/PlatformApiCompat.java
@@ -617,6 +617,41 @@ public final class PlatformApiCompat {
     }
 
     /**
+     * Returns absolute root paths of all git repositories detectable in the project,
+     * including <b>unregistered</b> ones in subfolders that IntelliJ has discovered but
+     * the user has not yet added to {@code Settings | Version Control}.
+     *
+     * <p>This is the source of truth for "what git repos exist in this project" — used by
+     * git tool error messages and root resolution. Paths returned here are not guaranteed
+     * to have a backing {@link git4idea.repo.GitRepository} instance, so APIs that require
+     * one (e.g. {@code Git.getInstance().checkout(repo, ...)}) must still go through
+     * {@link #getRepositoryForRoot}; CLI-based git operations work fine with just the path.
+     *
+     * <p>Falls back to {@link #getRepositories} alone when {@code VcsRootDetector} is
+     * unavailable (older IDE, missing VCS plugin).
+     */
+    public static @NotNull java.util.List<String> getDetectedGitRoots(@NotNull Project project) {
+        java.util.LinkedHashSet<String> roots = new java.util.LinkedHashSet<>();
+        for (git4idea.repo.GitRepository r : getRepositories(project)) {
+            roots.add(r.getRoot().getPath());
+        }
+        try {
+            java.util.Collection<com.intellij.openapi.vcs.VcsRoot> detected =
+                com.intellij.openapi.vcs.roots.VcsRootDetector.getInstance(project).getOrDetect();
+            for (com.intellij.openapi.vcs.VcsRoot vr : detected) {
+                com.intellij.openapi.vcs.AbstractVcs vcs = vr.getVcs();
+                com.intellij.openapi.vfs.VirtualFile path = vr.getPath();
+                if (vcs != null && "Git".equals(vcs.getName()) && path != null) {
+                    roots.add(path.getPath());
+                }
+            }
+        } catch (NoClassDefFoundError | Exception e) {
+            // VcsRootDetector unavailable or detection failed — fall through to registered-only.
+        }
+        return new java.util.ArrayList<>(roots);
+    }
+
+    /**
      * Returns the GitRepository whose root is exactly {@code rootPath}, or null if not found.
      */
     public static @Nullable git4idea.repo.GitRepository getRepositoryForRoot(

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStatusTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStatusTool.java
@@ -88,16 +88,15 @@ public final class GitStatusTool extends GitTool {
     }
 
     private String aggregateMultiRepoStatus(boolean verbose) throws Exception {
-        java.util.List<git4idea.repo.GitRepository> repos;
+        java.util.List<String> roots;
         try {
-            repos = com.github.catatafishen.agentbridge.psi.PlatformApiCompat.getRepositories(project);
+            roots = com.github.catatafishen.agentbridge.psi.PlatformApiCompat.getDetectedGitRoots(project);
         } catch (NoClassDefFoundError e) {
-            repos = java.util.Collections.emptyList();
+            roots = java.util.Collections.emptyList();
         }
         String basePath = project.getBasePath();
         StringBuilder sb = new StringBuilder();
-        for (git4idea.repo.GitRepository repo : repos) {
-            String absRoot = repo.getRoot().getPath();
+        for (String absRoot : roots) {
             String relRoot = toRelativePath(absRoot, basePath);
             sb.append("=== ").append(relRoot).append(" ===\n");
             sb.append(statusForRoot(absRoot, verbose)).append('\n');

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitTool.java
@@ -108,55 +108,32 @@ public abstract class GitTool extends Tool {
 
     // ── Multi-repo helpers ───────────────────────────────────
 
-    /**
-     * Returns true when the project contains more than one registered git repository.
-     */
     protected boolean isMultiRepo() {
         try {
-            return PlatformApiCompat.getRepositories(project).size() > 1;
+            return PlatformApiCompat.getDetectedGitRoots(project).size() > 1;
         } catch (NoClassDefFoundError e) {
             return false;
         }
     }
 
-    /**
-     * Returns the relative paths (from the project root) of all registered git repositories.
-     * Returns {@code ["."]} for a project root repo, {@code ["backend", "frontend"]} for
-     * side-by-side repos, etc. Used for error messages and status summaries.
-     */
     protected List<String> listRepoRoots() {
         try {
-            List<git4idea.repo.GitRepository> repos = PlatformApiCompat.getRepositories(project);
             String basePath = project.getBasePath();
-            return repos.stream()
-                .map(r -> toRelativePath(r.getRoot().getPath(), basePath))
+            return PlatformApiCompat.getDetectedGitRoots(project).stream()
+                .map(p -> toRelativePath(p, basePath))
                 .collect(Collectors.toList());
         } catch (NoClassDefFoundError e) {
             return Collections.emptyList();
         }
     }
 
-    /**
-     * Resolves the absolute repository root to use for a git command.
-     *
-     * <ul>
-     *   <li>If {@code repoParam} is non-null: finds the repo matching that relative path and
-     *       returns its absolute root, or an {@code "Error: ..."} string if not found.</li>
-     *   <li>If single repo: returns that repo's root (possibly a subdirectory of basePath).</li>
-     *   <li>If zero repos (git not initialised): returns {@code project.getBasePath()}.</li>
-     *   <li>If multiple repos and no param: returns the primary root (basePath-matching or first)
-     *       — callers that perform writes should call {@link #requireUnambiguousRepo} first.</li>
-     * </ul>
-     *
-     * @return absolute root path, or a string starting with {@code "Error:"} on failure
-     */
     @NotNull
     protected String resolveRepoRootOrError(@Nullable String repoParam) {
-        List<git4idea.repo.GitRepository> repos;
+        List<String> roots;
         try {
-            repos = PlatformApiCompat.getRepositories(project);
+            roots = PlatformApiCompat.getDetectedGitRoots(project);
         } catch (NoClassDefFoundError e) {
-            repos = Collections.emptyList();
+            roots = Collections.emptyList();
         }
 
         if (repoParam != null && !repoParam.isEmpty()) {
@@ -166,34 +143,34 @@ public abstract class GitTool extends Tool {
                 ? new File(basePath, repoParam).getAbsolutePath().replace("\\", "/")
                 : repoParam.replace("\\", "/");
 
-            for (git4idea.repo.GitRepository r : repos) {
-                if (r.getRoot().getPath().equals(absParam)) return r.getRoot().getPath();
+            for (String root : roots) {
+                if (root.equals(absParam)) return root;
             }
-            String available = repos.isEmpty() ? "none"
-                : repos.stream()
-                  .map(r -> "'" + toRelativePath(r.getRoot().getPath(), project.getBasePath()) + "'")
+            String available = roots.isEmpty() ? "none"
+                : roots.stream()
+                  .map(r -> "'" + toRelativePath(r, project.getBasePath()) + "'")
                   .collect(Collectors.joining(", "));
             return "Error: repository '" + repoParam + "' not found. Available: " + available
                 + ". Use git_status to list repositories.";
         }
 
-        if (repos.isEmpty()) {
+        if (roots.isEmpty()) {
             String basePath = project.getBasePath();
             return basePath != null ? basePath : "Error: no project base path";
         }
 
-        if (repos.size() == 1) {
-            return repos.getFirst().getRoot().getPath();
+        if (roots.size() == 1) {
+            return roots.getFirst();
         }
 
         // Multiple repos: prefer the one rooted at basePath, otherwise use first.
         String basePath = project.getBasePath();
         if (basePath != null) {
-            for (git4idea.repo.GitRepository r : repos) {
-                if (r.getRoot().getPath().equals(basePath)) return r.getRoot().getPath();
+            for (String root : roots) {
+                if (root.equals(basePath)) return root;
             }
         }
-        return repos.getFirst().getRoot().getPath();
+        return roots.getFirst();
     }
 
     /**


### PR DESCRIPTION
## Summary

Two distinct user-reported bugs, both root-caused and fixed.

### 1. Multi-repo discovery (`Available: none` for subfolder repos)

Git tools previously only saw repos registered in **Settings | Version Control** via `GitRepositoryManager.getRepositories()`. A project containing several `.git` subfolders that weren't manually registered would yield:

```
Error: repository 'renovatebot' not found. Available: none. Use git_status to list repositories.
```

…even though IntelliJ itself (Project View, Git tool window banner) had detected them.

**Fix:** new `PlatformApiCompat.getDetectedGitRoots(project)` combines registered repos with `VcsRootDetector.getOrDetect()` — the exact API IntelliJ uses to surface its "Unregistered roots" banner. `GitTool.{isMultiRepo, listRepoRoots, resolveRepoRootOrError}` and `GitStatusTool.aggregateMultiRepoStatus` all switch to it.

CLI-based git operations now work in any detected subfolder repo without requiring registration. APIs that need a live `GitRepository` instance (e.g. `Git.getInstance().checkout(repo, …)`) still fall back to CLI as before.

### 2. Nudge / system-notice double-delivery

Built-in-tool reprimands have two delivery paths:

1. `pendingNudge` → appended to the **next MCP tool result** for mid-turn feedback.
2. `CopilotClient.beforeSendPrompt` → prepended to the **next user prompt** when a turn ended without any MCP call.

If a turn ended without an MCP call, both fired in the next turn — the agent saw the same notice **twice** (once in the prompt, once on the first tool result). `beforeSendPrompt` now clears `pendingNudge` so the two paths stay mutually exclusive.

## Verification

- Build clean for touched files (incremental compile passes).
- Existing test suite has a pre-existing master breakage in `SessionStatsPanel.java` (`getTurnPremiumRequests` missing) unrelated to this PR — confirmed with `git diff origin/master`.

---

> ⚠️ This PR was authored by Copilot on the maintainer's behalf.