### PR TITLE
ci: free ~30 GB on runner before plugin verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,24 @@ jobs:
         with:
           egress-policy: audit
 
+      # Ubuntu runners ship with ~14 GB free out of 75 GB. The IntelliJ Plugin
+      # Verifier downloads ~6 IDE distributions (recommended() + PyCharm, WebStorm,
+      # GoLand) at ~3-5 GB extracted each, easily blowing the disk budget. This
+      # action removes pre-installed software we don't use and reclaims ~30 GB.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
+        with:
+          tool-cache: false        # keep the JDK/Node tool cache populated by setup-java/setup-node
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Show available disk space
+        run: df -h /
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
@@ -171,8 +189,15 @@ jobs:
       - name: Create pluginVerifier cache directory
         run: mkdir -p ~/.pluginVerifier/extracted-plugins
 
+      - name: Show disk space before plugin verification
+        run: df -h /
+
       - name: Verify plugins (marketplace compatibility)
         run: gradle :plugin-core:verifyPlugin --no-daemon --quiet
+
+      - name: Show disk space after plugin verification
+        if: always()
+        run: df -h /
 
       - name: Upload plugin-core artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1


### PR DESCRIPTION
## Why

PR #343's CI run died with:
```
System.IO.IOException: No space left on device
```
right around the `Verify plugins (marketplace compatibility)` step.

## Disk budget on a free GitHub-hosted runner

| Total disk | Pre-installed software | Free at job start |
|---|---|---|
| ~75 GB | ~60 GB (Android SDK, .NET, Haskell, Swift, CodeQL, Docker images, …) | **~14 GB** |

What we put on it:
- Gradle cache (~2 GB)
- Built plugin artefacts + test results (~1 GB)
- **`verifyPlugin` IDE downloads (~6 IDEs × 3–5 GB extracted = 20–30 GB)** ← the killer

## Fix

Add `jlumbroso/free-disk-space@v1.3.1` (pinned to SHA) right after Harden Runner. It removes the pre-installed software we never use and reclaims ~30 GB. The tool-cache is kept so `setup-java` and `setup-node` still hit it.

Also added `df -h /` before and after `verifyPlugin` so future disk pressure is visible at a glance.

## Why not run the verifier sequentially per-IDE?

Would require a custom Gradle task — the current `verifyPlugin` task fans out and downloads everything in parallel. Not worth the complexity if free-disk-space alone gives us enough headroom (~44 GB free after, vs ~20–30 GB needed).

If we ever push past the new headroom (say, by adding more IDE targets), the next steps are: drop the tool-cache too, switch the verifier to download-then-verify-then-delete in a custom task, or move to a self-hosted runner.

---

🤖 *This PR was authored by Copilot on @catatafishen's behalf.*