### PR TITLE
fix: session-tab time counters consistent and accurate

### DIFF
--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ProcessingTimerPanel.kt
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/ProcessingTimerPanel.kt
@@ -67,6 +67,13 @@ internal class ProcessingTimerPanel(
     }
 
     fun stop() {
+        // Guard against unmatched stop() calls. The chat input's sending-state listener
+        // fires stop() on every setSending(false), including transitions that never had a
+        // preceding start() (e.g. after restoreSessionStats or after a stop already ran).
+        // Without this guard, startedAt == 0L and we'd add (System.currentTimeMillis() - 0)
+        // ≈ 1.7 trillion ms into sessionTotalTimeMs, producing the "Session time = millions
+        // of minutes" display bug.
+        if (!isRunning) return
         ticker.stop()
         isRunning = false
         lastTurnElapsedSec = (System.currentTimeMillis() - startedAt) / 1000

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/ui/side/SessionStatsPanel.java
@@ -664,27 +664,34 @@ public final class SessionStatsPanel extends JPanel implements Disposable {
                         // by the time we repaint — using the *current* snapshot avoids
                         // rendering "Today" totals in the stale mode.
                         SessionStatsSnapshot currentSnap = timerPanel.getSessionSnapshot();
-                        boolean multiplierMode = currentSnap != null
-                            ? currentSnap.getMultiplierMode()
-                            : snap.getMultiplierMode();
-                        applyTodayTotals(totals, multiplierMode);
+                        applyTodayTotals(totals, currentSnap);
                     });
                 } catch (Exception ignored) {
                     // Stats are advisory — never let a query failure crash the UI refresh loop.
                 }
             });
         }
-        applyTodayTotals(todayTotalsRef.get(), snap.getMultiplierMode());
+        applyTodayTotals(todayTotalsRef.get(), snap);
     }
 
-    private void applyTodayTotals(TodayTotals t, boolean multiplierMode) {
-        if (t.turns() <= 0) {
+    private void applyTodayTotals(TodayTotals t, SessionStatsSnapshot snap) {
+        boolean multiplierMode = snap.getMultiplierMode();
+        // Add the active turn's elapsed time on top of the DB-persisted aggregate so the
+        // "Today — Time" counter ticks live during a turn, matching Turn / Session timers.
+        // Persisted rows only land in turn_stats on stop(), so without this addend the row
+        // would freeze for the duration of every turn.
+        long liveDurMs = t.durationMs() + (snap.isRunning() ? snap.getTurnElapsedSec() * 1000L : 0L);
+        // Show the section as soon as a turn is in flight today, even before any turn has
+        // been persisted, so the user gets immediate feedback on first use of the day.
+        boolean hasActivity = t.turns() > 0 || (snap.isRunning() && snap.getTurnElapsedSec() > 0);
+        if (!hasActivity) {
             todaySection.setVisible(false);
             return;
         }
         todaySection.setVisible(true);
-        todayTimeValue.setText(TimerDisplayFormatter.INSTANCE.formatElapsedTime(t.durationMs() / 1000));
-        todayTurnsValue.setText(String.valueOf(t.turns()));
+        todayTimeValue.setText(TimerDisplayFormatter.INSTANCE.formatElapsedTime(liveDurMs / 1000));
+        int liveTurns = t.turns() + (snap.isRunning() ? 1 : 0);
+        todayTurnsValue.setText(String.valueOf(liveTurns));
         todayToolsValue.setText(String.valueOf(t.toolCalls()));
         todayToolsRow.setVisible(t.toolCalls() > 0);
         long lines = t.linesAdded() + t.linesRemoved();


### PR DESCRIPTION
## Summary

Two related bugs in the **Session tab** time counters reported by the user:

1. **Session time sometimes shows a huge number** (millions of minutes / ~ epoch time)
2. **"Today" timer doesn't update during a turn** while Turn and Session timers tick live — inconsistent

## Root causes

### 1. Huge session time

`processingTimerPanel.stop()` is invoked on **every** `setSending(false)` transition (`ChatToolWindowContent.kt:1199`), including transitions where no matching `start()` ever ran — e.g. right after `restoreSessionStats` on session reload, after an extra stop callback, or after an early lifecycle event.

When that happens, `startedAt` is still `0L` and `stop()` does:
```kotlin
sessionTotalTimeMs += System.currentTimeMillis() - startedAt  // = epoch-now ms ≈ 1.7×10¹² ms
```
poisoning the running total with ~28 million minutes. Subsequent unmatched stops compound the damage.


### 2. "Today — Time" frozen during turns

`applyTodayTotals` reads only `turn_stats` rows persisted to the DB. Rows are only inserted on `stop()`, so the in-progress turn isn't represented. The Today row stayed frozen while Turn and Session ticked every second.

**Fix:** `applyTodayTotals` now takes the snapshot and, when `isRunning`, adds the active turn's elapsed ms on top of the DB aggregate (and bumps the live turn count by 1). All three timers now tick consistently.

## Verification

- `build_project` clean (0 errors, 0 warnings)
- Defensive: existing test paths unchanged; new behaviour is additive

## Disclaimer

Authored by **Copilot** on behalf of the maintainer. Please review carefully before merging.
