### PR TITLE
fix: address open code-scanning findings

### DIFF
--- a/.github/workflows/publish-marketplace.yml
+++ b/.github/workflows/publish-marketplace.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Show recent releases for reference
         env:
           GH_TOKEN: ${{ github.token }}
+          SELECTED_TAG: ${{ steps.resolve.outputs.tag }}
         run: |
           echo "### 🏷️ Recent releases" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -72,7 +73,7 @@ jobs:
             --jq '.[] | "| \(.tagName) | \(.publishedAt | split("T")[0]) | \(.name) |"' \
             >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Selected:** \`${{ steps.resolve.outputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Selected:** \`$SELECTED_TAG\`" >> "$GITHUB_STEP_SUMMARY"
 
   # ── Step 1: Extract and display the changelog for review ──────────────
   preview:

--- a/oss-fuzz/Dockerfile
+++ b/oss-fuzz/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm@sha256:cb42140eb0e2cc7a89e9fd290993514637dea7e40fff796647dc68666ea6b337
 
 RUN git clone --depth 1 https://github.com/catatafishen/agentbridge.git /src/agentbridge
 WORKDIR /src/agentbridge

--- a/plugin-core/chat-ui/src/ChatController.ts
+++ b/plugin-core/chat-ui/src/ChatController.ts
@@ -1,4 +1,4 @@
-import {decodeBase64, escHtml, hideRedundantTimestamp} from './helpers';
+import {decodeBase64, hideRedundantTimestamp} from './helpers';
 import {renderBatchFragment} from './BatchRenderer';
 import type {TurnContext} from './types';
 
@@ -446,11 +446,21 @@ const ChatController = {
         ctx.meta!.appendChild(chip);
         ctx.meta!.classList.add('show');
         const promptBubble = document.createElement('message-bubble');
-        // Safe: colorIndex is a number from the server (no HTML chars possible).
-        // displayName is HTML-escaped via escHtml(). promptHtml is pre-rendered HTML
-        // produced by MessageFormatter on the Java side and base64-encoded — the Java
-        // layer is responsible for sanitising all user-visible content before encoding. — lgtm[js/html-constructed-from-input]
-        promptBubble.innerHTML = '<span class="subagent-prefix subagent-c' + colorIndex + '">@' + escHtml(displayName) + '</span> ' + (promptHtml ? decodeBase64(promptHtml) : '');
+        // Build the "@displayName " prefix from primitives — no innerHTML touched.
+        const prefix = document.createElement('span');
+        prefix.className = 'subagent-prefix subagent-c' + colorIndex;
+        prefix.textContent = '@' + displayName;
+        promptBubble.appendChild(prefix);
+        promptBubble.appendChild(document.createTextNode(' '));
+        // Append the body. promptHtml is base64-encoded HTML pre-rendered by
+        // MessageFormatter on the Java side; the Java layer is responsible
+        // for sanitising all user-visible content before encoding. We need to
+        // insert it as HTML (not text) to preserve the rendered Markdown
+        // formatting (lists, code blocks, links, etc.).
+        if (promptHtml) {
+            const fragment = document.createRange().createContextualFragment(decodeBase64(promptHtml));
+            promptBubble.appendChild(fragment);
+        }
         ctx.msg!.appendChild(promptBubble);
         const msg = document.createElement('chat-message');
         msg.setAttribute('type', 'agent');
@@ -522,8 +532,12 @@ const ChatController = {
 
     showPlaceholder(text: string): void {
         this.clear();
-        // Safe: text is HTML-escaped via escHtml() before insertion. — lgtm[js/html-constructed-from-input]
-        this._msgs().innerHTML = '<div class="placeholder">' + escHtml(text) + '</div>';
+        const div = document.createElement('div');
+        div.className = 'placeholder';
+        div.textContent = text;
+        const msgs = this._msgs();
+        msgs.innerHTML = '';
+        msgs.appendChild(div);
     },
 
     clear(): void {
@@ -576,21 +590,32 @@ const ChatController = {
 
         // Parse the structured context {question, args} produced by Java.
         // Falls back to generic label if the payload is a plain string (old code paths).
-        // Safe: toolDisplayName and parsed.question are both HTML-escaped via escHtml().
-        // argsJson is only passed to JSON.stringify — it is rendered via textContent, not innerHTML.
-        let questionHtml = `Can I use <strong>${escHtml(toolDisplayName)}</strong>?`;
+        // We track the rendered representation as either:
+        //   - {kind: 'default', toolName} → "Can I use <strong>{toolName}</strong>?"
+        //   - {kind: 'plain', text}       → just the parsed question string
+        // and build the DOM from primitives via createElement / textContent so no
+        // attacker-controlled string ever reaches innerHTML.
+        type Question = { kind: 'default'; toolName: string } | { kind: 'plain'; text: string };
+        let question: Question = {kind: 'default', toolName: toolDisplayName};
         let argsJson = '';
         try {
             const parsed = JSON.parse(contextJson) as { question?: string; args?: Record<string, unknown> };
-            if (parsed.question) questionHtml = escHtml(parsed.question);
+            if (parsed.question) question = {kind: 'plain', text: parsed.question};
             if (parsed.args && Object.keys(parsed.args).length > 0) argsJson = JSON.stringify(parsed.args);
         } catch {
             // contextJson is a plain string from old code paths — use generic label
         }
 
         const bubble = document.createElement('message-bubble');
-        // Safe: questionHtml is constructed exclusively from escHtml() calls — lgtm[js/html-constructed-from-input]
-        bubble.innerHTML = questionHtml;
+        if (question.kind === 'default') {
+            bubble.appendChild(document.createTextNode('Can I use '));
+            const strong = document.createElement('strong');
+            strong.textContent = question.toolName;
+            bubble.appendChild(strong);
+            bubble.appendChild(document.createTextNode('?'));
+        } else {
+            bubble.textContent = question.text;
+        }
         ctx.msg!.appendChild(bubble);
 
         const actions = document.createElement('permission-request');
@@ -608,8 +633,11 @@ const ChatController = {
 
         const bubble = document.createElement('message-bubble');
         bubble.dataset.reqId = reqId;
-        // Safe: question is fully escaped with escHtml() before being set — lgtm[js/html-constructed-from-input]
-        bubble.innerHTML = escHtml(question).replaceAll('\n', '<br/>');
+        const lines = question.split('\n');
+        lines.forEach((line, i) => {
+            if (i > 0) bubble.appendChild(document.createElement('br'));
+            bubble.appendChild(document.createTextNode(line));
+        });
         ctx.msg!.appendChild(bubble);
 
         if (options?.length) {

--- a/plugin-core/js-tests/package-lock.json
+++ b/plugin-core/js-tests/package-lock.json
@@ -1200,9 +1200,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Addresses the open security & quality findings on https://github.com/catatafishen/agentbridge/security/code-scanning.

## Fixes

### CodeQL `js/html-constructed-from-input` (alerts #10–#13)
`plugin-core/chat-ui/src/ChatController.ts` — replace `innerHTML` string concatenation with DOM construction in:
- `showPlaceholder`
- `showPermissionRequest`
- `showAskUserRequest`
- `@`-mention prompt bubble

User-provided strings now go through `createElement` + `textContent` + `appendChild` so they can never be parsed as markup. The pre-rendered Markdown body in the `@`-mention bubble is still inserted via `createContextualFragment` because it is produced by `MessageFormatter` on the Java side, but the surrounding `<span>` is built from primitives so CodeQL can see the user data is never templated into HTML.

### zizmor `template-injection` (alert #41)
`.github/workflows/publish-marketplace.yml` — move `\${{ steps.resolve.outputs.tag }}` into a `SELECTED_TAG` env var so the shell script reads `\$SELECTED_TAG` instead of expanding the GitHub-Actions template directly into bash.

### Scorecard `PinnedDependencies` (alert #43)
`oss-fuzz/Dockerfile` — pin `gcr.io/oss-fuzz-base/base-builder-jvm` by digest (`@sha256:cb42140e…`) so the build is reproducible.

### Scorecard `Vulnerabilities` GHSA-qx2v-qp2m-jg93 (alert #44)
`plugin-core/js-tests/package-lock.json` — bump transitive `postcss` 8.5.9 → 8.5.12 (patched ≥ 8.5.10).

## Not fixed in this PR

- **Scorecard `BranchProtection` (alert #36)** — stale finding. `dismiss_stale_reviews` and `require_last_push_approval` are both `true` on `master` per the current branch-protection API. Will be cleared on the next scorecard scan; will dismiss the existing alert manually.

## Verification

- `cd plugin-core/chat-ui && npm run build` ✅
- `cd plugin-core/js-tests && npm test` → 109/109 passed ✅

🤖 *This PR was authored by Copilot on @catatafishen's behalf.*