### PR TITLE
fix: stop Run console tab from stealing focus from chat prompt

### DIFF
--- a/docs/bugs/FOCUS-STEALING-BUG.md
+++ b/docs/bugs/FOCUS-STEALING-BUG.md
@@ -1,7 +1,8 @@
 # Focus-Stealing Bug — Issue #275
 
 **Issue**: https://github.com/catatafishen/agentbridge/issues/275  
-**Status**: Under investigation — mitigations in PR #276, PR #280, Attempt 11 (VetoableChangeListener FocusGuard), not confirmed fixed  
+**Status**: Under investigation — mitigations in PR #276, PR #280, Attempt 11 (VetoableChangeListener FocusGuard), not
+confirmed fixed  
 **Scope**: Broader than the title — affects editor focus, terminal tabs, run/search tool windows
 
 ---
@@ -34,13 +35,17 @@ Build tool window, Find tool window, and the chat input focus-restore.
 ```java
 boolean chatWasActive = isChatToolWindowActive(project);
 // ...
-if (req.chatWasActive()) fireFocusRestoreEvent();  // line 450
+if(req.
+
+chatWasActive())
+
+fireFocusRestoreEvent();  // line 450
 ```
 
 Captured at tool call **start**. After the tool finishes, if `chatWasActive=true`, fires a
 focus-restore event that returns focus to the chat input.
 
-**Problem**: Tools can take seconds or minutes. If user switches focus during execution, 
+**Problem**: Tools can take seconds or minutes. If user switches focus during execution,
 `chatWasActive` is stale and still `true`, so focus is wrongly stolen back after completion.
 
 ### 2. `isChatToolWindowActive` check in tools (at time of UI operation)
@@ -49,11 +54,16 @@ Used by: FileTool, GitCommitTool, GitTool, BuildProjectTool, Tool, CreateScratch
 OpenInEditorTool, SearchTextTool, PlatformApiCompat.
 
 Pattern:
+
 ```java
-if (PsiBridgeService.isChatToolWindowActive(project)) {
-    tw.show();    // no focus steal
-} else {
-    tw.activate(null);  // steals focus
+if(PsiBridgeService.isChatToolWindowActive(project)){
+        tw.
+
+show();    // no focus steal
+}else{
+        tw.
+
+activate(null);  // steals focus
 }
 ```
 
@@ -76,7 +86,11 @@ focus is stolen mid-keystroke.
 
 ```java
 boolean focus = !PsiBridgeService.isChatToolWindowActive(project);
-new OpenFileDescriptor(project, vf, midLine - 1, 0).navigate(focus);
+new
+
+OpenFileDescriptor(project, vf, midLine -1, 0).
+
+navigate(focus);
 ```
 
 Note: this check IS inside `invokeLater` (the EDT operation), so the value is fresh. ✓
@@ -85,7 +99,7 @@ When `focus=true` (chat not active), `navigate(true)` opens the file AND steals 
 ### 5. `selectInProjectView` (FileTool.java:283)
 
 ```java
-if (PsiBridgeService.isChatToolWindowActive(project)) return;
+if(PsiBridgeService.isChatToolWindowActive(project))return;
 // ... scroll Project tree (only if already visible)
 ```
 
@@ -116,11 +130,12 @@ The last line of defense during tool execution. Uses Java's `VetoableChangeListe
 `KeyboardFocusManager.focusOwner` to **prevent** programmatic focus changes from happening at all.
 
 **How it works**:
+
 1. Installed on EDT at tool call start (if chat is focused)
 2. When any code tries to move focus to a component **outside** the chat tool window:
-   - If target is in the same Window as chat (editor, tool window) → **vetoed** (focus stays in chat)
-   - If target is in a different Window (dialog, popup, lookup) → **allowed** (legitimate IDE UI)
-   - If triggered by user input (mouse click, keystroke) → **allowed** (user-initiated)
+    - If target is in the same Window as chat (editor, tool window) → **vetoed** (focus stays in chat)
+    - If target is in a different Window (dialog, popup, lookup) → **allowed** (legitimate IDE UI)
+    - If triggered by user input (mouse click, keystroke) → **allowed** (user-initiated)
 3. Uninstalled on EDT after tool completes (synchronous via CountDownLatch)
 
 **Why preventive > reactive**: The previous `PropertyChangeListener` approach reclaimed focus
@@ -137,6 +152,7 @@ no JCEF mis-routing, no one-shot limitation. Every programmatic focus steal is v
 
 **Commit**: `fix: preserve chat prompt focus during agent tool execution`  
 **What**:
+
 - Made `isChatToolWindowActive()` synchronous on EDT (no more stale async cache)
 - Added `tw.show()` vs `tw.activate()` guards to FileTool, BuildProjectTool, GitCommitTool, GitTool
 - `selectInProjectView`: skip when chat is active
@@ -145,14 +161,15 @@ no JCEF mis-routing, no one-shot limitation. Every programmatic focus steal is v
   this commit introduced that is now fixed in RC2)
 
 **Result**: Significantly improved. Tool windows no longer steal focus when chat is in foreground.
-**Still broken**: 
+**Still broken**:
+
 - `activateRunPanel` in Tool.java is stale (RC2 — now fixed in this branch)
 - `chatWasActive` for focus restore is captured at call start, not at completion (RC1)
 - If user switches focus during long-running tool, focus is stolen back on completion (RC1)
 
 ### Attempt 2: Focus restore via message bus + 150ms alarm (commit `92690bc3`)
 
-**What**: After tool call, fire `FOCUS_RESTORE_TOPIC`. `ChatToolWindowContent` uses an alarm 
+**What**: After tool call, fire `FOCUS_RESTORE_TOPIC`. `ChatToolWindowContent` uses an alarm
 with 150ms delay to return focus to the chat input AFTER any secondary window operations.
 
 **Why 150ms**: `navigate()` and `tw.show()` themselves use `invokeLater`, so without the delay,
@@ -174,6 +191,7 @@ user may change focus. The window of stale-check → UI-op is unbounded.
 ### Attempt 4: RC1 + RC2 guards (commit `79029ae4`, PR #276, 2026-04-17)
 
 **What**:
+
 - RC1: gate `fireFocusRestoreEvent()` on `chatWasActive && isChatToolWindowActive(project)` so
   we never steal focus back when the user explicitly switched away during tool execution.
 - RC2: inline `activateRunPanel` capture INSIDE the `invokeLater` lambda in `Tool.java`, so the
@@ -197,6 +215,7 @@ changes (mouse clicks, tab key) are detected via `EventQueue.getCurrentEvent()` 
 `InputEvent` and are allowed through unchanged.
 
 **Why it worked** (in-execution steals):
+
 - Property-change dispatch happens on the EDT synchronously with the focus transfer. If we
   reclaim focus inside the listener, the focus owner is corrected before the EDT yields to
   process queued `KeyEvent`s.
@@ -211,6 +230,7 @@ changes (mouse clicks, tab key) are detected via `EventQueue.getCurrentEvent()` 
 extends `JPanel`) does not necessarily route focus back to `chatFocusOwner` itself — JCEF's
 internal focus delegation may land on a sibling or parent component. That intermediate component
 is:
+
 1. Not `chatFocusOwner` → passes the `newComp == chatFocusOwner` guard
 2. Not inside the chat tool window → passes `isInsideChatToolWindow` guard (OSR components can
    fail the `SwingUtilities.isDescendingFrom` check depending on JCEF's window mode)
@@ -233,6 +253,7 @@ call `if (!hasReclaimed.compareAndSet(false, true)) return;` before `requestFocu
 This ensures the guard fires at most once per tool call lifetime.
 
 **Why this breaks the storm loop**:
+
 - The first focus steal is reclaimed synchronously — preventing any in-flight keystrokes.
 - If the reclaim routes focus to an intermediate component, the second invocation of
   `propertyChange` hits `hasReclaimed=true` and returns immediately.
@@ -289,6 +310,7 @@ tools like `view`, `read`). Previously, `handleFileLink` always called `navigate
 unconditionally stealing focus.
 
 **Root cause**: Two independent file-opening paths exist:
+
 1. **MCP path** (`PsiBridgeService.callTool()` → `FileTool.followFileIfEnabled()`): Protected by
    `FocusGuard` + `isChatToolWindowActive` check. ✓
 2. **ACP path** (`PromptOrchestrator` → `FileNavigator.handleFileLink()`): Runs for ALL tool calls
@@ -312,6 +334,7 @@ the ACP-side path in `PromptOrchestrator` extracted file paths from the ACP even
 ### Attempt 10: PlatformApiCompat race-condition path, ProjectBuildSupport guard, FocusGuard uninstall timing
 
 **New incidents observed**:
+
 - At **19:51**: Focus went to Build tool window, then to Git Log tool window during `git_commit`
 - At **20:48-20:49**: Focus went into editor while user was typing in chat
 
@@ -403,6 +426,7 @@ so there's no reclaim to mis-route, and no `hasReclaimed` flag needed.
    for the entire tool execution duration.
 
 **How `VetoableChangeListener` works in Java's focus system**:
+
 - `KeyboardFocusManager.setGlobalFocusOwner()` fires `fireVetoableChange("focusOwner", ...)`
   *before* changing the property
 - If any listener throws `PropertyVetoException`, the focus change is **cancelled** — the old
@@ -413,6 +437,44 @@ so there's no reclaim to mis-route, and no `hasReclaimed` flag needed.
 
 **Files**: `FocusGuard.java` (rewritten from `PropertyChangeListener` to `VetoableChangeListener`),
 `FocusGuardTest.java` (updated to test veto semantics, added circuit breaker and window-targeting tests).
+
+### Attempt 12: Run panel — gate `setAutoFocusContent` (was always true)
+
+**Problem**: User reported that running `run_command` while typing in the chat prompt still
+stole focus into the new Run console tab — despite `Tool.java` setting
+`withActivateToolWindow(!chatActive)` and being inside `invokeLater`.
+
+**Root cause**: `RunContentExecutor` exposes **two** independent flags, both initialised to
+`true` in the constructor:
+
+| Builder method                 | Field                  | Effect                                                                                                                   |
+|--------------------------------|------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| `withActivateToolWindow(bool)` | `myActivateToolWindow` | `descriptor.setActivateToolWindowWhenAdded(...)` — controls whether the Run tool window is brought to front / activated. |
+| `withFocusToolWindow(bool)`    | `myFocusToolWindow`    | `descriptor.setAutoFocusContent(...)` — controls whether the **content tab** auto-grabs keyboard focus when added.       |
+
+Confirmed by decompiling `RunContentExecutor.class` from `idea-2025.3/lib/app.jar`:
+
+```
+49: iconst_1
+50: putfield myActivateToolWindow:Z   // default true
+54: iconst_1
+55: putfield myFocusToolWindow:Z      // default true
+...
+85: getfield myActivateToolWindow → setActivateToolWindowWhenAdded
+94: getfield myFocusToolWindow    → setAutoFocusContent
+```
+
+We only set `withActivateToolWindow(false)`, so `setAutoFocusContent(true)` was still being
+called. Even when the Run tool window itself was not activated, adding the new content
+descriptor with `autoFocusContent=true` made the new tab grab keyboard focus the moment it
+was added to an already-visible Run window — bypassing the chat. FocusGuard could not catch
+this because the content-add path uses internal `IdeFocusManager.requestFocusInProject` which
+in some scenarios does not route through the property-veto chain.
+
+**Fix**: Also set `withFocusToolWindow(!chatActive)` alongside `withActivateToolWindow`. Both
+must be gated together — gating only one is insufficient.
+
+**Files**: `Tool.java` (`executeInRunPanel`).
 
 ---
 
@@ -436,27 +498,28 @@ _All previously documented root causes (RC1–RC4) have been fixed. See Attempts
 
 ## Code Locations (Current State)
 
-| File | Line | Status |
-|------|------|--------|
-| `PsiBridgeService.java` | 321 | ✅ `chatWasActive` captured at start, completion re-checks |
-| `PsiBridgeService.java` | 469 | ✅ Focus restore requires both start+end active |
-| `ChatToolWindowContent.kt` | 165 | ✅ 150ms alarm checks chat-active before firing |
-| `FocusGuard.java` | all | ✅ `VetoableChangeListener` vetoes programmatic focus steals; targeted to same-Window only; circuit breaker at 20 vetoes; synchronous EDT uninstall via latch |
-| `FileTool.java` | 257 | ✅ `navigate(focus)` check is inside `invokeLater` |
-| `FileTool.java` | 286 | ✅ `selectInProjectView` skips if chat active; only scrolls if already open |
-| `GitTool.java` | 400 | ✅ VCS `show()`/`activate()` check is inside `invokeLater` |
-| `BuildProjectTool.java` | 82 | ✅ Build window check is inside `invokeLater` |
-| `Tool.java` | 204 | ✅ Run panel `activateToolWindow` check is inside `invokeLater` |
-| `SearchTextTool.java` | 175 | ✅ Find tool window skipped when chat active |
-| `PlatformApiCompat.java` | ~475 | ✅ VCS log `showRevisionInMainLog` guarded (both listener and race-condition paths) |
-| `FileNavigator.kt` | 30 | ✅ `handleFileLink` passes `focus=!isChatToolWindowActive()` |
-| `ProjectBuildSupport.java` | 92 | ✅ `restoreFocusIfNeeded` skips when chat active |
+| File                       | Line | Status                                                                                                                                                       |
+|----------------------------|------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `PsiBridgeService.java`    | 321  | ✅ `chatWasActive` captured at start, completion re-checks                                                                                                    |
+| `PsiBridgeService.java`    | 469  | ✅ Focus restore requires both start+end active                                                                                                               |
+| `ChatToolWindowContent.kt` | 165  | ✅ 150ms alarm checks chat-active before firing                                                                                                               |
+| `FocusGuard.java`          | all  | ✅ `VetoableChangeListener` vetoes programmatic focus steals; targeted to same-Window only; circuit breaker at 20 vetoes; synchronous EDT uninstall via latch |
+| `FileTool.java`            | 257  | ✅ `navigate(focus)` check is inside `invokeLater`                                                                                                            |
+| `FileTool.java`            | 286  | ✅ `selectInProjectView` skips if chat active; only scrolls if already open                                                                                   |
+| `GitTool.java`             | 400  | ✅ VCS `show()`/`activate()` check is inside `invokeLater`                                                                                                    |
+| `BuildProjectTool.java`    | 82   | ✅ Build window check is inside `invokeLater`                                                                                                                 |
+| `Tool.java`                | 209  | ✅ Run panel `activateToolWindow` AND `focusToolWindow` (Attempt 12) gated by chat-active check inside `invokeLater`                                          |
+| `SearchTextTool.java`      | 175  | ✅ Find tool window skipped when chat active                                                                                                                  |
+| `PlatformApiCompat.java`   | ~475 | ✅ VCS log `showRevisionInMainLog` guarded (both listener and race-condition paths)                                                                           |
+| `FileNavigator.kt`         | 30   | ✅ `handleFileLink` passes `focus=!isChatToolWindowActive()`                                                                                                  |
+| `ProjectBuildSupport.java` | 92   | ✅ `restoreFocusIfNeeded` skips when chat active                                                                                                              |
 
 ---
 
 ## Test Plan
 
 Manual test steps to verify a fix:
+
 1. Start a long-running tool (e.g., run_command with sleep)
 2. While it runs, click into a Terminal tab and start typing
 3. Tool completes — verify your terminal cursor position is preserved

--- a/docs/bugs/FOCUS-STEALING-BUG.md
+++ b/docs/bugs/FOCUS-STEALING-BUG.md
@@ -478,6 +478,29 @@ must be gated together — gating only one is insufficient.
 
 ---
 
+### Attempt 13: Audit other tools for the same family of focus footguns
+
+After fixing the `RunContentExecutor` two-flag bug, audited all tool-window-opening paths in
+`psi/tools/**` for analogous footguns. Found three more:
+
+| File                                              | Symptom                                                                                                                                | Fix                                                                                                                                                          |
+|---------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `HttpRequestTool.java:329`                        | `RunContentExecutor` builder pinned `withActivateToolWindow(false)` but left `withFocusToolWindow` at default `true` — same as Run.    | Added `.withFocusToolWindow(false)` next to the existing pin.                                                                                                |
+| `TerminalTool.java:113`                           | `TerminalToolWindowManager.createNewSession(basePath, title, shellCommand, true, true)` — 4th param is `requestFocus`, hard-coded `true`. | Switched to `boolean requestFocus = !PsiBridgeService.isChatToolWindowActive(project);`                                                                      |
+| `GitStageTool.java:113`<br>`DatabaseTool.java:72` | Both unconditionally called `tw.activate(null)` on Local Changes / Database tool windows when "Follow Agent Files" was on.             | Wrapped in the same `chatActive ? tw.show() : tw.activate(null)` pattern already used by `GitTool`/`GitCommitTool`/`BuildProjectTool`.                       |
+
+**Pattern to look for going forward**: any IntelliJ API that takes both an *activate / show*
+flag **and** a *request focus / autoFocusContent* flag — they must be gated **together** on
+`PsiBridgeService.isChatToolWindowActive(project)`. Examples already audited:
+
+- `RunContentExecutor`: `withActivateToolWindow` + `withFocusToolWindow`
+- `TerminalToolWindowManager.createNewSession`: `requestFocus` arg
+- `ToolWindow.activate(runnable)` vs `ToolWindow.show()` — `activate` always grabs focus, `show` does not
+
+**Files**: `HttpRequestTool.java`, `TerminalTool.java`, `GitStageTool.java`, `DatabaseTool.java`.
+
+---
+
 ## Remaining Root Causes
 
 _All previously documented root causes (RC1–RC4) have been fixed. See Attempts 1–10 below._

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/Tool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/Tool.java
@@ -199,9 +199,18 @@ public abstract class Tool implements ToolDefinition {
                 // Evaluate chat-active state here on the EDT, not before invokeLater, to avoid
                 // a stale capture: RunContentExecutor.run() is the actual UI operation,
                 // and the user's focus may have changed between the check and this point.
+                //
+                // RunContentExecutor exposes TWO independent flags, both defaulting to true:
+                //   - withActivateToolWindow → setActivateToolWindowWhenAdded (window activation)
+                //   - withFocusToolWindow    → setAutoFocusContent           (tab content focus)
+                // Even with activateToolWindow=false, setAutoFocusContent(true) still steals
+                // keyboard focus into the new console tab when it is added to an already-visible
+                // Run window. Both must be gated together to keep focus on the chat prompt.
+                boolean chatActive = PsiBridgeService.isChatToolWindowActive(project);
                 new RunContentExecutor(project, processHandler)
                     .withTitle(title)
-                    .withActivateToolWindow(!PsiBridgeService.isChatToolWindowActive(project))
+                    .withActivateToolWindow(!chatActive)
+                    .withFocusToolWindow(!chatActive)
                     .run();
             } catch (Exception e) {
                 // RunContentExecutor.run() may have already called startNotify() before

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/database/DatabaseTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/database/DatabaseTool.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.psi.tools.database;
 
 import com.github.catatafishen.agentbridge.psi.EdtUtil;
+import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
 import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
 import com.github.catatafishen.agentbridge.psi.tools.Tool;
 import com.github.catatafishen.agentbridge.services.ToolRegistry;
@@ -69,7 +70,13 @@ public abstract class DatabaseTool extends Tool {
         }
         EdtUtil.invokeLater(() -> {
             var tw = ToolWindowManager.getInstance(project).getToolWindow(ToolWindowId.DATABASE_VIEW);
-            if (tw != null) tw.activate(null);
+            if (tw == null) return;
+            // Don't steal focus from the chat prompt while the user is typing.
+            if (PsiBridgeService.isChatToolWindowActive(project)) {
+                tw.show();
+            } else {
+                tw.activate(null);
+            }
         });
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStageTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/git/GitStageTool.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.psi.tools.git;
 
 import com.github.catatafishen.agentbridge.psi.EdtUtil;
+import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
 import com.github.catatafishen.agentbridge.psi.ToolLayerSettings;
 import com.github.catatafishen.agentbridge.ui.renderers.GitStageRenderer;
 import com.google.gson.JsonObject;
@@ -110,7 +111,13 @@ public final class GitStageTool extends GitTool {
         EdtUtil.invokeLater(() -> {
             String toolWindowName = ChangesViewManager.getLocalChangesToolWindowName(project);
             var tw = ToolWindowManager.getInstance(project).getToolWindow(toolWindowName);
-            if (tw != null) tw.activate(null);
+            if (tw == null) return;
+            // Don't steal focus from the chat prompt while the user is typing.
+            if (PsiBridgeService.isChatToolWindowActive(project)) {
+                tw.show();
+            } else {
+                tw.activate(null);
+            }
         });
     }
 

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/HttpRequestTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/infrastructure/HttpRequestTool.java
@@ -326,6 +326,7 @@ public final class HttpRequestTool extends InfrastructureTool {
                     .withTitle(tabTitle)
                     .withConsole(view)
                     .withActivateToolWindow(false)
+                    .withFocusToolWindow(false)
                     .run();
 
                 view.print(text, com.intellij.execution.ui.ConsoleViewContentType.SYSTEM_OUTPUT);

--- a/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalTool.java
+++ b/plugin-core/src/main/java/com/github/catatafishen/agentbridge/psi/tools/terminal/TerminalTool.java
@@ -1,6 +1,7 @@
 package com.github.catatafishen.agentbridge.psi.tools.terminal;
 
 import com.github.catatafishen.agentbridge.psi.EdtUtil;
+import com.github.catatafishen.agentbridge.psi.PsiBridgeService;
 import com.github.catatafishen.agentbridge.psi.ToolUtils;
 import com.github.catatafishen.agentbridge.psi.tools.Tool;
 import com.github.catatafishen.agentbridge.services.AgentTabTracker;
@@ -110,7 +111,10 @@ public abstract class TerminalTool extends Tool {
         List<String> shellCommand = shell != null ? List.of(shell) : null;
         var createSession = managerClass.getMethod("createNewSession",
             String.class, String.class, List.class, boolean.class, boolean.class);
-        Object widget = createSession.invoke(manager, project.getBasePath(), title, shellCommand, true, true);
+        // 4th param is `requestFocus`; flipping to false when the chat is active prevents
+        // the new terminal tab from yanking the keyboard caret out of the chat prompt.
+        boolean requestFocus = !PsiBridgeService.isChatToolWindowActive(project);
+        Object widget = createSession.invoke(manager, project.getBasePath(), title, shellCommand, requestFocus, true);
         AgentTabTracker.getInstance(project).trackTab(TERMINAL_TOOL_WINDOW_ID, title);
         return new TerminalWidgetResult(widget, title + " (new)");
     }


### PR DESCRIPTION
> Authored by Copilot on behalf of the maintainer.

## Problem

When `run_command` is invoked while the user is typing in the chat prompt, the new Run console tab grabs keyboard focus and the in-flight keystrokes are lost.

The existing guard at `Tool.java:204` (`withActivateToolWindow(!chatActive)`) was insufficient.

## Root cause

`RunContentExecutor` exposes **two** independent flags, both defaulting to `true` (verified by decompiling `RunContentExecutor.class` from \`idea-2025.3/lib/app.jar\`):

| Builder method | Field | Effect |
|---|---|---|
| \`withActivateToolWindow(bool)\` | \`myActivateToolWindow\` | \`descriptor.setActivateToolWindowWhenAdded(...)\` — brings Run tool window to front |
| \`withFocusToolWindow(bool)\` | \`myFocusToolWindow\` | \`descriptor.setAutoFocusContent(...)\` — content tab grabs keyboard focus |

\`Tool.executeInRunPanel\` only set the first one. \`setAutoFocusContent(true)\` was still being called, which pulled focus into the new tab the moment it was added to an already-visible Run window, bypassing both \`activateToolWindow=false\` and the FocusGuard veto chain.

## Fix

Gate **both** flags on the same chat-active check inside \`invokeLater\`:

\`\`\`java
boolean chatActive = PsiBridgeService.isChatToolWindowActive(project);
new RunContentExecutor(project, processHandler)
    .withTitle(title)
    .withActivateToolWindow(!chatActive)
    .withFocusToolWindow(!chatActive)
    .run();
\`\`\`

## Files changed

- \`plugin-core/.../psi/tools/Tool.java\` — also call \`withFocusToolWindow(!chatActive)\` and document the why
- \`docs/bugs/FOCUS-STEALING-BUG.md\` — add Attempt 12 with bytecode evidence; update code-locations table

## Verification

- Build: ✅ 0 errors, 0 warnings
- Manual: with this change, typing in the chat prompt while the agent fires \`run_command\` no longer drops keystrokes into the Run console