### PR TITLE
chore(scorecard): pass admin-scoped token so Branch-Protection check sees all settings

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,6 +15,10 @@ jobs:
     permissions:
       security-events: write
       id-token: write
+      # Needed so the default GITHUB_TOKEN can read repo metadata as a fallback
+      # when SCORECARD_READ_TOKEN is not configured.
+      contents: read
+      actions: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
@@ -31,6 +35,13 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
+          # Admin-scoped PAT so the Branch-Protection check can read settings
+          # that GITHUB_TOKEN cannot see (DismissStaleReviews, EnforceAdmins,
+          # RequireLastPushApproval, RequiresStatusChecks, UpToDateBeforeMerge).
+          # Without it, those settings are silently skipped and the score caps
+          # at Tier 1 (3/10) regardless of actual branch protection.
+          # See docs/SCORECARD-SETUP.md for one-time PAT setup.
+          repo_token: ${{ secrets.SCORECARD_READ_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF results
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2

--- a/docs/SCORECARD-SETUP.md
+++ b/docs/SCORECARD-SETUP.md
@@ -1,0 +1,67 @@
+# OpenSSF Scorecard Setup
+
+The `scorecard.yml` workflow runs the [OpenSSF Scorecard](https://github.com/ossf/scorecard)
+weekly and on every push to `master`. Several checks — most importantly **Branch-Protection** —
+require an admin-scoped token to read settings the default `GITHUB_TOKEN` cannot see:
+
+- `DismissStaleReviews`
+- `EnforceAdmins`
+- `RequireLastPushApproval`
+- `RequiresStatusChecks`
+- `UpToDateBeforeMerge`
+
+Without an admin token, those settings are silently treated as missing, capping the
+Branch-Protection score at Tier 1 (3/10) regardless of actual branch protection.
+
+## One-time PAT setup
+
+1. Go to <https://github.com/settings/tokens?type=beta> and click **Generate new token**.
+2. **Resource owner**: your account (the repo owner).
+3. **Repository access**: *Only select repositories* → pick `agentbridge`.
+4. **Repository permissions**:
+   - `Administration` → **Read-only**
+   - `Contents` → **Read-only**
+   - `Metadata` → **Read-only** (auto-selected)
+5. **Expiration**: 1 year (set a calendar reminder to rotate).
+6. Generate and copy the token.
+
+## Add as a repo secret
+
+1. <https://github.com/catatafishen/agentbridge/settings/secrets/actions/new>
+2. **Name**: `SCORECARD_READ_TOKEN`
+3. **Value**: paste the PAT.
+4. Save.
+
+The workflow will pick it up automatically on the next run. If the secret is absent, the
+workflow falls back to `GITHUB_TOKEN` (with the existing reduced-score behaviour).
+
+## Expected score after setup
+
+With our current branch protection on `master`:
+
+| Tier | Requirement                                  | Status |
+|------|----------------------------------------------|--------|
+| 1    | Prevent force push, prevent deletion         | ✅     |
+| 2    | ≥1 reviewer, PR required, up-to-date, last-push approval | ✅ |
+| 3    | ≥1 status check                              | ✅     |
+| 4    | ≥2 reviewers, code-owner review              | ✅     |
+| 5    | Dismiss stale reviews, **include admin**     | ⚠️ partial |
+
+`enforce_admins` is intentionally **disabled** so the project owner can bypass review when
+needed (e.g. emergency security patch, scorecard-only changes). This caps the score at
+**9/10** — the missing point is by design.
+
+## Verifying
+
+Run the workflow manually after adding the secret:
+
+```
+gh workflow run scorecard.yml
+```
+
+Then check the SARIF output in the **Security → Code scanning** tab or the workflow logs:
+
+```
+gh run list --workflow=scorecard.yml --limit 1
+gh run view <run-id> --log | grep -A2 'Branch-Protection'
+```


### PR DESCRIPTION
## Problem

The OpenSSF Scorecard **Branch-Protection** check is reporting **5/10** even though
master is configured with strong protection (verified via API):

| Setting                          | Configured | Visible to default token? |
|----------------------------------|------------|---------------------------|
| Force-push prevented             | ✅         | ✅                        |
| Branch deletion prevented        | ✅         | ✅                        |
| ≥ 2 reviewers required           | ✅         | ✅                        |
| Code-owner review required       | ✅         | ✅                        |
| Linear history required          | ✅         | ✅                        |
| `dismiss_stale_reviews`          | ✅         | ❌ admin-only             |
| `require_last_push_approval`     | ✅         | ❌ admin-only             |
| `required_status_checks` (strict)| ✅ (2 ctx) | ❌ admin-only             |
| `enforce_admins`                 | ❌ (intentional) | ❌ admin-only        |

Per the [Scorecard docs](https://github.com/ossf/scorecard?tab=readme-ov-file#authentication-with-fine-grained-pat-optional),
the admin-only settings are **silently treated as missing** when the action is
run with the default `GITHUB_TOKEN`. This caps the score at Tier 1 (3/10) plus
whatever non-admin Tier 2 items are visible — matching the observed score.

## Changes

- `scorecard.yml` now passes `repo_token: secrets.SCORECARD_READ_TOKEN ||
  secrets.GITHUB_TOKEN`. Behaviour is unchanged when the secret is absent.
- Added explicit `contents: read` and `actions: read` to the job-level
  permissions block (job-level overrides top-level `permissions: read-all`,
  so these were silently dropped).
- New `docs/SCORECARD-SETUP.md` documents the one-time fine-grained PAT setup
  required to populate the secret (1 year expiry, Administration: read-only,
  Contents: read-only, Metadata: read-only, single-repo scope).

## Expected score after secret is added

**9/10**. The missing point is by design — `enforce_admins` is intentionally
disabled so the project owner can bypass review for emergency patches and
scorecard-only changes.

## Verifying

After merging and adding the secret, trigger the workflow manually
(`gh workflow run scorecard.yml`) or wait for the next scheduled run
(Mondays 06:00 UTC), then inspect the SARIF output in the Security tab.

🤖 *This PR was authored by Copilot on @catatafishen's behalf.*
