### PR TITLE
feat(ci): add ClusterFuzzLite for continuous fuzzing

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -13,6 +13,15 @@
 # limitations under the License.
 #
 ################################################################################
+#
+# ClusterFuzzLite Dockerfile for AgentBridge.
+#
+# Build context is the repository root (ClusterFuzzLite invokes
+# `docker build -f .clusterfuzzlite/Dockerfile <repo-root>`).
+#
+# Pinned by digest to satisfy supply-chain checks. Update via:
+#   docker pull gcr.io/oss-fuzz-base/base-builder-jvm
+#   docker inspect --format='{{index .RepoDigests 0}}' gcr.io/oss-fuzz-base/base-builder-jvm
 
 FROM gcr.io/oss-fuzz-base/base-builder-jvm@sha256:cb42140eb0e2cc7a89e9fd290993514637dea7e40fff796647dc68666ea6b337
 
@@ -31,7 +40,9 @@ RUN apt-get update \
 ENV JAVA_HOME=/usr/lib/jvm/temurin-21-jdk-amd64
 ENV PATH=$JAVA_HOME/bin:$PATH
 
-RUN git clone --depth 1 https://github.com/catatafishen/agentbridge.git $SRC/agentbridge
+COPY . $SRC/agentbridge
 WORKDIR $SRC/agentbridge
 
-COPY build.sh $SRC/
+# Reuse the shared OSS-Fuzz build script. Both integrations produce the same
+# Jazzer wrapper layout in $OUT, so a single script works for both.
+COPY oss-fuzz/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,6 @@
+language: jvm
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+main_repo: 'https://github.com/catatafishen/agentbridge.git'

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Keep ClusterFuzzLite docker build context lean. The Dockerfile uses
+# `COPY . $SRC/agentbridge`, so anything not excluded here is shipped into
+# the image.
+.git
+.gradle
+.idea
+.kotlin
+.agent-work
+.copilot
+build
+**/build
+**/out
+**/.gradle
+**/node_modules
+**/dist
+plugin-core/chat-ui/node_modules
+plugin-core/build
+mcp-server/build
+integration-tests/build
+ide_launch.log
+*.iml
+.DS_Store

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -1,0 +1,54 @@
+name: ClusterFuzzLite batch fuzzing
+
+on:
+  schedule:
+    - cron: '17 */6 * * *'  # Every 6 hours, offset to avoid runner contention
+  workflow_dispatch:
+
+permissions: read-all
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  BatchFuzzing:
+    name: ClusterFuzzLite Batch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Build Fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          language: jvm
+          sanitizer: ${{ matrix.sanitizer }}
+          # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/catatafishen/agentbridge-cflite-storage.git
+          # storage-repo-branch: main
+
+      - name: Run Fuzzers (${{ matrix.sanitizer }})
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 1800
+          mode: 'batch'
+          sanitizer: ${{ matrix.sanitizer }}
+          output-sarif: true
+          # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/catatafishen/agentbridge-cflite-storage.git
+          # storage-repo-branch: main
+          # storage-repo-branch-coverage: gh-pages

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -1,0 +1,48 @@
+name: ClusterFuzzLite continuous build
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '**/*.java'
+      - '**/*.kt'
+      - '**/*.kts'
+      - '.clusterfuzzlite/**'
+      - 'oss-fuzz/build.sh'
+      - '.github/workflows/cflite_build.yml'
+
+permissions: read-all
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  Build:
+    name: ClusterFuzzLite Continuous Build
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Build Fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          language: jvm
+          sanitizer: ${{ matrix.sanitizer }}
+          upload-build: true

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -1,0 +1,45 @@
+name: ClusterFuzzLite cron tasks
+
+on:
+  schedule:
+    - cron: '23 3 * * *'  # Daily at 03:23 UTC
+  workflow_dispatch:
+
+permissions: read-all
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  Pruning:
+    name: ClusterFuzzLite Corpus Pruning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Build Fuzzers
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          language: jvm
+          # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/catatafishen/agentbridge-cflite-storage.git
+          # storage-repo-branch: main
+
+      - name: Run Fuzzers (prune)
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 600
+          mode: 'prune'
+          # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/catatafishen/agentbridge-cflite-storage.git
+          # storage-repo-branch: main

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,65 @@
+name: ClusterFuzzLite PR fuzzing
+
+on:
+  pull_request:
+    paths:
+      - '**/*.java'
+      - '**/*.kt'
+      - '**/*.kts'
+      - '.clusterfuzzlite/**'
+      - 'oss-fuzz/build.sh'
+      - '.github/workflows/cflite_pr.yml'
+
+permissions: read-all
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  PR:
+    name: ClusterFuzzLite PR
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Build Fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          language: jvm
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sanitizer: ${{ matrix.sanitizer }}
+          # Enable storage repo for affected-fuzzer detection + corpus reuse:
+          # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/catatafishen/agentbridge-cflite-storage.git
+          # storage-repo-branch: main
+          # storage-repo-branch-coverage: gh-pages
+
+      - name: Run Fuzzers (${{ matrix.sanitizer }})
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1  # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 300
+          mode: 'code-change'
+          sanitizer: ${{ matrix.sanitizer }}
+          output-sarif: true
+          # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/catatafishen/agentbridge-cflite-storage.git
+          # storage-repo-branch: main
+          # storage-repo-branch-coverage: gh-pages

--- a/TESTING.md
+++ b/TESTING.md
@@ -192,3 +192,33 @@ When the agent profile system refactoring removed `CopilotSettings`, the billing
 
 This ensures the feature continues to work and future changes won't break it silently.
 
+
+## Fuzz Testing
+
+The repo has Jazzer fuzz targets under `plugin-core/src/test/java/.../fuzz/` and
+`mcp-server/src/test/java/.../mcp/`. They are exercised three ways:
+
+| Where                                  | When                                  | Duration             | Persists corpus |
+|----------------------------------------|---------------------------------------|----------------------|-----------------|
+| `.github/workflows/fuzz.yml`           | Weekly + manual dispatch              | 120 s/target         | No (smoke test) |
+| `.github/workflows/cflite_pr.yml`      | Pull requests touching JVM/build code | 300 s total          | Via storage repo |
+| `.github/workflows/cflite_batch.yml`   | Every 6 h                             | 1800 s total         | Via storage repo |
+| `.github/workflows/cflite_cron.yml`    | Daily                                 | 600 s (corpus prune) | Via storage repo |
+| `.github/workflows/cflite_build.yml`   | Push to `master`                      | Build-only artifact  | n/a              |
+
+ClusterFuzzLite (`.clusterfuzzlite/`) reuses the OSS-Fuzz build script
+(`oss-fuzz/build.sh`) — both produce the same Jazzer wrapper layout in `$OUT/`.
+The OSS-Fuzz integration files are kept for future re-application once the
+project is more mature (the initial submission was deferred — too new at the time).
+
+### Enabling persisted corpus / coverage (recommended)
+
+Without a storage repo, ClusterFuzzLite still detects crashes but loses the
+corpus between runs. To enable persistence and affected-fuzzer detection on PRs:
+
+1. Create an empty repo `catatafishen/agentbridge-cflite-storage`.
+2. Generate a fine-grained PAT with **Contents: read & write** scoped to that
+   repo only. Add it to `agentbridge` as the `PERSONAL_ACCESS_TOKEN` secret.
+3. Uncomment the `storage-repo*` lines in all four `cflite_*.yml` workflows.
+
+See <https://google.github.io/clusterfuzzlite/running-clusterfuzzlite/github-actions/#storage-repo>.

--- a/oss-fuzz/build.sh
+++ b/oss-fuzz/build.sh
@@ -15,11 +15,12 @@
 #
 ################################################################################
 #
-# OSS-Fuzz build script for AgentBridge (IntelliJ Copilot Plugin).
-# Called inside the Docker container by OSS-Fuzz infrastructure.
-# $SRC, $OUT, and $JAVA_HOME are set by the base image.
+# Shared build script for AgentBridge (IntelliJ Copilot Plugin) fuzz targets.
+# Used by both OSS-Fuzz (oss-fuzz/Dockerfile) and ClusterFuzzLite
+# (.clusterfuzzlite/Dockerfile). Called inside the Docker container by the
+# fuzzing infrastructure. $SRC, $OUT, and $JAVA_HOME are set by the base image.
 
-cd /src/agentbridge
+cd "$SRC/agentbridge"
 
 # Build all test classes (fuzz targets live in the test source sets).
 ./gradlew :plugin-core:testClasses :mcp-server:testClasses --no-daemon --quiet


### PR DESCRIPTION
## Why

The OSS-Fuzz onboarding submission ([oss-fuzz#15377](https://github.com/google/oss-fuzz/pull/15377)) was deferred — the project is too new (< 3 months on Marketplace, ~2k downloads). The OSS-Fuzz maintainers suggested **ClusterFuzzLite** instead, which runs the same Jazzer engine inside our own GitHub Actions and requires no external onboarding.

This wires CFL into the existing fuzz harness setup (the 7 Jazzer fuzz targets in `plugin-core/src/test/.../fuzz/` and `mcp-server/src/test/.../mcp/`).

## What's in here

**`.clusterfuzzlite/`**
- `Dockerfile` — `FROM gcr.io/oss-fuzz-base/base-builder-jvm` (pinned by digest), installs Temurin JDK 21 (the base image ships an older JDK that can't compile our sources), copies the workspace via the build context, and reuses `oss-fuzz/build.sh` so the two integrations can't drift.
- `project.yaml` — `language: jvm`, `sanitizers: [address]`.

**`.dockerignore`** — keeps `.git`, build outputs, IDE state, and `node_modules` out of the docker context. Without it, `COPY .` would ship hundreds of MB.

**`.github/workflows/cflite_*.yml`** — four standard CFL workflows:

| Workflow | Trigger | Mode | Duration |
|---|---|---|---|
| `cflite_pr.yml` | PRs touching JVM/build code | code-change | 300 s |
| `cflite_batch.yml` | Every 6 h | batch | 1800 s |
| `cflite_cron.yml` | Daily | prune | 600 s |
| `cflite_build.yml` | Push to master | build artifact | n/a |

All actions pinned to commit SHAs (`google/clusterfuzzlite/actions/* @ 884713a6c30a92e5e8544c39945cd7cb630abcd1` = v1) for zizmor + Scorecard pinned-dependencies.

**`oss-fuzz/`** — shared `build.sh` updated to use `\$SRC` (works identically under both systems); Dockerfile gets the same JDK 21 install. Kept for future OSS-Fuzz re-application once the project is more mature.

**`TESTING.md`** — new "Fuzz Testing" section explaining all five fuzz workflows + storage-repo setup.

## What this does NOT do (yet)

**Persisted corpus / coverage** requires a separate storage repo. Wired in everywhere but commented out, since it needs you to:

1. Create empty repo `catatafishen/agentbridge-cflite-storage`.
2. Generate a fine-grained PAT — **Contents: read & write**, scoped to that repo only.
3. Add as `PERSONAL_ACCESS_TOKEN` secret on `agentbridge`.
4. Uncomment the `storage-repo*` lines in all four `cflite_*.yml` files.

Without it, CFL still detects crashes but loses corpus between runs and can't do affected-fuzzer detection on PRs. Full instructions in `TESTING.md`.

## What's kept and why

- **`fuzz.yml`** — kept. Runs Jazzer directly without Docker in ~3 min vs CFL's ~15 min. Useful as a fast smoke test when iterating on harnesses.
- **`oss-fuzz/`** — kept. Will become useful once the project is mature enough to re-apply.

## Scorecard impact

Scorecard's `Fuzzing` check detects ClusterFuzzLite via the presence of `.clusterfuzzlite/Dockerfile`. Score should move from **0 → 10**.

## Cost note

CFL Docker builds for JVM/Gradle download hundreds of MB of deps each run. PR fuzzing will take ~10–15 min and triggers on JVM/build path changes only (not docs-only PRs). Batch + cron together are ~6 runs/day × ~30 min = ~3 h/day of runner time. Within free GitHub Actions quotas for public repos but worth keeping an eye on.

## Validation done

- All 5 new YAML files parse.
- Plan reviewed by rubber-duck agent — caught the JDK-version mismatch (fixed: explicit Temurin 21 install), missing `.dockerignore` (added), unpinned base image (now pinned), missing concurrency on PR workflow (added), and the JVM coverage caveat (skipped coverage workflow accordingly).

## Follow-ups (not in this PR)

- Set up the storage repo + PAT (manual one-time step).
- Once we have a few weeks of corpus data, consider increasing batch fuzz duration to 3600 s.